### PR TITLE
fix edge case in bayesian ar detect

### DIFF
--- a/alg/teca_bayesian_ar_detect.cxx
+++ b/alg/teca_bayesian_ar_detect.cxx
@@ -477,7 +477,7 @@ public:
                 // compute the probability from the connected components
                 p_teca_variant_array wvcc =
                     mesh->get_point_arrays()->get(this->component_array_name);
-                if (wvcc)
+                if (!wvcc)
                 {
                     TECA_ERROR("pipeline error, component array \""
                         << this->component_array_name << "\" is not present")


### PR DESCRIPTION
fix typo in the case where there is only 1 parameter table row.

resolves #215
resolves #305 