### PR TITLE
add support for writing tables in NetCDF format

### DIFF
--- a/alg/teca_table_calendar.cxx
+++ b/alg/teca_table_calendar.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_metadata.h"
+#include "teca_array_attributes.h"
 
 #include <algorithm>
 #include <iostream>
@@ -156,6 +157,9 @@ const_p_teca_dataset teca_table_calendar::execute(
     p_teca_table out_table = teca_table::New();
     out_table->copy_metadata(in_table);
 
+    teca_metadata atrs;
+    out_table->get_metadata().get("attributes", atrs);
+
     unsigned long n_rows = time->size();
 
     p_teca_variant_array_impl<int> year;
@@ -166,6 +170,11 @@ const_p_teca_dataset teca_table_calendar::execute(
         year = std::static_pointer_cast
             <teca_variant_array_impl<int>>(out_table->get_column(year_col));
         year->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "year";
+        atts.description = calendar + " calendar year";
+        atrs.set("year", (teca_metadata)atts);
     }
 
     p_teca_variant_array_impl<int> month;
@@ -176,6 +185,11 @@ const_p_teca_dataset teca_table_calendar::execute(
         month = std::static_pointer_cast
             <teca_variant_array_impl<int>>(out_table->get_column(month_col));
         month->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "month";
+        atts.description = calendar + " calendar month of year";
+        atrs.set("month", (teca_metadata)atts);
     }
 
     p_teca_variant_array_impl<int> day;
@@ -186,6 +200,11 @@ const_p_teca_dataset teca_table_calendar::execute(
         day = std::static_pointer_cast
             <teca_variant_array_impl<int>>(out_table->get_column(day_col));
         day->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "day";
+        atts.description = calendar + " calendar day of the monnth";
+        atrs.set("day", (teca_metadata)atts);
     }
 
     p_teca_variant_array_impl<int> hour;
@@ -196,6 +215,11 @@ const_p_teca_dataset teca_table_calendar::execute(
         hour = std::static_pointer_cast
             <teca_variant_array_impl<int>>(out_table->get_column(hour_col));
         hour->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "hour";
+        atts.description = "hour of the day";
+        atrs.set("hour", (teca_metadata)atts);
     }
 
     p_teca_variant_array_impl<int> minute;
@@ -206,6 +230,11 @@ const_p_teca_dataset teca_table_calendar::execute(
         minute = std::static_pointer_cast
             <teca_variant_array_impl<int>>(out_table->get_column(minute_col));
         minute->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "minute";
+        atts.description = "minute of the hour";
+        atrs.set("minute", (teca_metadata)atts);
     }
 
     p_teca_variant_array_impl<double> second;
@@ -216,7 +245,14 @@ const_p_teca_dataset teca_table_calendar::execute(
         second = std::static_pointer_cast
             <teca_variant_array_impl<double>>(out_table->get_column(second_col));
         second->reserve(n_rows);
+
+        teca_array_attributes atts;
+        atts.long_name = "second";
+        atts.description = "second of the minute";
+        atrs.set("second", (teca_metadata)atts);
     }
+
+    out_table->get_metadata().set("attributes", atrs);
 
     // make the date computations
     TEMPLATE_DISPATCH(

--- a/apps/teca_convert_table.in
+++ b/apps/teca_convert_table.in
@@ -17,7 +17,7 @@ parser.add_argument('out_file', type=str,
 
 parser.add_argument('--out_format', type=str, default='auto',
     help='The file formate to use in the output. ' \
-         'One of: auto, bin, csv. (auto)')
+         'One of: auto, bin, csv, netcdf. (auto)')
 
 parser.add_argument('--select', type=str, required=False,
     help='a logical expression on table columns. '      \
@@ -35,6 +35,8 @@ elif args.in_format == 'bin':
     reader.set_file_format_bin()
 elif args.in_format == 'csv':
     reader.set_file_format_csv()
+elif args.in_format == 'netcdf':
+    reader.set_file_format_netcdf()
 else:
     sys.stderr.write('ERROR: Invalid input file format %s'%(
         args.in_format))

--- a/io/teca_netcdf_util.cxx
+++ b/io/teca_netcdf_util.cxx
@@ -698,4 +698,80 @@ read_variable::data_t read_variable::operator()()
         << "\" from \"" << m_file << "\". Unsupported data type")
     return this->package(m_id);
 }
+
+// **************************************************************************
+int write_variable_attributes(netcdf_handle &fh, int var_id,
+    teca_metadata &array_atts)
+{
+    int ierr = 0;
+    unsigned long n_atts = array_atts.size();
+    for (unsigned long j = 0; j < n_atts; ++j)
+    {
+        std::string att_name;
+        if (array_atts.get_name(j, att_name))
+        {
+            TECA_ERROR("failed to get name of the " << j << "th attribute")
+            return -1;
+        }
+
+        // skip non-standard internal book keeping metadata this is
+        // potentially OK to pass through but likely of no interest to
+        // anyone else
+        if ((att_name == "cf_id") || (att_name == "cf_dims") ||
+            (att_name == "cf_dim_names") || (att_name == "type_code") ||
+            (att_name == "cf_type_code") || (att_name == "centering") ||
+            (att_name == "size"))
+            continue;
+
+        // get the attribute value
+        const_p_teca_variant_array att_values = array_atts.get(att_name);
+
+        // handle string type
+        TEMPLATE_DISPATCH_CASE(
+            const teca_variant_array_impl, std::string,
+            att_values.get(),
+            if (att_values->size() > 1)
+                continue;
+            const std::string att_val = static_cast<const TT*>(att_values.get())->get(0);
+#if !defined(HDF5_THREAD_SAFE)
+            {
+            std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
+#endif
+            if ((ierr = nc_put_att_text(fh.get(),
+                var_id, att_name.c_str(), att_val.size()+1,
+                att_val.c_str())) != NC_NOERR)
+            {
+                TECA_ERROR("failed to put attribute \"" << att_name << "\"")
+            }
+#if !defined(HDF5_THREAD_SAFE)
+            }
+#endif
+            )
+        // handle POD types
+        else TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            att_values.get(),
+
+            int type = teca_netcdf_util::netcdf_tt<NT>::type_code;
+            const NT *pvals = static_cast<TT*>(att_values.get())->get();
+            unsigned long n_vals = att_values->size();
+
+#if !defined(HDF5_THREAD_SAFE)
+            {
+            std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
+#endif
+            if ((ierr = nc_put_att(fh.get(), var_id, att_name.c_str(), type,
+                n_vals, pvals)) != NC_NOERR)
+            {
+                TECA_ERROR("failed to put attribute \"" << att_name << "\" "
+                    << nc_strerror(ierr))
+            }
+#if !defined(HDF5_THREAD_SAFE)
+            }
+#endif
+            )
+    }
+
+    return 0;
+}
+
 }

