### PR TITLE
travis ci use xcode 12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ os:
   - linux
   - osx
 
+osx_image:
+  - xcode12.2
+
 env:
   global:
     - BUILD_TYPE=Debug


### PR DESCRIPTION
this seemed to help builds that timed out when brew was installing cmake 3.19, it also gets us better compiler diagnostics and users are more likely to be on the newer macos release. 