### PR TITLE
use mpich on Travis CI Apple Mac OS

### DIFF
--- a/test/travis_ci/install_osx.sh
+++ b/test/travis_ci/install_osx.sh
@@ -6,7 +6,7 @@ export PATH=/usr/local/bin:$PATH
 # install deps. note than many are included as a part of brew-core
 # these days. hence this list isn't comprehensive
 brew update
-brew install openmpi swig svn udunits
+brew install mpich swig svn udunits
 # matplotlib currently doesn't have a formula
 # teca fails to locate mpi4py installed from brew
 pip3 install numpy mpi4py matplotlib


### PR DESCRIPTION
@elbashandy this should resolve failing mac os tests with the error:

```
[Traviss-Mac-6.local:49996] PMIX ERROR: ERROR in file gds_ds12_lock_pthread.c at line 206
```