--- a/io/teca_netcdf_util.h
+++ b/io/teca_netcdf_util.h
@@ -209,7 +209,6 @@ int read_variable_attributes(netcdf_handle &fh, int var_id,
 int read_variable_attributes(netcdf_handle &fh,
     const std::string &name, teca_metadata &atts);
 
-
 // functional that reads and returns a variable from the
 // named file. we're doing this so we can do thread
 // parallel I/O to hide some of the cost of opening files
@@ -295,7 +294,10 @@ private:
     unsigned long m_id;
 };
 
+// write the attributes in array_atts to the variable identified by var_id the
+// name is used in error messages. returns zero of successful.
+int write_variable_attributes(netcdf_handle &fh, int var_id,
+    teca_metadata &array_atts);
 
 }
-
 #endif

--- a/io/teca_table_writer.h
+++ b/io/teca_table_writer.h
@@ -34,7 +34,8 @@ public:
 
     // set the output filename. for time series the substring
     // %t% is replaced with the current time step. the substring
-    // %e% is replaced with .bin in binary mode and .csv otherwise
+    // %e% is replaced with .bin in binary mode, .csv in csv mode, .nc in
+    // netcdf mode, and xlsx in MS Excel mode.
     // %s% is replaced with the table name (workbooks only).
     TECA_ALGORITHM_PROPERTY(std::string, file_name)
 
@@ -43,14 +44,19 @@ public:
     TECA_GET_ALGORITHM_PROPERTIES_DESCRIPTION()
     TECA_SET_ALGORITHM_PROPERTIES()
 
-    // Select the output file format. 0 : csv, 1 : bin, 2 : xlsx.
-    // the default is csv.
-    enum {format_csv, format_bin, format_xlsx, format_auto};
+    // Select the output file format.
+    //
+    //      0 : auto, 1 : csv, 2 : bin, 3 : xlsx, 4 : netcdf
+    //
+    // in the auto format mode, the format is selected using the file
+    // name extention. the default is auto.
+    enum {format_auto, format_csv, format_bin, format_xlsx, format_netcdf};
     TECA_ALGORITHM_PROPERTY(int, output_format)
+    void set_output_format_auto(){ this->set_output_format(format_auto); }
     void set_output_format_csv(){ this->set_output_format(format_csv); }
     void set_output_format_bin(){ this->set_output_format(format_bin); }
     void set_output_format_xlsx(){ this->set_output_format(format_xlsx); }
-    void set_output_format_auto(){ this->set_output_format(format_auto); }
+    void set_output_format_netcdf(){ this->set_output_format(format_netcdf); }
 
 protected:
     teca_table_writer();

