### PR TITLE
Fixes for pythonpath and rpath distutils install issues

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -46,7 +46,7 @@ set(teca_alg_cxx_srcs
     teca_dataset_diff.cxx
     )
 
-teca_py_install(lib
+teca_py_install(${LIB_PREFIX}
     teca_tc_stats.py
     teca_tc_wind_radii_stats.py
     teca_tc_trajectory_scalars.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,8 +19,14 @@ if (TECA_HAS_PYTHON)
 
     PYTHON_ADD_MODULE(_teca_py ${CMAKE_CURRENT_BINARY_DIR}/teca_py.cxx)
 
-    # make the rpath relative so that moving the so file doesn't break the link
-    SET_TARGET_PROPERTIES(_teca_py PROPERTIES INSTALL_RPATH "\$ORIGIN/./")
+    # include the directory containing _teca_py in the rpath
+    # this enables one not to have to set (DY)LD_LIBRARY_PATH
+    # prior to importing teca.
+    if (APPLE)
+        set_target_properties(_teca_py PROPERTIES INSTALL_RPATH "@loader_path/./")
+    elseif(UNIX)
+        set_target_properties(_teca_py PROPERTIES INSTALL_RPATH "\$ORIGIN/./")
+    endif()
 
     target_link_libraries(_teca_py ${PYTHON_LIBRARIES}
         teca_core teca_data teca_alg teca_io teca_system)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -19,6 +19,9 @@ if (TECA_HAS_PYTHON)
 
     PYTHON_ADD_MODULE(_teca_py ${CMAKE_CURRENT_BINARY_DIR}/teca_py.cxx)
 
+    # make the rpath relative so that moving the so file doesn't break the link
+    SET_TARGET_PROPERTIES(_teca_py PROPERTIES INSTALL_RPATH "\$ORIGIN/./")
+
     target_link_libraries(_teca_py ${PYTHON_LIBRARIES}
         teca_core teca_data teca_alg teca_io teca_system)
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ class CMakeBuild(build_ext):
 
         # this is where setuptools will look for our files to install
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        # put verything in a directory below this for pip, if we don't do so
+        # pip puts it all right in site-packages making a big fat mess
+        extdir = os.path.join(extdir, 'teca')
 
         # set some flags for the cmake command line configuring this build
         # specifically we need to put the build where setuptools can find it
@@ -83,14 +86,13 @@ class CMakeBuild(build_ext):
             sys.stderr.write('\n')
             raise
 
-        # generate on the fly the top level python module that can be imported from the
-        # setuptools install
-        f = open(os.path.join(extdir, 'teca.py'), 'w')
+        # because we are putting everything in a subdirectory (see comment above re: pip)
+        # write the init file that actually does the loading sets up the paths correctly
+        f = open(os.path.join(extdir, '__init__.py'), 'w')
         f.write('import sys, os\n')
-        f.write('sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)),"lib"))\n')
-        f.write('from teca_py import *\n')
+        f.write('sys.path.append(os.path.dirname(os.path.abspath(__file__)))\n')
+        f.write('from teca.teca_py import *\n')
         f.close()
-
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ class CMakeBuild(build_ext):
         # setuptools install
         f = open(os.path.join(extdir, 'teca.py'), 'w')
         f.write('import sys, os\n')
-        f.write('from teca import *\n')
+        f.write('sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)),"lib"))\n')
+        f.write('from teca_py import *\n')
         f.close()
 
 


### PR DESCRIPTION
Modifications to address setup.py install issues described in #213 .

The most recent commit fixes the rpath and pythonpath issues.  But when installing via pip (`pip install TECA/`, where `TECA/` is a local TECA clone), the files are still installed directly in the base directory of site-packages.  However, when running `python setup.py install`, the files are installed in a subdirectory of site-packages (like `teca-2.2.1-py3.6-linux-x86_64.egg`).  This should be addressed before this PR is merged.
