### PR TITLE
Fix connected components

### DIFF
--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -87,6 +87,8 @@ void component_area(unsigned long nlon, unsigned long nlat,
     d_cos_phi[0] = calc_t();
     d_cos_phi[nlatm1] = calc_t();
 
+    const component_t neg_one = -1;
+
     // finish off the calc by multiplying the factors
     for (unsigned long j = 1; j < nlatm1; ++j)
     {
@@ -94,7 +96,12 @@ void component_area(unsigned long nlon, unsigned long nlat,
         unsigned long jj = j*nlon;
         for (unsigned long i = 1; i < nlonm1; ++i)
         {
-            area[labels[jj + i]] += rho_sq_d_theta[i]*d_cos_phi_j;
+
+            // avoid calculating the area of background labels
+            if (labels[jj + i] != neg_one)
+            {
+              area[labels[jj + i]] += rho_sq_d_theta[i]*d_cos_phi_j;
+            }
         }
     }
 

--- a/alg/teca_connected_components.cxx
+++ b/alg/teca_connected_components.cxx
@@ -121,6 +121,8 @@ void periodic_labeler(unsigned long i0, unsigned long j0, unsigned long k0,
     std::deque<id3> work_queue;
     work_queue.push_back(id3(i0,j0,k0));
 
+    component_t neg_one = -1;
+
     while (work_queue.size())
     {
         id3 ijk = work_queue.back();
@@ -151,7 +153,7 @@ void periodic_labeler(unsigned long i0, unsigned long j0, unsigned long k0,
                     qq = (qq + nx) % nx;
                     unsigned long w = qq + jj + kk;
 
-                    if (segments[w] && !components[w])
+                    if (segments[w] && (components[w] == neg_one))
                     {
                         components[w] = current_component;
                         work_queue.push_back(id3(qq,rr,ss));
@@ -178,9 +180,11 @@ void label(unsigned long *ext, int periodic_in_x, int periodic_in_y,
     unsigned long nz = ext[5] - ext[4] + 1;
     unsigned long nxy = nx*ny;
 
+    component_t neg_one = -1;
+
     // initialize the components
-    component_t current_component = 0;
-    memset(components, 0, nxy*nz*sizeof(component_t));
+    component_t current_component = neg_one;
+    memset(components, neg_one, nxy*nz*sizeof(component_t));
 
     // visit each element to see if it is a seed
     for (unsigned long k = 0; k < nz; ++k)
@@ -194,7 +198,7 @@ void label(unsigned long *ext, int periodic_in_x, int periodic_in_y,
                 unsigned long q = kk + jj + i;
 
                 // found seed, label it
-                if (segments[q] && !components[q])
+                if (segments[q] && (components[q] == neg_one))
                 {
                     components[q] = ++current_component;
                     periodic_labeler(i,j,k, current_component,

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -35,6 +35,10 @@ teca_add_test(py_test_cf_writer_mpi_threads
     FEATURES ${TECA_HAS_MPI} ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)
 
+teca_add_test(py_test_connected_components_simple
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_connected_components_simple.py
+    5 5 0 "py_test_connected_components_simple_%t%.%e%")
+
 # TODO -- camke_parse_arguments eats ""
 if (TECA_DATA_ROOT AND TECA_HAS_NETCDF)
     add_test(NAME py_test_connected_components

--- a/test/python/test_connected_components_simple.py
+++ b/test/python/test_connected_components_simple.py
@@ -1,0 +1,107 @@
+from teca import *
+import sys
+import numpy as np
+
+set_stack_trace_on_error()
+
+def isequal(a, b, epsilon):
+    return np.fabs(a - b) < epsilon
+
+
+if not len(sys.argv) == 5:
+    sys.stderr.write('test_connected_components.py [nx] [ny] [threshold]\n' \
+            '[out_file]')
+    sys.exit(-1)
+
+nx = int(sys.argv[1])
+ny = int(sys.argv[2])
+threshold = float(sys.argv[3])
+out_file = str(sys.argv[4])
+
+
+nxy = nx*ny
+
+dx = 360./float(nx - 1)
+x = []
+for i in range(nx):
+    x.append(i*dx)
+
+dy = 180./float(ny - 1)
+y = []
+for i in range(ny):
+    y.append(-90. + i*dy)
+
+x = teca_variant_array.New(x)
+y = teca_variant_array.New(y)
+z = teca_variant_array.New([0.])
+t = teca_variant_array.New([1.])
+
+# set the segmentation array
+segmentation_array = np.zeros([nx,ny])
+# insert a single above-threshold value in the center
+segmentation_array[int(nx/2), int(ny/2)] = threshold + 1
+
+test_grid = teca_variant_array.New(segmentation_array.ravel())
+
+wext = [0, nx - 1, 0, ny - 1, 0, 0]
+
+mesh = teca_cartesian_mesh.New()
+mesh.set_x_coordinates("lon", x)
+mesh.set_y_coordinates("lat", y)
+mesh.set_z_coordinates("z", z)
+mesh.set_whole_extent(wext)
+mesh.set_extent(wext)
+mesh.set_time(1.0)
+mesh.set_time_step(0)
+mesh.get_point_arrays().append("test_grid", test_grid)
+
+md = teca_metadata()
+md["whole_extent"] = wext
+md["time_steps"] = [0]
+md["variables"] = ["test_grid"]
+md["number_of_time_steps"] = 1
+md["index_initializer_key"] = "number_of_time_steps"
+md["index_request_key"] = "time_step"
+
+source = teca_dataset_source.New()
+source.set_metadata(md)
+source.set_dataset(mesh)
+
+seg = teca_binary_segmentation.New()
+seg.set_threshold_variable("test_grid")
+seg.set_segmentation_variable("segmented_grid")
+seg.set_low_threshold_value(threshold)
+seg.set_input_connection(source.get_output_port())
+
+cc = teca_connected_components.New()
+cc.set_segmentation_variable("segmented_grid")
+cc.set_component_variable("connected_component")
+cc.set_input_connection(seg.get_output_port())
+
+seg_o = teca_dataset_capture.New()
+seg_o.set_input_connection(cc.get_output_port())
+
+exe = teca_index_executive.New()
+exe.set_start_index(0)
+exe.set_end_index(0)
+
+wri = teca_cartesian_mesh_writer.New()
+wri.set_input_connection(seg_o.get_output_port())
+wri.set_executive(exe)
+wri.set_file_name(out_file)
+
+wri.update()
+
+# get the dataset
+ds = seg_o.get_dataset()
+# get the metadata
+mdo = ds.get_metadata()
+
+# get the counts
+num_components = mdo['number_of_components']
+
+# check that there is only 1
+if num_components != 1:
+    sys.stderr.write("Number of components is not 1; it is: " 
+                     + str(num_components) + "\n")
+    sys.exit(-1)


### PR DESCRIPTION
Connected components currently counts one too many objects.  Analysis of output meshes indicates that it counts the background as a connected component.  The first commit in this branch adds a test `test/python/test_connected_components_simple.py` demonstrating this on a simple test case.

@burlen - could you please verify that this test is valid and that the failure indeed indicates a bug?