### PR TITLE
Route parameters into metadata for AR detector components

### DIFF
--- a/alg/teca_binary_segmentation.cxx
+++ b/alg/teca_binary_segmentation.cxx
@@ -319,5 +319,8 @@ const_p_teca_dataset teca_binary_segmentation::execute(
     this->get_segmentation_variable(segmentation_var);
     out_mesh->get_point_arrays()->set(segmentation_var, segmentation);
 
+    out_mesh->get_metadata().insert("low_threshold_value", low);
+    out_mesh->get_metadata().insert("high_threshold_value", high);
+
     return out_mesh;
 }

--- a/alg/teca_component_area_filter.cxx
+++ b/alg/teca_component_area_filter.cxx
@@ -300,12 +300,18 @@ const_p_teca_dataset teca_component_area_filter::execute(
                 }
             }
 
+            n_component_ids = component_area.size();
+
             std::string labels_var_post_fix = labels_var + this->variable_post_fix;
             out_mesh->get_point_arrays()->set(labels_var_post_fix, filtered_labels_array);
 
             out_metadata.insert(this->number_of_components_key + this->variable_post_fix, component_ids.size());
             out_metadata.insert(this->component_ids_key + this->variable_post_fix, component_ids);
             out_metadata.insert(this->component_area_key + this->variable_post_fix, component_area);
+
+            out_mesh->get_metadata().insert("low_area_threshold_km", low_val);
+            out_mesh->get_metadata().insert("high_area_threshold_km", high_val);
+
             )
         )
 

--- a/alg/teca_latitude_damper.cxx
+++ b/alg/teca_latitude_damper.cxx
@@ -329,6 +329,9 @@ const_p_teca_dataset teca_latitude_damper::execute(
         free(filter);
     )
 
+    out_mesh->get_metadata().insert("gaussian_filter_hwhm", sigma);
+    out_mesh->get_metadata().insert("gaussian_filter_center_lat", mu);
+
     return out_mesh;
 }
 


### PR DESCRIPTION
This is a work in progress - there are several remaining items to tackle, including improved comments, generalizing the metadata keys in several of the files, and hardcoding of types in a routine (see comment below).

Following #198, this adds the AR detector input parameters into the AR detector pipeline.  The parameter reduction step combines parameters in the metadata.

@burlen or @elbashandy - in the `property_reduce()` subroutine (starting at line 36 of `alg/teca_bayesian_ar_detect.cxx`), I have the parameter type hardcoded as double, which I know isn't good.  Specifically, there are three instances of `std::vector<double>` in the sub. I could use your help to generalize this.
 
Closes #198 