### PR TITLE
Replaced ARTMIP datasets that don't have time dimension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - BUILD_TYPE=Debug
     - TECA_DIR=/travis_teca_dir
     - TECA_PYTHON_VERSION=3
-    - TECA_DATA_REVISION=61
+    - TECA_DATA_REVISION=68
   jobs:
     - DOCKER_IMAGE=ubuntu IMAGE_VERSION=18.04 IMAGE_NAME=ubuntu_18_04
     - DOCKER_IMAGE=fedora IMAGE_VERSION=31 IMAGE_NAME=fedora_31

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,9 +77,9 @@ teca_add_test(test_cf_reader_era5
 
 teca_add_test(test_cf_reader_file_time
     COMMAND test_cf_reader
-    -i "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D_20170210_06\.nc"
+    -i "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D_2017-05-16-00Z\.nc"
     -o "test_cf_reader_file_time_%t%.%e%" -s 0,-1 -x lon -y lat
-    -n "ARTMIP_MERRA_2D_%Y%m%d_%H.nc" IVT
+    -t time -n "ARTMIP_MERRA_2D_%Y-%m-%d-%HZ.nc" IVT
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -308,7 +308,7 @@ teca_add_test(py_test_bayesian_ar_detect_mpi_threads
 teca_add_test(py_test_deeplabv3p_ar_detect
     COMMAND  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_deeplabv3p_ar_detect.py
     "${TECA_DATA_ROOT}/cascade_deeplab_IVT.pt"
-    "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D.*\.nc$"
+    "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D_2017-05-16-00Z\.nc$"
     "${TECA_DATA_ROOT}/test_deeplabv3p_ar_detect.bin" IVT 1
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)
@@ -317,7 +317,7 @@ teca_add_test(py_test_deeplabv3p_ar_detect_mpi
     COMMAND ${MPIEXEC} -n ${HALF_TEST_CORES} ${PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/test_deeplabv3p_ar_detect.py
        "${TECA_DATA_ROOT}/cascade_deeplab_IVT.pt"
-        "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D.*\.nc$"
+        "${TECA_DATA_ROOT}/ARTMIP_MERRA_2D_2017-05-16-00Z\.nc$"
         "${TECA_DATA_ROOT}/test_deeplabv3p_ar_detect.bin" IVT 1
     FEATURES ${TECA_HAS_NETCDF} ${TECA_HAS_MPI} ${MPI4Py_FOUND}
     REQ_TECA_DATA)

--- a/test/python/test_deeplabv3p_ar_detect.py
+++ b/test/python/test_deeplabv3p_ar_detect.py
@@ -30,7 +30,6 @@ n_threads = int(sys.argv[5])
 
 cf_reader = teca_cf_reader.New()
 cf_reader.set_files_regex(mesh_data_regex)
-cf_reader.set_t_axis_variable("")
 cf_reader.set_periodic_in_x(1)
 
 deeplabv3p_ar_detect = teca_deeplabv3p_ar_detect.New()


### PR DESCRIPTION
Replaced ARTMIP_MERRA_2D_20170210* with ARTMIP_MERRA_2D_2017-05-16-00Z.nc as the old ones didn't have time dimension. The new one does.