### PR TITLE
Closes #321 Fixing travis-ci osx to use python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ env:
     - TECA_DIR=/travis_teca_dir
     - TECA_PYTHON_VERSION=3
     - TECA_DATA_REVISION=49
-  matrix:
+  jobs:
     - DOCKER_IMAGE=ubuntu IMAGE_VERSION=18.04 IMAGE_NAME=ubuntu_18_04
     - DOCKER_IMAGE=fedora IMAGE_VERSION=28 IMAGE_NAME=fedora_28
     - NO_DOCKER=TRUE
 
-matrix:
+jobs:
   exclude:
     - os: osx
       env: DOCKER_IMAGE=ubuntu IMAGE_VERSION=18.04 IMAGE_NAME=ubuntu_18_04

--- a/test/travis_ci/install_osx.sh
+++ b/test/travis_ci/install_osx.sh
@@ -6,11 +6,10 @@ export PATH=/usr/local/bin:$PATH
 # install deps. note than many are included as a part of brew-core
 # these days. hence this list isn't comprehensive
 brew update
-brew upgrade python
 brew install openmpi swig svn udunits
 # matplotlib currently doesn't have a formula
 # teca fails to locate mpi4py installed from brew
-pip3 install mpi4py matplotlib
+pip3 install numpy mpi4py matplotlib
 
 # install data files.
 # On Apple svn is very very slow. On my mac book pro


### PR DESCRIPTION
`Numpy` was not installed. Adding `pip3 install numpy...` fixed it.