### PR TITLE
Adding the ability to override PYTHON_EXECUTABLE to specify Python.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,12 @@ set(TECA_HAS_BOOST ${tmp} CACHE BOOL "Boost features")
 
 # configure for Python
 set(tmp OFF)
-find_package(PythonInterp)
+if(DEFINED PYTHON_EXECUTABLE AND EXISTS ${PYTHON_EXECUTABLE})
+  message(STATUS "Using supplied Python interpreter: ${PYTHON_EXECUTABLE}")
+  set(PYTHONINTERP_FOUND)
+else()
+  find_package(PythonInterp)
+endif()
 if(PYTHONINTERP_FOUND)
     find_program(PYTHON_CONFIG_EXECUTABLE python-config)
     if (NOT PYTHON_CONFIG_EXECUTABLE)


### PR DESCRIPTION
This is needed for us to build TECA binaries using TECA_3rdparty, which builds its own Python interpreter.