--- a/test/apps/CMakeLists.txt
+++ b/test/apps/CMakeLists.txt
@@ -205,3 +205,11 @@ teca_add_test(test_convert_table_app_bin_csv
     "cam5-025deg-all-hist-est1-v3-r1-tracks_size.bin"
     "cam5-025deg-all-hist-est1-v3-r1-tracks_size.csv"
     REQ_TECA_DATA)
+
+teca_add_test(test_convert_table_app_bin_netcdf
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_convert_table_app.sh
+    ${CMAKE_BINARY_DIR}/${BIN_PREFIX} ${TECA_DATA_ROOT}
+    "test_descriptive_statistics.bin"
+    "test_descriptive_statistics.nc"
+    FEATURES ${TECA_HAS_NETCDF}
+    REQ_TECA_DATA)

--- a/test/apps/CMakeLists.txt
+++ b/test/apps/CMakeLists.txt
@@ -192,7 +192,16 @@ teca_add_test(test_table_diff_app_fail
     REQ_TECA_DATA
     WILL_FAIL)
 
-teca_add_test(test_convert_table_app
+teca_add_test(test_convert_table_app_csv_bin
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_convert_table_app.sh
     ${CMAKE_BINARY_DIR}/${BIN_PREFIX} ${TECA_DATA_ROOT}
+    "cam5-025deg-all-hist-est1-v3-r1-tracks_size.csv"
+    "cam5-025deg-all-hist-est1-v3-r1-tracks_size.bin"
+    REQ_TECA_DATA)
+
+teca_add_test(test_convert_table_app_bin_csv
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_convert_table_app.sh
+    ${CMAKE_BINARY_DIR}/${BIN_PREFIX} ${TECA_DATA_ROOT}
+    "cam5-025deg-all-hist-est1-v3-r1-tracks_size.bin"
+    "cam5-025deg-all-hist-est1-v3-r1-tracks_size.csv"
     REQ_TECA_DATA)


### PR DESCRIPTION
* supports writing attributes in the same way the cf_reader does. an algorithm may add attributes in metadata the writer looks for them and if present writes them.
* add attribute generation to some of the table algorithms (see teca_descriptive_stats and teca_table_calendar)
* we will at some point need to add support for reading this format, see #469 
* added a regression test

an example output file obtained from the new regression test follows
```
$ncdump bin/test/test_descriptive_statistics.nc 
netcdf test_descriptive_statistics {
dimensions:
	n_rows = 4 ;
variables:
	int year(n_rows) ;
		year:description = "noleap calendar year" ;
		year:long_name = "year" ;
	int month(n_rows) ;
		month:description = "noleap calendar month of year" ;
		month:long_name = "month" ;
	int day(n_rows) ;
		day:description = "noleap calendar day of the monnth" ;
		day:long_name = "day" ;
	int hour(n_rows) ;
		hour:description = "hour of the day" ;
		hour:long_name = "hour" ;
	int minute(n_rows) ;
		minute:description = "minute of the hour" ;
		minute:long_name = "minute" ;
	int step(n_rows) ;
		step:description = "input dataset time step" ;
		step:long_name = "time step" ;
		step:units = "unitless" ;
	double time(n_rows) ;
		time:bounds = "time_bnds" ;
		time:calendar = "noleap" ;
		time:long_name = "time" ;
		time:units = "days since 1979-01-01 00:00:00" ;
	float min_TMQ(n_rows) ;
		min_TMQ:description = "minimum of TMQ" ;
		min_TMQ:long_name = "min_TMQ" ;
		min_TMQ:units = "k" ;
	float max_TMQ(n_rows) ;
		max_TMQ:description = "maximum of TMQ" ;
		max_TMQ:long_name = "max_TMQ" ;
		max_TMQ:units = "k" ;
	float avg_TMQ(n_rows) ;
		avg_TMQ:description = "average of TMQ" ;
		avg_TMQ:long_name = "avg_TMQ" ;
		avg_TMQ:units = "k" ;
	float var_TMQ(n_rows) ;
		var_TMQ:description = "variance of TMQ" ;
		var_TMQ:long_name = "var_TMQ" ;
		var_TMQ:units = "k" ;
	float low_q_TMQ(n_rows) ;
		low_q_TMQ:description = "lower quartile of TMQ" ;
		low_q_TMQ:long_name = "low_q_TMQ" ;
		low_q_TMQ:units = "k" ;
	float med_TMQ(n_rows) ;
		med_TMQ:description = "median of TMQ" ;
		med_TMQ:long_name = "med_TMQ" ;
		med_TMQ:units = "k" ;
	float up_q_TMQ(n_rows) ;
		up_q_TMQ:description = "upper quartile of TMQ" ;
		up_q_TMQ:long_name = "up_q_TMQ" ;
		up_q_TMQ:units = "k" ;
	float min_T200(n_rows) ;
		min_T200:description = "minimum of T200" ;
		min_T200:long_name = "min_T200" ;
		min_T200:units = "K" ;
	float max_T200(n_rows) ;
		max_T200:description = "maximum of T200" ;
		max_T200:long_name = "max_T200" ;
		max_T200:units = "K" ;
	float avg_T200(n_rows) ;
		avg_T200:description = "average of T200" ;
		avg_T200:long_name = "avg_T200" ;
		avg_T200:units = "K" ;
	float var_T200(n_rows) ;
		var_T200:description = "variance of T200" ;
		var_T200:long_name = "var_T200" ;
		var_T200:units = "K" ;
	float low_q_T200(n_rows) ;
		low_q_T200:description = "lower quartile of T200" ;
		low_q_T200:long_name = "low_q_T200" ;
		low_q_T200:units = "K" ;
	float med_T200(n_rows) ;
		med_T200:description = "median of T200" ;
		med_T200:long_name = "med_T200" ;
		med_T200:units = "K" ;
	float up_q_T200(n_rows) ;
		up_q_T200:description = "upper quartile of T200" ;
		up_q_T200:long_name = "up_q_T200" ;
		up_q_T200:units = "K" ;
	float min_T500(n_rows) ;
		min_T500:description = "minimum of T500" ;
		min_T500:long_name = "min_T500" ;
		min_T500:units = "K" ;
	float max_T500(n_rows) ;
		max_T500:description = "maximum of T500" ;
		max_T500:long_name = "max_T500" ;
		max_T500:units = "K" ;
	float avg_T500(n_rows) ;
		avg_T500:description = "average of T500" ;
		avg_T500:long_name = "avg_T500" ;
		avg_T500:units = "K" ;
	float var_T500(n_rows) ;
		var_T500:description = "variance of T500" ;
		var_T500:long_name = "var_T500" ;
		var_T500:units = "K" ;
	float low_q_T500(n_rows) ;
		low_q_T500:description = "lower quartile of T500" ;
		low_q_T500:long_name = "low_q_T500" ;
		low_q_T500:units = "K" ;
	float med_T500(n_rows) ;
		med_T500:description = "median of T500" ;
		med_T500:long_name = "med_T500" ;
		med_T500:units = "K" ;
	float up_q_T500(n_rows) ;
		up_q_T500:description = "upper quartile of T500" ;
		up_q_T500:long_name = "up_q_T500" ;
		up_q_T500:units = "K" ;

// global attributes:
		:TECA_VERSION_DESCR = "TECA-BARD-v1.0.1-56-gea6d7f9" ;
		:APP_NAME = "python3.7" ;
data:

 year = 1991, 1991, 1991, 1991 ;

 month = 10, 10, 10, 10 ;

 day = 1, 1, 2, 2 ;

 hour = 6, 18, 6, 18 ;

 minute = 0, 0, 0, 0 ;

 step = 0, 0, 1, 0 ;

 time = 4653.25, 4653.75, 4654.25, 4654.75 ;

 min_TMQ = 0.1191005, 0.09403745, 0.08582211, 0.1252477 ;

 max_TMQ = 76.23008, 78.3484, 78.1083, 79.13735 ;

 avg_TMQ = 18.03778, 18.07848, 18.06511, 18.0578 ;

 var_TMQ = 231.1843, 232.8742, 233.3356, 232.8826 ;

 low_q_TMQ = 5.763391, 5.67127, 5.535318, 5.365588 ;

 med_TMQ = 12.79058, 12.80874, 12.88422, 12.91382 ;

 up_q_TMQ = 29.3114, 29.45477, 29.281, 29.47255 ;

 min_T200 = 191.2269, 192.4285, 191.5595, 191.0852 ;

 max_T200 = 226.4853, 225.9221, 226.9441, 226.7378 ;

 avg_T200 = 211.8242, 211.7446, 211.6758, 211.6421 ;

 var_T200 = 60.16385, 57.5494, 56.1035, 56.28493 ;

 low_q_T200 = 209.679, 209.7598, 209.7874, 209.6552 ;

 med_T200 = 215.6794, 215.5036, 215.3713, 215.3148 ;

 up_q_T200 = 217.5495, 217.4861, 217.4305, 217.3619 ;

 min_T500 = 224.3729, 224.0471, 223.944, 224.0193 ;

 max_T500 = 273.1478, 272.4973, 272.0215, 272.1913 ;

 avg_T500 = 251.4466, 251.4457, 251.4339, 251.4803 ;

 var_T500 = 170.4879, 170.0122, 168.2282, 166.6425 ;

 low_q_T500 = 240.7278, 240.405, 240.2772, 240.1098 ;

 med_T500 = 253.8495, 253.6426, 253.5895, 253.761 ;

 up_q_T500 = 265.0396, 265.0972, 264.952, 264.9814 ;
}

```