### PR TITLE
fix copy paste bug in Bayesian AR reduce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - BUILD_TYPE=Debug
     - TECA_DIR=/travis_teca_dir
     - TECA_PYTHON_VERSION=2
-    - TECA_DATA_REVISION=44
+    - TECA_DATA_REVISION=45
   matrix:
     - DOCKER_IMAGE=ubuntu IMAGE_VERSION=18.04 SCRIPT_DIR=ubuntu_18_04
     - DOCKER_IMAGE=fedora IMAGE_VERSION=28 SCRIPT_DIR=fedora_28

--- a/alg/teca_bayesian_ar_detect.cxx
+++ b/alg/teca_bayesian_ar_detect.cxx
@@ -227,7 +227,7 @@ public:
             p_teca_variant_array prob_0 = mesh_0->get_point_arrays()->get(this->probability_array_name);
 
             p_teca_cartesian_mesh mesh_1 = std::dynamic_pointer_cast<teca_cartesian_mesh>(dataset_1);
-            p_teca_variant_array wvcc_1 = mesh_0->get_point_arrays()->get(this->component_array_name);
+            p_teca_variant_array wvcc_1 = mesh_1->get_point_arrays()->get(this->component_array_name);
             p_teca_variant_array prob_1 = mesh_1->get_point_arrays()->get(this->probability_array_name);
 
             if (prob_0 && prob_1)


### PR DESCRIPTION
a copy paste error resulted in use of connected component data from mesh_0
instead of mesh_1 in reduction. this certainly impacted the results and test
data needed to be re-baselined.