### PR TITLE
fix for bounds to extent when coordinate axis is descending

### DIFF
--- a/data/teca_coordinate_util.h
+++ b/data/teca_coordinate_util.h
@@ -97,7 +97,7 @@ int index_of(const data_t *data, unsigned long l, unsigned long r,
         return 0;
     }
     else
-    if (val < data[m_0])
+    if (bracket_t::comp1_t::eval(val, data[m_0]))
     {
         // split range to the left
         return teca_coordinate_util::index_of<data_t, bracket_t>(


### PR DESCRIPTION
this arises in k hat axis when the units are pressure levels.
the fix is to apply the comparison operator in the binary search bisect
step rather than always using operator<.