### PR TITLE
bayesian_ar_detect add flag to control verbose terminal output

### DIFF
--- a/alg/teca_bayesian_ar_detect.cxx
+++ b/alg/teca_bayesian_ar_detect.cxx
@@ -554,7 +554,7 @@ teca_bayesian_ar_detect::teca_bayesian_ar_detect() :
     min_component_area_variable("min_component_area"),
     min_water_vapor_variable("min_water_vapor"),
     hwhm_latitude_variable("hwhm_latitude"), thread_pool_size(1),
-    internals(new internals_t)
+    verbose(0), internals(new internals_t)
 {
     this->set_number_of_input_connections(1);
     this->set_number_of_output_ports(1);
@@ -588,6 +588,9 @@ void teca_bayesian_ar_detect::get_properties_description(
             "half width at half max latitude (\"hwhm_latitude\")")
         TECA_POPTS_GET(int, prefix, thread_pool_size,
             "number of threads to parallelize execution over (1)")
+        TECA_POPTS_GET(int, prefix, verbose,
+            "flag indicating diagnostic info should be displayed in "
+            "the terminal (0)")
         ;
 
     global_opts.add(opts);
@@ -601,10 +604,8 @@ void teca_bayesian_ar_detect::set_properties(const std::string &prefix,
     TECA_POPTS_SET(opts, std::string, prefix, min_component_area_variable)
     TECA_POPTS_SET(opts, std::string, prefix, min_water_vapor_variable)
     TECA_POPTS_SET(opts, std::string, prefix, hwhm_latitude_variable)
-
-    std::string opt_name = (prefix.empty()?"":prefix+"::") + "thread_pool_size";
-    if (opts.count(opt_name))
-        this->set_thread_pool_size(opts[opt_name].as<int>());
+    TECA_POPTS_SET(opts, int, prefix, thread_pool_size)
+    TECA_POPTS_SET(opts, int, prefix, verbose)
 }
 #endif
 
@@ -631,7 +632,7 @@ void teca_bayesian_ar_detect::set_modified()
 void teca_bayesian_ar_detect::set_thread_pool_size(int n)
 {
     this->internals->queue = new_teca_data_request_queue(
-        this->get_communicator(), n, true, true);
+        this->get_communicator(), n, true, this->get_verbose());
 }
 
 // --------------------------------------------------------------------------

--- a/alg/teca_bayesian_ar_detect.h
+++ b/alg/teca_bayesian_ar_detect.h
@@ -34,6 +34,10 @@ public:
     TECA_ALGORITHM_PROPERTY(std::string, min_component_area_variable)
     TECA_ALGORITHM_PROPERTY(std::string, hwhm_latitude_variable)
 
+    // flag indicating verbose terminal output is desired.
+    // default is 0
+    TECA_ALGORITHM_PROPERTY(int, verbose)
+
     // set/get the number of threads in the pool. setting
     // to -1 results in a thread per core factoring in all MPI
     // ranks running on the node. the default is -1.
@@ -72,6 +76,7 @@ private:
     std::string min_water_vapor_variable;
     std::string hwhm_latitude_variable;
     int thread_pool_size;
+    int verbose;
 
     struct internals_t;
     internals_t *internals;

--- a/apps/teca_bayesian_ar_detect.cpp
+++ b/apps/teca_bayesian_ar_detect.cpp
@@ -49,6 +49,7 @@ int main(int argc, char **argv)
         ("start_date", value<string>(), "first time to proces in YYYY-MM-DD hh:mm:ss format")
         ("end_date", value<string>(), "first time to proces in YYYY-MM-DD hh:mm:ss format")
         ("n_threads", value<int>(), "thread pool size. default is 1. -1 for all")
+        ("verbose", "enable extra terminal output")
         ("help", "display the basic options help")
         ("advanced_help", "display the advanced options help")
         ("full_help", "display entire help message")
@@ -95,6 +96,7 @@ int main(int argc, char **argv)
     p_teca_cf_writer cf_writer = teca_cf_writer::New();
     cf_writer->get_properties_description("cf_writer", advanced_opt_defs);
     cf_writer->set_input_connection(ar_detect->get_output_port());
+    cf_writer->set_verbose(0);
     cf_writer->set_thread_pool_size(1);
 
     // package basic and advanced options for display
@@ -187,10 +189,18 @@ int main(int argc, char **argv)
     if (opt_vals.count("last_step"))
         cf_writer->set_last_step(opt_vals["last_step"].as<long>());
 
+    if (opt_vals.count("verbose"))
+    {
+        ar_detect->set_verbose(1);
+        cf_writer->set_verbose(1);
+        exec->set_verbose(1);
+    }
+
     if (opt_vals.count("n_threads"))
         ar_detect->set_thread_pool_size(opt_vals["n_threads"].as<int>());
     else
         ar_detect->set_thread_pool_size(-1);
+
 
     // some minimal check for missing options
     if (cf_reader->get_number_of_file_names() == 0
@@ -284,6 +294,7 @@ int main(int argc, char **argv)
     }
 
     // run the pipeline
+
     cf_writer->set_executive(exec);
     cf_writer->update();
 

--- a/core/teca_index_executive.cxx
+++ b/core/teca_index_executive.cxx
@@ -7,8 +7,6 @@
 #include <iostream>
 #include <utility>
 
-using std::cerr;
-using std::endl;
 
 // --------------------------------------------------------------------------
 teca_index_executive::teca_index_executive()
@@ -173,12 +171,17 @@ int teca_index_executive::initialize(MPI_Comm comm, const teca_metadata &md)
 
     // print some info about the set of requests
     if (this->get_verbose())
-        cerr << teca_parallel_id()
+    {
+        std::ostringstream oss;
+        oss << teca_parallel_id()
             << " teca_index_executive::initialize index_initializer_key="
-            << this->index_initializer_key << " index_request_key="
-            << this->index_request_key << " first=" << this->start_index
-            << " last=" << this->end_index << " stride=" << this->stride
-            << endl;
+            << this->index_initializer_key << " " << this->index_initializer_key
+            << "=" << n_indices << " index_request_key=" << this->index_request_key
+            << " first=" << this->start_index << " last=" << this->end_index
+            << " stride=" << this->stride << " block_start=" << block_start + first
+            << " block_size=" << block_size;
+        std::cerr << oss.str() << std::endl;
+    }
 
     return 0;
 }
@@ -222,7 +225,7 @@ teca_metadata teca_index_executive::get_next_request()
                     << bds[2] << ", " << bds[3] << ", " << bds[4] << ", " << bds[5];
             }
 
-            cerr << oss.str() << endl;
+            std::cerr << oss.str() << std::endl;
         }
     }
 


### PR DESCRIPTION
as requested in #300 

* adds some detail to the verbose option of the executive. which when run
  in verbose mode now describes how the index space is partitioned to
  ranks and reports the details of each request as it is accessed.

* adds --verbose to the bayesian_ar_detect command line
  this defaults to off for 2 reasons.

    1. Terminal will become trashed at large scales, limitting the
       usefulness of the output
    2. Especially with the thread pool, there is a cost (communication &
       synchronization) when generating the report