### PR TITLE
Integrated vapor transport

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -43,6 +43,7 @@ set(teca_alg_cxx_srcs
     teca_tc_trajectory.cxx
     teca_temporal_average.cxx
     teca_variant_array_operand.cxx
+    teca_vertical_reduction.cxx
     teca_vorticity.cxx
     teca_dataset_diff.cxx
     )

--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -25,6 +25,7 @@ set(teca_alg_cxx_srcs
     teca_descriptive_statistics.cxx
     teca_evaluate_expression.cxx
     teca_geography.cxx
+    teca_integrated_vapor_transport.cxx
     teca_l2_norm.cxx
     teca_latitude_damper.cxx
     teca_laplacian.cxx

--- a/alg/teca_integrated_vapor_transport.cxx
+++ b/alg/teca_integrated_vapor_transport.cxx
@@ -1,0 +1,326 @@
+#include "teca_integrated_vapor_transport.h"
+
+#include "teca_cartesian_mesh.h"
+#include "teca_array_collection.h"
+#include "teca_variant_array.h"
+#include "teca_metadata.h"
+#include "teca_coordinate_util.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <cmath>
+
+#if defined(TECA_HAS_BOOST)
+#include <boost/program_options.hpp>
+#endif
+
+using std::string;
+using std::vector;
+using std::cerr;
+using std::endl;
+using std::cos;
+
+//#define TECA_DEBUG
+
+namespace {
+template <typename coord_t, typename num_t>
+void cartesian_ivt(unsigned long nx, unsigned long ny,
+    unsigned long nz, const coord_t *plev, const num_t *wind,
+    const num_t *q, num_t *ivt)
+{
+    unsigned long nxy = nx*ny;
+    unsigned long nxyz = nxy*nz;
+
+    // compute the integrand
+    num_t *f = (num_t*)malloc(nxyz*sizeof(num_t));
+    for (unsigned long i = 0; i < nxyz; ++i)
+        f[i] = wind[i]*q[i];
+
+    // initialize the result
+    memset(ivt, 0, nxy*sizeof(num_t));
+
+    // work an x-y slice at  a time
+    unsigned long nzm1 = nz - 1;
+    for (unsigned long k = 0; k < nzm1; ++k)
+    {
+        // dp over the slice
+        num_t h2 = num_t(0.5) * (plev[k+1] - plev[k]);
+
+        // the current two x-y-planes of data
+        unsigned long knxy = k*nxy;
+        num_t *f_k0 = f + knxy;
+        num_t *f_k1 = f_k0 + nxy;
+
+        // accumulate this plane of data using trapazoid rule
+        for (unsigned long q = 0; q < nxy; ++q)
+        {
+            ivt[q] += h2 * (f_k0[q] + f_k1[q]);
+        }
+    }
+
+    // free up the integrand
+    free(f);
+
+    // check the sign, in this way we can handle both increasing and decreasing
+    // pressure coordinates
+    num_t s = plev[1] - plev[0] < num_t(0) ? num_t(-1) : num_t(1);
+
+    // scale by -1/g
+    num_t m1g = s/num_t(9.80665);
+    for (unsigned long i = 0; i < nxy; ++i)
+        ivt[i] *= m1g;
+}
+}
+
+// --------------------------------------------------------------------------
+teca_integrated_vapor_transport::teca_integrated_vapor_transport() :
+    wind_u_variable("ua"), wind_v_variable("va"),
+    specific_humidity_variable("hus"), ivt_u_variable("ivt_u"),
+    ivt_v_variable("ivt_v")
+{
+    this->set_number_of_input_connections(1);
+    this->set_number_of_output_ports(1);
+}
+
+// --------------------------------------------------------------------------
+teca_integrated_vapor_transport::~teca_integrated_vapor_transport()
+{}
+
+#if defined(TECA_HAS_BOOST)
+// --------------------------------------------------------------------------
+void teca_integrated_vapor_transport::get_properties_description(
+    const string &prefix, options_description &global_opts)
+{
+    options_description opts("Options for "
+        + (prefix.empty()?"teca_integrated_vapor_transport":prefix));
+
+    opts.add_options()
+        TECA_POPTS_GET(std::string, prefix, wind_u_variable,
+            "name of the variable containg the lon component of the wind vector (ua)")
+        TECA_POPTS_GET(std::string, prefix, wind_v_variable,
+            "name of the variable containg the lat component of the wind vector (va)")
+        TECA_POPTS_GET(std::string, prefix, specific_humidty_variable,
+            "array containg the specific humidity (hus)")
+        ;
+
+    global_opts.add(opts);
+}
+
+// --------------------------------------------------------------------------
+void teca_integrated_vapor_transport::set_properties(
+    const string &prefix, variables_map &opts)
+{
+    TECA_POPTS_SET(opts, std::string, prefix, wind_u_variable)
+    TECA_POPTS_SET(opts, std::string, prefix, wind_v_variable)
+    TECA_POPTS_SET(opts, std::string, prefix, specific_humidity_variable)
+}
+#endif
+
+// --------------------------------------------------------------------------
+teca_metadata teca_integrated_vapor_transport::get_output_metadata(
+    unsigned int port,
+    const std::vector<teca_metadata> &input_md)
+{
+#ifdef TECA_DEBUG
+    std::cerr << teca_parallel_id()
+        << "teca_integrated_vapor_transport::get_output_metadata" << std::endl;
+#endif
+    (void)port;
+
+    // the base class will handle dealing with the transformation of
+    // mesh dimensions and reporting the array we produce, but we have
+    // to determine the data type and tell the name of the produced array.
+    const teca_metadata &md = input_md[0];
+
+    teca_metadata attributes;
+    if (md.get("attributes", attributes))
+    {
+        TECA_ERROR("Failed to determine output data type "
+            "because attributes are misisng")
+        return teca_metadata();
+    }
+
+    teca_metadata u_atts;
+    if (attributes.get(this->wind_u_variable, u_atts))
+    {
+        TECA_ERROR("Failed to determine output data type "
+            "because attributes for \"" << this->wind_u_variable
+            << "\" are misisng")
+        return teca_metadata();
+    }
+
+    int type_code = 0;
+    if (u_atts.get("type_code", type_code))
+    {
+        TECA_ERROR("Failed to determine output data type "
+            "because attributes for \"" << this->wind_u_variable
+            << "\" is misisng a \"type_code\"")
+        return teca_metadata();
+    }
+
+    teca_array_attributes ivt_u_atts(
+        type_code, teca_array_attributes::point_centering,
+        0, "kg m^{-1} s^{-1}", "longitudinal integrated vapor transport",
+        "the longitudinal component of integrated vapor transport");
+
+    teca_array_attributes ivt_v_atts(
+        type_code, teca_array_attributes::point_centering,
+        0, "kg m^{-1} s^{-1}", "latitudinal integrated vapor transport",
+        "the latitudinal component of integrated vapor transport");
+
+    // install name and attributes of the output variables in the base classs
+    this->clear_derived_variables();
+    this->append_derived_variable(this->ivt_u_variable);
+    this->append_derived_variable(this->ivt_v_variable);
+
+    this->clear_derived_variable_attributes();
+    this->append_derived_variable_attribute(ivt_u_atts);
+    this->append_derived_variable_attribute(ivt_v_atts);
+
+    // invoke the base class method, which does the work of transforming
+    // the mesh and reporting the variables and their attributes.
+    return teca_vertical_reduction::get_output_metadata(port, input_md);
+}
+
+// --------------------------------------------------------------------------
+std::vector<teca_metadata> teca_integrated_vapor_transport::get_upstream_request(
+    unsigned int port,
+    const std::vector<teca_metadata> &input_md,
+    const teca_metadata &request)
+{
+    // install the names of the input variables in the base class
+    this->clear_dependent_variables();
+    this->append_dependent_variable(this->wind_u_variable);
+    this->append_dependent_variable(this->wind_v_variable);
+    this->append_dependent_variable(this->specific_humidity_variable);
+
+    // invoke th ebase class methd
+    return teca_vertical_reduction::get_upstream_request(port, input_md, request);
+}
+
+// --------------------------------------------------------------------------
+const_p_teca_dataset teca_integrated_vapor_transport::execute(
+    unsigned int port,
+    const std::vector<const_p_teca_dataset> &input_data,
+    const teca_metadata &request)
+{
+#ifdef TECA_DEBUG
+    std::cerr << teca_parallel_id()
+        << "teca_integrated_vapor_transport::execute" << std::endl;
+#endif
+    (void)port;
+
+    // get the input mesh
+    const_p_teca_cartesian_mesh in_mesh
+        = std::dynamic_pointer_cast<const teca_cartesian_mesh>(input_data[0]);
+
+    if (!in_mesh)
+    {
+        TECA_ERROR("Failed to compute IVT because a cartesian mesh is required.")
+        return nullptr;
+    }
+
+    // get the input dimensions
+    unsigned long extent[6] = {0};
+    if (in_mesh->get_extent(extent))
+    {
+        TECA_ERROR("Failed to compute IVT because mesh extent is missing.")
+        return nullptr;
+    }
+
+    unsigned long nx = extent[1] - extent[0] + 1;
+    unsigned long ny = extent[3] - extent[2] + 1;
+    unsigned long nz = extent[5] - extent[4] + 1;
+
+    // get the pressure coordinates
+    const_p_teca_variant_array p = in_mesh->get_z_coordinates();
+    if (!p)
+    {
+        TECA_ERROR("Failed to compute IVT because pressure coordinates are missing")
+        return nullptr;
+    }
+
+    if (p->size() < 2)
+    {
+        TECA_ERROR("Failed to compute IVT because z dimensions "
+            << p->size() << " < 2 as required by the integration method")
+        return nullptr;
+    }
+
+    // gather the input arrays
+    const_p_teca_variant_array wind_u =
+        in_mesh->get_point_arrays()->get(this->wind_u_variable);
+
+    if (!wind_u)
+    {
+        TECA_ERROR("Failed to compute IVT because longitudinal wind \""
+            << this->wind_u_variable << "\" is missing")
+        return nullptr;
+    }
+
+    const_p_teca_variant_array wind_v =
+        in_mesh->get_point_arrays()->get(this->wind_v_variable);
+
+    if (!wind_v)
+    {
+        TECA_ERROR("Failed to compute IVT because latitudinal wind \""
+            << this->wind_v_variable << "\" is missing")
+        return nullptr;
+    }
+
+    const_p_teca_variant_array q =
+        in_mesh->get_point_arrays()->get(this->specific_humidity_variable);
+
+    if (!q)
+    {
+        TECA_ERROR("Failed to compute IVT because specific humidity \""
+            << this->specific_humidity_variable << "\" is missing")
+        return nullptr;
+    }
+
+    // the base class will construct the output mesh
+    p_teca_cartesian_mesh out_mesh
+        = std::dynamic_pointer_cast<teca_cartesian_mesh>(
+            std::const_pointer_cast<teca_dataset>(
+                teca_vertical_reduction::execute(port, input_data, request)));
+
+    if (!out_mesh)
+    {
+        TECA_ERROR("Failed to compute IVT because the output mesh was "
+            "not constructed")
+        return nullptr;
+    }
+
+    // allocate the output arrays
+    unsigned long nxy = nx*ny;
+    p_teca_variant_array ivt_u = wind_u->new_instance(nxy);
+    p_teca_variant_array ivt_v = wind_u->new_instance(nxy);
+
+    // store the result
+    out_mesh->get_point_arrays()->set(this->ivt_u_variable, ivt_u);
+    out_mesh->get_point_arrays()->set(this->ivt_v_variable, ivt_v);
+
+    // calculate IVT
+    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        p.get(), _COORDS,
+
+        const NT_COORDS *p_p = static_cast<TT_COORDS*>(p.get())->get();
+
+        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+            ivt_u.get(), _DATA,
+
+            const NT_DATA *p_wind_u = static_cast<const TT_DATA*>(wind_u.get())->get();
+            const NT_DATA *p_wind_v = static_cast<const TT_DATA*>(wind_v.get())->get();
+            const NT_DATA *p_q = static_cast<const TT_DATA*>(q.get())->get();
+
+            NT_DATA *p_ivt_u = static_cast<TT_DATA*>(ivt_u.get())->get();
+            NT_DATA *p_ivt_v = static_cast<TT_DATA*>(ivt_v.get())->get();
+
+            ::cartesian_ivt(nx, ny, nz, p_p, p_wind_u, p_q, p_ivt_u);
+            ::cartesian_ivt(nx, ny, nz, p_p, p_wind_v, p_q, p_ivt_v);
+            )
+        )
+
+    return out_mesh;
+}

