### PR TITLE
Fix negative component areas

### DIFF
--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -94,7 +94,7 @@ void component_area(unsigned long nlon, unsigned long nlat,
         unsigned long jj = j*nlon;
         for (unsigned long i = 1; i < nlonm1; ++i)
         {
-            area[labels[jj + i]] += abs(rho_sq_d_theta[i]*d_cos_phi_j);
+            area[labels[jj + i]] += std::abs(rho_sq_d_theta[i]*d_cos_phi_j);
         }
     }
 

--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -94,7 +94,7 @@ void component_area(unsigned long nlon, unsigned long nlat,
         unsigned long jj = j*nlon;
         for (unsigned long i = 1; i < nlonm1; ++i)
         {
-            area[labels[jj + i]] += rho_sq_d_theta[i]*d_cos_phi_j;
+            area[labels[jj + i]] += abs(rho_sq_d_theta[i]*d_cos_phi_j);
         }
     }
 


### PR DESCRIPTION
Simple fix - adds `abs()` around area during summation.

Closes #210 