### PR TITLE
Binary test data now lives in a TECA_data repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ env:
 
 script: ./test/travis_ci/script_$TRAVIS_OS_NAME.sh
 
+after_failure: 
+  - cat build/Testing/Temporary/LastTest.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,9 @@ add_subdirectory(alg)
 add_subdirectory(apps)
 
 # enable regression tests
-set(TECA_DATA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/test/datasets"
-    CACHE STRING "Path to test datasets")
+if (NOT TECA_DATA_ROOT)
+  set(TECA_DATA_ROOT $ENV{TECA_DATA_ROOT} CACHE STRING "TECA data directory")
+endif()
 set(BUILD_TESTING OFF CACHE BOOL "Enable tests")
 if (BUILD_TESTING)
     enable_testing()

--- a/alg/teca_vorticity.cxx
+++ b/alg/teca_vorticity.cxx
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
+#include <cmath>
 
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
@@ -17,6 +18,7 @@ using std::string;
 using std::vector;
 using std::cerr;
 using std::endl;
+using std::cos;
 
 //#define TECA_DEBUG
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,13 +81,15 @@ if (TECA_HAS_NETCDF)
             PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR")
     endif()
 
-    teca_add_test(test_temporal_average
-        SOURCES test_temporal_average.cpp
-        LIBS teca_core teca_data teca_io teca_alg ${teca_test_link}
-        COMMAND test_temporal_average
-        "${TECA_DATA_ROOT}/cam5_1_amip_run2\\.cam2\\.h2\\.1991-10-01-10800\\.nc"
-        test_temporal_average_%t%.vtk 0 -1 3 U850
-        REQ_TECA_DATA)
+    if (TECA_DATA_ROOT)
+      teca_add_test(test_temporal_average
+          SOURCES test_temporal_average.cpp
+          LIBS teca_core teca_data teca_io teca_alg ${teca_test_link}
+          COMMAND test_temporal_average
+          "${TECA_DATA_ROOT}/cam5_1_amip_run2.cam2.h2.1991-10-01-10800.nc"
+          test_temporal_average_%t%.vtk 0 -1 3 U850
+          REQ_TECA_DATA)
+    endif()
 
     # TODO -- locate test data for this test
     add_executable(test_cartesian_mesh_regrid

--- a/test/datasets/cam5_1_amip_run2.cam2.h2.1991-10-01-10800.nc
+++ b/test/datasets/cam5_1_amip_run2.cam2.h2.1991-10-01-10800.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e77eccf12c0f0e6a722be5ad0871ac8bd6e3a217d9db9fb09f2c9fdf1abeba7
-size 113304412

--- a/test/datasets/cam5_1_amip_run2.cam2.h2.1991-10-02-10800.nc
+++ b/test/datasets/cam5_1_amip_run2.cam2.h2.1991-10-02-10800.nc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae50f666bf692fc6866065e5a880a44e5ceac4118f1f0c912aef03bf008a2448
-size 113304412

--- a/test/travis_ci/install_linux.sh
+++ b/test/travis_ci/install_linux.sh
@@ -20,3 +20,7 @@ pip install --user numpy
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
 sudo apt-get install git-lfs
 sudo rm /usr/local/bin/git-lfs
+
+# install data files.
+git clone https://github.com/LBL-EESA/TECA_data.git
+pushd TECA_data && git lfs pull && popd

--- a/test/travis_ci/install_osx.sh
+++ b/test/travis_ci/install_osx.sh
@@ -3,10 +3,14 @@
 # install deps
 brew update
 brew tap Homebrew/homebrew-science
-brew install gcc openmpi hdf5 netcdf python swig
+brew install gcc openmpi hdf5 netcdf python swig git-lfs
 pip install numpy
 # TODO
 # brew install boost --c++11
 
 # override system install
 export PATH=/usr/local/bin:$PATH
+
+# install data files.
+git clone https://github.com/LBL-EESA/TECA_data.git
+pushd TECA_data && git lfs pull && popd

--- a/test/travis_ci/script_linux.sh
+++ b/test/travis_ci/script_linux.sh
@@ -5,8 +5,6 @@ set -v
 export PYTHONPATH=${TRAVIS_BUILD_DIR}/build/lib
 export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/build/lib
 
-git lfs pull
-
 mkdir build
 cd build
 
@@ -16,6 +14,7 @@ cmake \
     -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DBUILD_TESTING=ON \
+    -DTECA_DATA_ROOT=${TRAVIS_BUILD_DIR}/TECA_data \
     ..
 
 make -j4

--- a/test/travis_ci/script_osx.sh
+++ b/test/travis_ci/script_osx.sh
@@ -6,8 +6,6 @@ export PYTHONPATH=${TRAVIS_BUILD_DIR}/build/lib
 export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/build/lib
 export DYLD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/build/lib
 
-git lfs pull
-
 mkdir build
 cd build
 
@@ -17,6 +15,7 @@ cmake \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DCMAKE_CXX_FLAGS="-Wall -Wextra" \
     -DBUILD_TESTING=ON \
+    -DTECA_DATA_ROOT=${TRAVIS_BUILD_DIR}/TECA_data \
     ..
 
 make -j4


### PR DESCRIPTION
- Removed the binary files from this repo's Git LFS.
- Allowing TECA_DATA_ROOT to be set with an environment variable or via command-line.
- Fixed a minor compiler error.