--- a/alg/teca_integrated_vapor_transport.h
+++ b/alg/teca_integrated_vapor_transport.h
@@ -1,0 +1,86 @@
+#ifndef teca_integrated_vapor_transport_h
+#define teca_integrated_vapor_transport_h
+
+#include "teca_shared_object.h"
+#include "teca_vertical_reduction.h"
+#include "teca_metadata.h"
+
+#include <string>
+#include <vector>
+
+TECA_SHARED_OBJECT_FORWARD_DECL(teca_integrated_vapor_transport)
+
+/// an algorithm that computes integrated vapor transport (IVT)
+/**
+Compute integrated vaport transport (IVT) from wind vector and
+specific humidity.
+
+IVT = - \frac{1}{g} \int_{p_0}^{p_1} \vec{v} q dp
+
+where q is the specific humidity, and \vec{v} = (u, v) are the
+longitudinal and latitudinal components of wind.
+
+This calculation is an instance of a vertical reduction where
+a 3D mesh is transformed into a 2D one.
+*/
+class teca_integrated_vapor_transport : public teca_vertical_reduction
+{
+public:
+    TECA_ALGORITHM_STATIC_NEW(teca_integrated_vapor_transport)
+    TECA_ALGORITHM_DELETE_COPY_ASSIGN(teca_integrated_vapor_transport)
+    TECA_ALGORITHM_CLASS_NAME(teca_integrated_vapor_transport)
+    ~teca_integrated_vapor_transport();
+
+    // report/initialize to/from Boost program options
+    // objects.
+    TECA_GET_ALGORITHM_PROPERTIES_DESCRIPTION()
+    TECA_SET_ALGORITHM_PROPERTIES()
+
+    // set the name of the varaiable that contains the longitudinal
+    // component of the wind vector ("ua")
+    TECA_ALGORITHM_PROPERTY(std::string, wind_u_variable)
+
+    // set the name of the varaiable that contains the latitudinal
+    // component of the wind vector ("va")
+    TECA_ALGORITHM_PROPERTY(std::string, wind_v_variable)
+
+    // set the name of the variable that contains the specific
+    // humidity ("hus")
+    TECA_ALGORITHM_PROPERTY(std::string,
+        specific_humidity_variable)
+
+    // set the name of the varaiable that contains the longitudinal
+    // component of the ivt vector ("ivt_u")
+    TECA_ALGORITHM_PROPERTY(std::string, ivt_u_variable)
+
+    // set the name of the varaiable that contains the latitudinal
+    // component of the ivt vector ("ivt_v")
+    TECA_ALGORITHM_PROPERTY(std::string, ivt_v_variable)
+
+protected:
+    teca_integrated_vapor_transport();
+
+private:
+    teca_metadata get_output_metadata(
+        unsigned int port,
+        const std::vector<teca_metadata> &input_md) override;
+
+    std::vector<teca_metadata> get_upstream_request(
+        unsigned int port,
+        const std::vector<teca_metadata> &input_md,
+        const teca_metadata &request) override;
+
+    const_p_teca_dataset execute(
+        unsigned int port,
+        const std::vector<const_p_teca_dataset> &input_data,
+        const teca_metadata &request) override;
+
+private:
+    std::string wind_u_variable;
+    std::string wind_v_variable;
+    std::string specific_humidity_variable;
+    std::string ivt_u_variable;
+    std::string ivt_v_variable;
+};
+
+#endif

