### PR TITLE
teca_bayesian_ar_detect re-use thread pool

### DIFF
--- a/alg/teca_bayesian_ar_detect.h
+++ b/alg/teca_bayesian_ar_detect.h
@@ -32,8 +32,11 @@ public:
     TECA_ALGORITHM_PROPERTY(std::string, min_component_area_variable)
     TECA_ALGORITHM_PROPERTY(std::string, hwhm_latitude_variable)
 
-    // set the number of threads to use internally
-    TECA_ALGORITHM_PROPERTY(int, thread_pool_size)
+    // set/get the number of threads in the pool. setting
+    // to -1 results in a thread per core factoring in all MPI
+    // ranks running on the node. the default is -1.
+    void set_thread_pool_size(int n_threads);
+    unsigned int get_thread_pool_size() const noexcept;
 
     // override the input connections because we are going to
     // take the first input and use it to generate metadata.


### PR DESCRIPTION
make the thread pool directly set-able in teca_threaded_algorithm.
create and cache a thread pool for use during teca_bayesian_ar_detect,
this enables the threads to be bound correctly to cores across MPI
ranks, reduces overhead from repeated contruction when parallelizing
over control parameters.