### PR TITLE
pytorch use GPUs

### DIFF
--- a/apps/teca_deeplab_ar_detect.in
+++ b/apps/teca_deeplab_ar_detect.in
@@ -90,6 +90,9 @@ parser.add_argument('--output_file', type=str, required=True,
 parser.add_argument('--steps_per_file', type=int, required=False, default=128,
     help='number of time steps per output file')
 
+parser.add_argument('--target_device', type=str, default='cpu',
+    help='set the execution target. May be one of "cpu", or "cuda"')
+
 parser.add_argument('--n_threads', type=int, default=-1,
     help='Sets the thread pool size on each MPI rank. When the default'
          ' value of -1 is used TECA will coordinate the thread pools across'
@@ -209,6 +212,7 @@ ar_detect = teca_deeplab_ar_detect.New()
 ar_detect.set_input_connection(coords.get_output_port())
 ar_detect.set_verbose(args.verbose)
 ar_detect.set_ivt_variable(args.ivt)
+ar_detect.set_target_device(args.target_device)
 ar_detect.set_thread_pool_size(args.n_threads)
 ar_detect.set_max_thread_pool_size(args.n_threads_max)
 ar_detect.load_model(args.pytorch_model)

--- a/doc/rtd/applications.rst
+++ b/doc/rtd/applications.rst
@@ -2223,6 +2223,9 @@ Command Line Arguments
 --steps_per_file STEPS_PER_FILE
     number of time steps per output file (default: 128)
 
+--target_device TARGET_DEVICE
+    set the execution target. May be one of "cpu", or "cuda" (default: cpu)
+
 --n_threads N_THREADS
     Sets the thread pool size on each MPI rank. When the default value of -1 is used TECA will
     coordinate the thread pools across ranks such each thread is bound to a unique physical core.
@@ -2275,12 +2278,22 @@ Command Line Arguments
 Node level parallelism
 ~~~~~~~~~~~~~~~~~~~~~~
 Torch can make use of GPUs or OpenMP thread pools for node level parallelism.
+
+OpenMP
+^^^^^^
 TECA internally configures OpenMP such that its thread pools will make use of
 up to 4 threads bound to unique CPU cores taking into account all ranks running
 on the node. To take advantage of threads on Cori KNL when using the
 `teca_deeplab_ar_detect` application limit the number of MPI ranks per node to
 17 or fewer, or on Cori Haswell 8 or fewer. To use more than 4 threads per rank
 (not recommended) set `--n_threads_max` to a number larger than 4.
+
+CUDA
+^^^^
+To enable use of CUDA pass `--target_device cuda` to the
+`teca_deeplab_ar_detect` application.  TECA assigns MPI ranks to GPUs in a
+round robin fashion.  If more MPI ranks than GPUs are scheduled to a node then
+multiple MPI ranks will share a single GPU.
 
 Examples
 ~~~~~~~~~

--- a/test/python/test_deeplab_ar_detect.py
+++ b/test/python/test_deeplab_ar_detect.py
@@ -28,6 +28,7 @@ baseline = sys.argv[3]
 water_vapor_var = sys.argv[4]
 n_threads = int(sys.argv[5])
 vrb = 1
+dev = 'cuda'
 
 cf_reader = teca_cf_reader.New()
 cf_reader.set_files_regex(input_regex)
@@ -35,11 +36,11 @@ cf_reader.set_periodic_in_x(1)
 
 ar_detect = teca_deeplab_ar_detect.New()
 ar_detect.set_input_connection(cf_reader.get_output_port())
+ar_detect.set_target_device(dev)
 ar_detect.set_verbose(vrb)
 ar_detect.set_ivt_variable(water_vapor_var)
 ar_detect.set_thread_pool_size(n_threads)
 ar_detect.load_model(deeplab_model)
-
 
 rex = teca_index_executive.New()
 rex.set_arrays(['ar_probability'])
@@ -58,7 +59,7 @@ if do_test:
     diff = teca_dataset_diff.New()
     diff.set_input_connection(0, baseline_reader.get_output_port())
     diff.set_input_connection(1, ar_detect.get_output_port())
-    diff.set_relative_tolerance(1e-4)
+    diff.set_relative_tolerance(5e-4)
     diff.set_executive(rex)
     diff.update()
 


### PR DESCRIPTION
* adds optional mechanism to specify cpu or cuda.
  in MPI parallel GPUs are selected round robin.
* refactors the load_model method, moves more of the
  boilerplate into the base class.