--- a/alg/teca_vertical_reduction.cxx
+++ b/alg/teca_vertical_reduction.cxx
@@ -1,0 +1,266 @@
+#include "teca_vertical_reduction.h"
+
+#include "teca_cartesian_mesh.h"
+#include "teca_array_collection.h"
+#include "teca_variant_array.h"
+#include "teca_metadata.h"
+#include "teca_coordinate_util.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <cmath>
+
+#if defined(TECA_HAS_BOOST)
+#include <boost/program_options.hpp>
+#endif
+
+// --------------------------------------------------------------------------
+teca_vertical_reduction::teca_vertical_reduction()
+{
+    this->set_number_of_input_connections(1);
+    this->set_number_of_output_ports(1);
+}
+
+// --------------------------------------------------------------------------
+teca_vertical_reduction::~teca_vertical_reduction()
+{}
+
+#if defined(TECA_HAS_BOOST)
+// --------------------------------------------------------------------------
+void teca_vertical_reduction::get_properties_description(
+    const std::string &prefix, options_description &global_opts)
+{
+    options_description opts("Options for "
+        + (prefix.empty()?"teca_vertical_reduction":prefix));
+
+    opts.add_options()
+        TECA_POPTS_GET(std::vector<std::string>, prefix, dependent_variables,
+            "list of arrays needed to compute the derived quantity")
+        TECA_POPTS_GET(std::vector<std::string>, prefix, derived_variables,
+            "name of the derived quantity")
+        ;
+
+    global_opts.add(opts);
+}
+
+// --------------------------------------------------------------------------
+void teca_vertical_reduction::set_properties(
+    const std::string &prefix, variables_map &opts)
+{
+    TECA_POPTS_SET(opts, std::vector<std::string>, prefix, dependent_variables)
+    TECA_POPTS_SET(opts, std::vector<std::string>, prefix, derived_variables)
+}
+#endif
+
+// --------------------------------------------------------------------------
+teca_metadata teca_vertical_reduction::get_output_metadata(
+    unsigned int port,
+    const std::vector<teca_metadata> &input_md)
+{
+#ifdef TECA_DEBUG
+    std::cerr << teca_parallel_id()
+        << "teca_vertical_reduction::get_output_metadata" << std::endl;
+#endif
+    (void)port;
+
+    if (this->derived_variables.empty())
+    {
+        TECA_ERROR("A derived variable was not specififed")
+        return teca_metadata();
+    }
+
+    // add in the arrays we will generate and their attributes
+    teca_metadata out_md(input_md[0]);
+
+    teca_metadata attributes;
+    out_md.get("attributes", attributes);
+
+    size_t n_derived = this->derived_variables.size();
+    for (size_t i = 0; i < n_derived; ++i)
+    {
+        out_md.append("variables", this->derived_variables[i]);
+
+        attributes.set(this->derived_variables[i],
+            (teca_metadata)this->derived_variable_attributes[i]);
+    }
+    out_md.set("attributes", attributes);
+
+    // get the input extents
+    unsigned long whole_extent[6] = {0};
+    if (out_md.get("whole_extent", whole_extent, 6))
+    {
+        TECA_ERROR("Metadata is missing whole_whole_extent")
+        return teca_metadata();
+    }
+
+    // set the output extent, with vertical dim reduced
+    whole_extent[6] = whole_extent[5] = 0;
+    out_md.set("whole_extent", whole_extent, 6);
+
+    // fix bounds if it is present
+    double bounds[6] = {0.0};
+    if (out_md.get("bounds", bounds, 6) == 0)
+    {
+        bounds[6] = bounds[5] = 0.0;
+        out_md.set("bounds", bounds, 6);
+    }
+
+    return out_md;
+}
+
+// --------------------------------------------------------------------------
+std::vector<teca_metadata> teca_vertical_reduction::get_upstream_request(
+    unsigned int port,
+    const std::vector<teca_metadata> &input_md,
+    const teca_metadata &request)
+{
+    (void)port;
+
+    std::vector<teca_metadata> up_reqs;
+
+    // copy the incoming request to preserve the downstream
+    // requirements and add the arrays we need
+    teca_metadata req(request);
+
+    // transform extent, add back the vertical dimension
+    const teca_metadata md = input_md[0];
+
+    // get the whole extent and bounds
+    double bounds[6] = {0.0};
+    unsigned long whole_extent[6] = {0};
+    if (teca_coordinate_util::get_cartesian_mesh_extent(md,
+        whole_extent, bounds))
+    {
+        TECA_ERROR("Failed to get input data set extent")
+        return up_reqs;
+    }
+
+    /*bool has_bounds = request.has("bounds");
+    bool has_extent = request.has("extent");*/
+
+    // restore vertical bounds
+    double bounds_up[6] = {0.0};
+    unsigned long extent_up[6] = {0};
+    if (request.get("bounds", bounds_up, 6) == 0)
+    {
+        bounds_up[5] = bounds[5];
+        bounds_up[6] = bounds[6];
+        req.set("bounds", bounds_up, 6);
+    }
+
+    // restore vertical extent
+    else if (request.get("extent", extent_up, 6) == 0)
+    {
+        extent_up[5] = whole_extent[5];
+        extent_up[6] = whole_extent[6];
+        req.set("extent", extent_up, 6);
+    }
+    // no subset requested, request all the data
+    else
+    {
+        req.set("extent", whole_extent);
+    }
+
+    // add the dependent variables into the requested arrays
+    std::set<std::string> arrays;
+    if (req.has("arrays"))
+        req.get("arrays", arrays);
+
+    int n_dep_vars = this->dependent_variables.size();
+    for (int i = 0; i < n_dep_vars; ++i)
+        arrays.insert(this->dependent_variables[i]);
+
+    // capture the arrays we produce
+    size_t n_derived = this->derived_variables.size();
+    for (size_t i = 0; i < n_derived; ++i)
+       arrays.erase(this->derived_variables[i]);
+
+    // update the request
+    req.set("arrays", arrays);
+
+    // send it up
+    up_reqs.push_back(req);
+    return up_reqs;
+}
+
+// --------------------------------------------------------------------------
+const_p_teca_dataset teca_vertical_reduction::execute(
+    unsigned int port,
+    const std::vector<const_p_teca_dataset> &input_data,
+    const teca_metadata &request)
+{
+#ifdef TECA_DEBUG
+    std::cerr << teca_parallel_id()
+        << "teca_vertical_reduction::execute" << std::endl;
+#endif
+    (void)port;
+    (void)request;
+
+    // get the input mesh
+    const_p_teca_mesh in_mesh =
+        std::dynamic_pointer_cast<const teca_mesh>(input_data[0]);
+
+    if (!in_mesh)
+    {
+        TECA_ERROR("teca_mesh is required")
+        return nullptr;
+    }
+
+    // construct the output
+    p_teca_mesh out_mesh =
+        std::dynamic_pointer_cast<teca_mesh>(in_mesh->new_instance());
+
+    // copy metadata
+    out_mesh->copy_metadata(in_mesh);
+
+    // copy the coordinates
+    // out_mesh->copy_coordinates(in_mesh);
+
+    // fix the metadata
+    teca_metadata out_md = out_mesh->get_metadata();
+
+    // fix whole extent
+    unsigned long whole_extent[6] = {0};
+    if (out_md.get("whole_extent", whole_extent, 6) == 0)
+    {
+        whole_extent[5] = whole_extent[6] = 0;
+        out_md.set("whole_extent", whole_extent, 6);
+    }
+
+    // fix extent
+    unsigned long extent[6] = {0};
+    if (out_md.get("extent", extent, 6) == 0)
+    {
+        extent[5] = extent[6] = 0;
+        out_md.set("extent", extent, 6);
+    }
+
+    // fix bounds
+    double bounds[6] = {0};
+    if (out_md.get("bounds", bounds, 6) == 0)
+    {
+        bounds[5] = bounds[6] = 0.0;
+        out_md.set("bounds", bounds, 6);
+    }
+
+    out_mesh->set_metadata(out_md);
+
+
+    // fix the z axis
+    p_teca_cartesian_mesh cart_mesh =
+        std::dynamic_pointer_cast<teca_cartesian_mesh>(out_mesh);
+
+    if (cart_mesh)
+    {
+        std::string z_var;
+        cart_mesh->get_z_coordinate_variable(z_var);
+
+        const_p_teca_variant_array in_z = cart_mesh->get_z_coordinates();
+
+        p_teca_variant_array out_z = in_z->new_instance(1);
+        cart_mesh->set_z_coordinates(z_var, out_z);
+    }
+
+    return out_mesh;
+}

