### PR TITLE
Added option for parsing dates from filenames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - BUILD_TYPE=Debug
     - TECA_DIR=/travis_teca_dir
     - TECA_PYTHON_VERSION=2
-    - TECA_DATA_REVISION=48
+    - TECA_DATA_REVISION=49
   matrix:
     - DOCKER_IMAGE=ubuntu IMAGE_VERSION=18.04 SCRIPT_DIR=ubuntu_18_04
     - DOCKER_IMAGE=fedora IMAGE_VERSION=28 SCRIPT_DIR=fedora_28

--- a/io/teca_cf_reader.h
+++ b/io/teca_cf_reader.h
@@ -86,9 +86,12 @@ public:
     TECA_ALGORITHM_PROPERTY(std::string, t_axis_variable)
 
     // time calendar and time unit if the user wants to
-    // specify them 
+    // specify them
     TECA_ALGORITHM_PROPERTY(std::string, t_calendar)
     TECA_ALGORITHM_PROPERTY(std::string, t_units)
+
+    // a way to infer time from the filename if needed
+    TECA_ALGORITHM_PROPERTY(std::string, filename_time_template)
 
     // time values to use instead if time variable doesn't
     // exist.
@@ -124,6 +127,7 @@ private:
     std::string t_axis_variable;
     std::string t_calendar;
     std::string t_units;
+    std::string filename_time_template;
     std::vector<double> t_values;
     int periodic_in_x;
     int periodic_in_y;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,14 @@ teca_add_test(test_cf_reader_era5
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)
 
+teca_add_test(test_cf_reader_file_time
+    COMMAND test_cf_reader
+    -i "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D_20170210_06\.nc"
+    -o "test_cf_reader_file_time_%t%.%e%" -s 0,-1 -x lon -y lat
+    -n "ARTMIP_MERRA_2D_%Y%m%d_%H.nc" IVT
+    FEATURES ${TECA_HAS_NETCDF}
+    REQ_TECA_DATA)
+
 teca_add_test(test_cf_writer_cam5_serial
     EXEC_NAME test_cf_writer
     SOURCES test_cf_writer.cpp

--- a/test/test_cf_reader.cpp
+++ b/test/test_cf_reader.cpp
@@ -79,6 +79,7 @@ int parse_command_line(int argc, char **argv, int rank,
     string y_ax = "lat";
     string z_ax = "";
     string t_ax = "";
+    string t_template = "";
     long first_step = 0;
     long last_step = -1;
     std::vector<double> bounds;
@@ -117,6 +118,11 @@ int parse_command_line(int argc, char **argv, int rank,
             t_ax = argv[++i];
             ++j;
         }
+        else if (!strcmp("-n", argv[i]))
+        {
+            t_template = argv[++i];
+            ++j;
+        }
         else if (!strcmp("-s", argv[i]))
         {
             sscanf(argv[++i], "%li,%li",
@@ -151,6 +157,7 @@ int parse_command_line(int argc, char **argv, int rank,
     cf_reader->set_z_axis_variable(z_ax);
     cf_reader->set_t_axis_variable(t_ax);
     cf_reader->set_files_regex(regex);
+    cf_reader->set_filename_time_template(t_template);
 
     vtk_writer->set_file_name(output);
 


### PR DESCRIPTION
The new cfreader::filename_time_template option allows TECA to infer time information from filenames.  This is particularly for the ARTMIP MERRA2 data, which doesn't have a time coordinate. This runs like follows:

`teca_bayesian_ar_detect --input_regex "/project/projectdirs/m1517/cascade/external_datasets/ARTMIP/MERRA 2D/1983/ARTMIP_MERRA_2D_198309\.\*.nc" --cf_reader::filename_time_template "ARTMIP_MERRA_2D_%Y%m%d_%H.nc" --cf_reader::t_axis_variable ""`