### PR TITLE
update cdash drop settings for new nersc config

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,6 +1,6 @@
 set(CTEST_PROJECT_NAME "TECA")
 set(CTEST_NIGHTLY_START_TIME "23:00:00 PDT")
-set(CTEST_DROP_METHOD "https")
-set(CTEST_DROP_SITE "cdash.nersc.gov")
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "cdash.cdash.development.svc.spin.nersc.org")
 set(CTEST_DROP_LOCATION "/submit.php?project=TECA")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ TECA(Toolkit for Extreme Climate Analysis) is a collection of climate analysis a
 # Documentation
 For more information please see the [TECA User's Guide](https://teca.readthedocs.io/en/latest/).
 
+# Continuous Integration and Regression Testing
+For the latest regression suite results see the [TECA CDash project site](http://cdash.cdash.development.svc.spin.nersc.org/index.php?project=TECA).
+
 #Copyright Notice#
 TECA, Copyright (c) 2015, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 


### PR DESCRIPTION
recent cdash outage was caused by migration from one server to another, Jonathan recommends the following changes to get it working again.