--- a/alg/teca_vertical_reduction.h
+++ b/alg/teca_vertical_reduction.h
@@ -1,0 +1,67 @@
+#ifndef teca_vertical_reduction_h
+#define teca_vertical_reduction_h
+
+#include "teca_shared_object.h"
+#include "teca_algorithm.h"
+#include "teca_metadata.h"
+#include "teca_array_attributes.h"
+
+#include <string>
+#include <vector>
+
+TECA_SHARED_OBJECT_FORWARD_DECL(teca_vertical_reduction)
+
+/// base class for vertical reducitons
+/**
+implements common operations associated with computing a vertical
+reduction where a 3D dataset is transformed into a 2D dataset
+by a reduction along the 3rd spatial dimension.
+*/
+class teca_vertical_reduction : public teca_algorithm
+{
+public:
+    TECA_ALGORITHM_STATIC_NEW(teca_vertical_reduction)
+    TECA_ALGORITHM_DELETE_COPY_ASSIGN(teca_vertical_reduction)
+    TECA_ALGORITHM_CLASS_NAME(teca_vertical_reduction)
+    ~teca_vertical_reduction();
+
+    // report/initialize to/from Boost program options
+    // objects.
+    TECA_GET_ALGORITHM_PROPERTIES_DESCRIPTION()
+    TECA_SET_ALGORITHM_PROPERTIES()
+
+    // set/get the list of variables that are needed to produce
+    // the derived quantity
+    TECA_ALGORITHM_VECTOR_PROPERTY(std::string, dependent_variable)
+
+    // set/get the name of the variable that is produced
+    TECA_ALGORITHM_VECTOR_PROPERTY(std::string, derived_variable)
+
+    // set/get the attributes of the variable that is produced
+    TECA_ALGORITHM_VECTOR_PROPERTY(teca_array_attributes,
+        derived_variable_attribute)
+
+protected:
+    teca_vertical_reduction();
+
+    teca_metadata get_output_metadata(
+        unsigned int port,
+        const std::vector<teca_metadata> &input_md) override;
+
+    std::vector<teca_metadata> get_upstream_request(
+        unsigned int port,
+        const std::vector<teca_metadata> &input_md,
+        const teca_metadata &request) override;
+
+    const_p_teca_dataset execute(
+        unsigned int port,
+        const std::vector<const_p_teca_dataset> &input_data,
+        const teca_metadata &request) override;
+
+private:
+    std::vector<std::string> dependent_variables;
+    std::vector<std::string> derived_variables;
+    std::vector<teca_array_attributes> derived_variable_attributes;
+};
+
+#endif

