### PR TITLE
compile fix for comparator

### DIFF
--- a/alg/teca_table_sort.cxx
+++ b/alg/teca_table_sort.cxx
@@ -36,7 +36,7 @@ public:
     less() : m_data(nullptr) {}
     less(const num_t *data) : m_data(data) {}
 
-    bool operator()(const size_t &l, size_t &r)
+    bool operator()(const size_t &l, const size_t &r)
     {
         return m_data[l] < m_data[r];
     }


### PR DESCRIPTION
fix for compilation error on gcc 4.8.4 (Ubuntu 14.04)
