### PR TITLE
ARTMIP output format

### DIFF
--- a/alg/teca_binary_segmentation.cxx
+++ b/alg/teca_binary_segmentation.cxx
@@ -318,13 +318,13 @@ const_p_teca_dataset teca_binary_segmentation::execute(
 
     // do segmentation
     size_t n_elem = input_array->size();
-    p_teca_unsigned_char_array segmentation =
-        teca_unsigned_char_array::New(n_elem);
+    p_teca_char_array segmentation =
+        teca_char_array::New(n_elem);
 
     TEMPLATE_DISPATCH(const teca_variant_array_impl,
         input_array.get(),
         const NT *p_in = static_cast<TT*>(input_array.get())->get();
-        unsigned char *p_seg = segmentation->get();
+        char *p_seg = segmentation->get();
 
         if (this->threshold_mode == BY_VALUE)
         {
@@ -351,6 +351,19 @@ const_p_teca_dataset teca_binary_segmentation::execute(
     teca_metadata &out_metadata = out_mesh->get_metadata();
     out_metadata.set("low_threshold_value", low);
     out_metadata.set("high_threshold_value", high);
+
+
+    // get a copy of the attributes
+    teca_metadata attributes;
+    out_metadata.get("attributes", attributes);
+
+    // insert attributes for the segmentation variable
+    // into the output metadata pointer
+    attributes.set(segmentation_var.c_str(),
+        this->get_segmentation_variable_atts());
+
+    // overwrite the outgoing metadata with the new attributes variable
+    out_metadata.set("attributes", attributes);
 
     return out_mesh;
 }

--- a/alg/teca_binary_segmentation.h
+++ b/alg/teca_binary_segmentation.h
@@ -40,6 +40,10 @@ public:
     TECA_ALGORITHM_PROPERTY(double, low_threshold_value)
     TECA_ALGORITHM_PROPERTY(double, high_threshold_value)
 
+
+    // set the metadata for the segmentation variable
+    TECA_ALGORITHM_PROPERTY(teca_metadata, segmentation_variable_atts)
+
     // Set the threshold mode. In BY_PERCENTILE mode low and high thresholds
     // define the percentiles (0 to 100) between which data is in the
     // segmentation. default is BY_VALUE.
@@ -73,6 +77,7 @@ private:
     double low_threshold_value;
     double high_threshold_value;
     int threshold_mode;
+    teca_metadata segmentation_variable_atts;
 };
 
 #endif

--- a/io/teca_cf_reader.cxx
+++ b/io/teca_cf_reader.cxx
@@ -562,6 +562,13 @@ teca_metadata teca_cf_reader::get_output_metadata(
                         teca_netcdf_util::crtrim(tmp, att_len);
                         atts.set(att_name, std::string(tmp));
                     }
+                    else if (att_type == NC_STRING)
+                    {
+                        char *strs[1] = {nullptr};
+                        nc_get_att_string(fh.get(), i, att_name, strs);
+                        atts.set(att_name, std::string(strs[0]));
+                        nc_free_string(1, strs);
+                    }
                     else
                     {
                         NC_DISPATCH(att_type,

--- a/io/teca_cf_writer.h
+++ b/io/teca_cf_writer.h
@@ -61,6 +61,12 @@ public:
     // be better when using fixed dimensions. (1)
     TECA_ALGORITHM_PROPERTY(int, use_unlimited_dim)
 
+
+    // sets the compression level used for each variable
+    // compression is not used if the value is less than
+    // or equal to 0
+    TECA_ALGORITHM_PROPERTY(int, compression_level)
+
 protected:
     teca_cf_writer();
 
@@ -83,6 +89,7 @@ private:
     unsigned int steps_per_file;
     int mode_flags;
     int use_unlimited_dim;
+    int compression_level;
 };
 
 #endif

--- a/python/teca_py_alg.i
+++ b/python/teca_py_alg.i
@@ -4,6 +4,7 @@
 #include "teca_algorithm.h"
 #include "teca_apply_binary_mask.h"
 #include "teca_bayesian_ar_detect.h"
+#include "teca_bayesian_ar_detect_parameters.h"
 #include "teca_binary_segmentation.h"
 #include "teca_cartesian_mesh_source.h"
 #include "teca_cartesian_mesh_subset.h"
@@ -440,6 +441,14 @@ struct teca_tc_saffir_simpson
 %shared_ptr(teca_bayesian_ar_detect)
 %ignore teca_bayesian_ar_detect::operator=;
 %include "teca_bayesian_ar_detect.h"
+
+/***************************************************************************
+ bayesian_ar_detect_parameters
+ ***************************************************************************/
+%ignore teca_bayesian_ar_detect_parameters::shared_from_this;
+%shared_ptr(teca_bayesian_ar_detect_parameters)
+%ignore teca_bayesian_ar_detect_parameters::operator=;
+%include "teca_bayesian_ar_detect_parameters.h"
 
 /***************************************************************************
  component_statistics

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,13 @@ teca_add_test(test_cf_writer_cam5_serial
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)
 
+teca_add_test(test_cf_writer_cam5_compression
+    COMMAND test_cf_writer
+    -i "${TECA_DATA_ROOT}/cam5_1_amip_run2\\.cam2\\.h2\\.1991-10-[0-9][0-9]-10800\\.nc"
+    -o "test_cf_writer_%t%.%e%" -s 0,-1 -x lon -y lat -t time -c 2 -n 1 -d 4 U850 V850
+    FEATURES ${TECA_HAS_NETCDF}
+    REQ_TECA_DATA)
+
 teca_add_test(test_cf_writer_cfsr_serial
     COMMAND test_cf_writer
     -i "${TECA_DATA_ROOT}/NCEP_CFSR_0\\.5_1979\\.nc"

--- a/test/test_cf_writer.cpp
+++ b/test/test_cf_writer.cpp
@@ -67,7 +67,8 @@ int parse_command_line(int argc, char **argv, int rank,
                 << "test_cf_writer [-i input regex] [-o output] [-s first step,last step] "
                 << "[-x x axis variable] [-y y axis variable] [-z z axis variable] "
                 << "[-t t axis variable] [-b x0,x1,y0,y1,z0,z1] [-e i0,i1,j0,j1,k0,k1] "
-                << "[-c index count] [-n num threads] [array 0] ... [array n]"
+                << "[-c index count] [-n num threads] [array 0] [ -d compression level] "
+                << "... [array n]"
                 << endl << endl;
         }
         return -1;
@@ -83,6 +84,7 @@ int parse_command_line(int argc, char **argv, int rank,
     long first_step = 0;
     long last_step = -1;
     long steps_per_file = 1;
+    int deflate_level = -1;
     std::vector<double> bounds;
     std::vector<unsigned long> extent;
 
@@ -151,6 +153,11 @@ int parse_command_line(int argc, char **argv, int rank,
             steps_per_file = atoi(argv[++i]);
             ++j;
         }
+        else if (!strcmp("-d", argv[i]))
+        {
+            deflate_level = atoi(argv[++i]);
+            ++j;
+        }
     }
 
     vector<string> arrays;
@@ -167,6 +174,7 @@ int parse_command_line(int argc, char **argv, int rank,
     cf_writer->set_file_name(output);
     cf_writer->set_thread_pool_size(n_threads);
     cf_writer->set_steps_per_file(steps_per_file);
+    cf_writer->set_compression_level(deflate_level);
 
     exec->set_start_index(first_step);
     exec->set_end_index(last_step);


### PR DESCRIPTION
modifications for compliance with ARTMIP: 
 * added ability to add attributes to teca_binary_segmentation variable
 * added ar_binary_tag (segments ar_probability at a user-specified
   level) and metadata to netcdf output
 * added option to turn compression on for point arrays
 * added test for cf_writer::set_compression_level()