--- a/data/teca_coordinate_util.cxx
+++ b/data/teca_coordinate_util.cxx
@@ -241,4 +241,48 @@ int bounds_to_extent(const double *bounds,
     TECA_ERROR("invalid coordinate array type")
     return -1;
 }
+
+// **************************************************************************
+int get_cartesian_mesh_extent(const teca_metadata &md,
+    unsigned long *whole_extent, double *bounds)
+{
+    // get the whole extent
+    if (md.get("whole_extent", whole_extent, 6))
+    {
+        TECA_ERROR("metadata is missing \"whole_extent\"")
+        return -1;
+    }
+
+    if (md.get("bounds", bounds, 6))
+    {
+        // get coordinates
+        teca_metadata coords;
+        if (md.get("coordinates", coords))
+        {
+            TECA_ERROR("metadata is missing \"coordinates\"")
+            return -1;
+        }
+
+        // get the coordinate arrays
+        p_teca_variant_array x, y, z;
+        if (!(x = coords.get("x")) || !(y = coords.get("y"))
+            || !(z = coords.get("z")))
+        {
+            TECA_ERROR("coordinate metadata is missing x,y, and or z "
+                "coordinate arrays")
+            return -1;
+        }
+
+        // get bounds of the whole_extent being read
+        x->get(whole_extent[0], bounds[0]);
+        x->get(whole_extent[1], bounds[1]);
+        y->get(whole_extent[2], bounds[2]);
+        y->get(whole_extent[3], bounds[3]);
+        z->get(whole_extent[4], bounds[4]);
+        z->get(whole_extent[5], bounds[5]);
+    }
+
+    return 0;
+}
+
 };

