### PR TITLE
revert Python app name changes

### DIFF
--- a/CMake/teca_python.cmake
+++ b/CMake/teca_python.cmake
@@ -26,10 +26,10 @@ function(teca_py_install_apps)
         foreach(pysrc ${pysrcs})
             get_filename_component(appname ${pysrc} NAME_WE)
             configure_file(${pysrc}
-                ${CMAKE_CURRENT_BINARY_DIR}/../${BIN_PREFIX}/${appname}.py
+                ${CMAKE_CURRENT_BINARY_DIR}/../${BIN_PREFIX}/${appname}
                 @ONLY)
             list(APPEND pyapps
-                ${CMAKE_CURRENT_BINARY_DIR}/../${BIN_PREFIX}/${appname}.py)
+                ${CMAKE_CURRENT_BINARY_DIR}/../${BIN_PREFIX}/${appname})
         endforeach()
         install(PROGRAMS ${pyapps} DESTINATION ${BIN_PREFIX})
         # TODO compile the sources


### PR DESCRIPTION
This fixes bugs introduced in 85d8d9337 & 748ded0cac where Python applications
were incorrectly renamed during configuration.