--- a/data/teca_coordinate_util.h
+++ b/data/teca_coordinate_util.h
@@ -385,5 +385,12 @@ template<> struct interpolate_t<1>
     }
 };
 
+// given carteisan mesh metadata extract whole_extent and bounds
+// if bounds metadata is not already present then it is initialized
+// from coordinate arrays. It's an error if whole_extent or coordinate
+// arrays are not present. return zero if successful.
+int get_cartesian_mesh_extent(const teca_metadata &md,
+    unsigned long *whole_extent, double *bounds);
+
 };
 #endif

--- a/python/teca_py_alg.i
+++ b/python/teca_py_alg.i
@@ -11,9 +11,7 @@
 #include "teca_cartesian_mesh_regrid.h"
 #include "teca_connected_components.h"
 #include "teca_component_statistics.h"
-#include "teca_2d_component_area.h"
 #include "teca_component_area_filter.h"
-#include "teca_latitude_damper.h"
 #include "teca_dataset_diff.h"
 #include "teca_dataset_capture.h"
 #include "teca_dataset_source.h"
@@ -21,15 +19,17 @@
 #include "teca_derived_quantity_numerics.h"
 #include "teca_descriptive_statistics.h"
 #include "teca_evaluate_expression.h"
-#include "teca_table_region_mask.h"
+#include "teca_integrated_vapor_transport.h"
 #include "teca_l2_norm.h"
 #include "teca_laplacian.h"
+#include "teca_latitude_damper.h"
 #include "teca_mask.h"
 #include "teca_normalize_coordinates.h"
 #include "teca_saffir_simpson.h"
 #include "teca_table_calendar.h"
 #include "teca_table_sort.h"
 #include "teca_table_reduce.h"
+#include "teca_table_region_mask.h"
 #include "teca_table_remove_rows.h"
 #include "teca_table_to_stream.h"
 #include "teca_tc_candidates.h"
@@ -424,3 +424,11 @@ from teca_temporal_reduction import *
 %shared_ptr(teca_vertical_reduction)
 %ignore teca_vertical_reduction::operator=;
 %include "teca_vertical_reduction.h"
+
+/***************************************************************************
+ integrated_vapor_transport
+ ***************************************************************************/
+%ignore teca_integrated_vapor_transport::shared_from_this;
+%shared_ptr(teca_integrated_vapor_transport)
+%ignore teca_integrated_vapor_transport::operator=;
+%include "teca_integrated_vapor_transport.h"

--- a/python/teca_py_alg.i
+++ b/python/teca_py_alg.i
@@ -37,6 +37,7 @@
 #include "teca_tc_trajectory.h"
 #include "teca_tc_wind_radii.h"
 #include "teca_temporal_average.h"
+#include "teca_vertical_reduction.h"
 #include "teca_vorticity.h"
 
 #include "teca_py_object.h"
@@ -415,3 +416,11 @@ struct teca_tc_saffir_simpson
 %pythoncode %{
 from teca_temporal_reduction import *
 %}
+
+/***************************************************************************
+ vertical_reduction
+ ***************************************************************************/
+%ignore teca_vertical_reduction::shared_from_this;
+%shared_ptr(teca_vertical_reduction)
+%ignore teca_vertical_reduction::operator=;
+%include "teca_vertical_reduction.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -661,3 +661,10 @@ teca_add_test(test_cf_writer_bad_type
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA
     WILL_FAIL)
+
+teca_add_test(test_integrated_vapor_transport
+    SOURCES test_integrated_vapor_transport.cpp
+    LIBS teca_core teca_data teca_alg teca_io ${teca_test_link}
+    COMMAND test_integrated_vapor_transport
+    FEATURES ${TECA_HAS_NETCDF}
+    REQ_TECA_DATA)

--- a/test/test_integrated_vapor_transport.cpp
+++ b/test/test_integrated_vapor_transport.cpp
@@ -1,0 +1,195 @@
+
+#include "teca_cartesian_mesh_source.h"
+#include "teca_cartesian_mesh_writer.h"
+#include "teca_cf_writer.h"
+#include "teca_integrated_vapor_transport.h"
+#include "teca_coordinate_util.h"
+#include "teca_dataset_capture.h"
+
+
+#include <cmath>
+#include <functional>
+
+
+// ivt = - \frac{1}{g} \int_{p_{sfc}}^{p_{top}} q \vec{v} dp
+//
+// strategy: define integrands that are the product of 2 functions, subsitute in
+// q, u, and v and evaluate numerically using our implementation and analytically
+// and compare the results as a check
+//
+// let q = sin p , u = cos p, and v = p.
+//
+// we can then validate our implementation against the analyitic solutions:
+//
+// ivt_u = - \frac{1}{g} \int_{p_{sfc}}^{p_{top}} p sin p dp
+//       = - \frac{1}{g} [ -p cos p + sin p + c ]
+//
+// ivt_v = - \frac{1}{g} \int_{p_{sfc}}^{p_{top}} cos p sin p dp
+//       = - \frac{1}{g} [ \frac{1}{2} sin^2 p + c ]
+//
+
+template <typename num_t>
+struct function_of_z
+{
+    using f_type = std::function<num_t(num_t)>;
+
+    function_of_z(const f_type &a_f) : m_f(a_f) {}
+
+    p_teca_variant_array operator()(const const_p_teca_variant_array &x,
+        const const_p_teca_variant_array &y, const const_p_teca_variant_array &z,
+        double t)
+    {
+        (void)t;
+
+        size_t nx = x->size();
+        size_t ny = y->size();
+        size_t nz = z->size();
+        size_t nxy = nx*ny;
+
+        p_teca_variant_array_impl<num_t> fz = teca_variant_array_impl<num_t>::New(nx*ny*nz);
+        num_t *pfz = fz->get();
+
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
+            fz.get(),
+            const NT *pz = dynamic_cast<const TT*>(z.get())->get();
+            for (size_t k = 0; k < nz; ++k)
+            {
+                for (size_t j = 0; j < ny; ++j)
+                {
+                    for (size_t i = 0; i < nx; ++i)
+                    {
+                        pfz[k*nxy + j*nx + i] = this->m_f(pz[k]);
+                    }
+                }
+            }
+            )
+
+        return fz;
+    }
+
+    f_type m_f;
+};
+
+// an actual sequence of pressure levels from the HighResMIP data
+// plev = 92500, 85000, 70000, 60000, 50000, 25000, 5000 ;
+
+int main(int argc, char **argv)
+{
+    unsigned long z1 = 1024;
+    double p_sfc = 92500e-4;
+    double p_top = 5000e-4;
+    int write_input = 0;
+    int write_output = 0;
+
+    p_teca_cartesian_mesh_source s = teca_cartesian_mesh_source::New();
+    s->set_whole_extents({0, 2, 0, 2, 0, z1, 0, 0});
+    s->set_bounds({-1.0, 1.0, -1.0, 1.0, p_sfc, p_top, 0.0, 0.0});
+    s->set_calendar("standard");
+    s->set_time_units("days since 2020-09-30 00:00:00");
+
+    // let q = sin(p)
+    function_of_z<double> q([](double p) -> double { return sin(p); });
+
+    s->append_field_generator({"q",
+        teca_array_attributes(teca_variant_array_code<double>::get(),
+            teca_array_attributes::point_centering, 0, "g kg^-1",
+            "specific humidty", "test data where q = sin(p)"),
+            q});
+
+    // let u = cos(p)
+    function_of_z<double> u([](double p) -> double { return cos(p); });
+
+    s->append_field_generator({"u",
+        teca_array_attributes(teca_variant_array_code<double>::get(),
+            teca_array_attributes::point_centering, 0, "m s^-1",
+            "longitudinal wind velocity", "test data where u = cos(p)"),
+            u});
+
+    // let v = p
+    function_of_z<double> v([](double z) -> double { return z; });
+
+    s->append_field_generator({"v",
+        teca_array_attributes(teca_variant_array_code<double>::get(),
+            teca_array_attributes::point_centering, 0, "m s^-1",
+            "latiitudinal wind velocity", "test data where v = p"),
+            v});
+
+    // write the test input dataset
+    if (write_input)
+    {
+        p_teca_cf_writer w = teca_cf_writer::New();
+        w->set_input_connection(s->get_output_port());
+        w->set_file_name("test_integrated_vapor_transport_input_%t%.nc");
+        w->set_thread_pool_size(1);
+        w->set_point_arrays({"q", "u", "v"});
+        w->update();
+    }
+
+    // compute IVT
+    p_teca_integrated_vapor_transport ivt = teca_integrated_vapor_transport::New();
+    ivt->set_input_connection(s->get_output_port());
+    ivt->set_wind_u_variable("u");
+    ivt->set_wind_v_variable("v");
+    ivt->set_specific_humidity_variable("q");
+
+    // write the result
+    if (write_output)
+    {
+        p_teca_cf_writer w = teca_cf_writer::New();
+        w->set_input_connection(ivt->get_output_port());
+        w->set_file_name("test_integrated_vapor_transport_output_%t%.nc");
+        w->set_thread_pool_size(1);
+        w->set_point_arrays({"ivt_u", "ivt_v"});
+        w->update();
+    }
+
+    // capture the result
+    p_teca_dataset_capture dsc = teca_dataset_capture::New();
+    dsc->set_input_connection(ivt->get_output_port());
+    dsc->update();
+
+    const_p_teca_cartesian_mesh m =
+        std::dynamic_pointer_cast<const teca_cartesian_mesh>(dsc->get_dataset());
+
+    const_p_teca_double_array ivt_u =
+        std::dynamic_pointer_cast<const teca_double_array>
+            (m->get_point_arrays()->get("ivt_u"));
+
+    const_p_teca_double_array ivt_v =
+        std::dynamic_pointer_cast<const teca_double_array>
+            (m->get_point_arrays()->get("ivt_v"));
+
+    double test_ivt_u = ivt_u->get(0);
+    double test_ivt_v = ivt_v->get(0);
+
+    // calculate the analytic solution
+    double g = 9.80665;
+
+    double base_ivt_u = -(1./g) * (1./2.) * (sin(p_top)*sin(p_top)
+                                           - sin(p_sfc)*sin(p_sfc));
+
+    double base_ivt_v = -(1./g) * ((-p_top * cos(p_top) + sin(p_top))
+                                 - (-p_sfc * cos(p_sfc) + sin(p_sfc)));
+
+    // display
+    std::cerr << "base_ivt_u = " << base_ivt_u << std::endl;
+    std::cerr << "test_ivt_u = " << test_ivt_u << std::endl << std::endl;
+
+    std::cerr << "base_ivt_v = " << base_ivt_v << std::endl;
+    std::cerr << "test_ivt_v = " << test_ivt_v << std::endl;
+
+    // compare against the analytic solution
+    if (!teca_coordinate_util::equal(base_ivt_u, test_ivt_u, 1e-4))
+    {
+        TECA_ERROR("base_ivt_u = " << base_ivt_u << " test_ivt_u = " << test_ivt_u)
+        return -1;
+    }
+
+    if (!teca_coordinate_util::equal(base_ivt_v, test_ivt_v, 1e-4))
+    {
+        TECA_ERROR("base_ivt_v = " << base_ivt_v << " test_ivt_v = " << test_ivt_v)
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
* adds teca_vertical_integral a base class containing common code for transforming meshes from 3D to 2D by a reduction along the vertical axis.
* adds teca_integrated_vapor_transport an instance of a teca_vertical_reduction that calculates IVT from specific humidity and wind fields. includes a test validating the calculation against an analytically derived result. 

resolves #390.