### PR TITLE
fix thread parameters error out when detection fails

### DIFF
--- a/core/teca_thread_pool.h
+++ b/core/teca_thread_pool.h
@@ -113,8 +113,16 @@ void teca_thread_pool<task_t, data_t>::create_threads(MPI_Comm comm,
     int n_threads = n_requested;
 
     std::deque<int> core_ids;
-    teca_thread_util::thread_parameters(comm, -1,
-        n_requested, bind, verbose, n_threads, core_ids);
+
+    if (teca_thread_util::thread_parameters(comm, -1,
+        n_requested, bind, verbose, n_threads, core_ids))
+    {
+        TECA_WARNING("Failed to detetermine thread parameters."
+            " Falling back to 1 thread, affinity disabled.")
+
+        n_threads = 1;
+        bind = false;
+    }
 
     // allocate the threads
     for (int i = 0; i < n_threads; ++i)

--- a/core/teca_thread_util.cxx
+++ b/core/teca_thread_util.cxx
@@ -296,7 +296,7 @@ int thread_parameters(MPI_Comm comm, int base_core_id, int n_requested,
     (void)affinity;
     if (n_requested < 1)
     {
-        TECA_WARNING("Cannot autmatically detect threading parameters "
+        TECA_WARNING("Can not automatically detect threading parameters "
             "on this platform. The default is 1 thread per process.")
         n_threads = 1;
     }
@@ -404,7 +404,7 @@ int thread_parameters(MPI_Comm comm, int base_core_id, int n_requested,
 
     // there are enough cores that each thread can have it's own core
     // mark the cores which have the root thread as used so that we skip them.
-    // if we always did this in the fully apcked case we'd always be assigning
+    // if we always did this in the fully packed case we'd always be assigning
     // hyperthreads off core. it is better to keep them local.
     if (((n_threads+1)*n_procs) < cores_per_node)
     {

--- a/core/teca_thread_util.cxx
+++ b/core/teca_thread_util.cxx
@@ -368,14 +368,17 @@ int thread_parameters(MPI_Comm comm, int base_core_id, int n_requested,
     }
 
     // if the user runs more MPI ranks than cores some of the ranks
-    // will have no cores to use. fallback to 1 thread on core 0
-    if (n_threads < 1)
+    // will have no cores to use.
+    if (n_procs > cores_per_node)
     {
+        TECA_WARNING(<< n_procs << " MPI ranks running on this node but only "
+            << cores_per_node << " CPU cores are available. Performance will"
+            " be degraded.")
+
         n_threads = 1;
-        affinity.push_back(0);
-        TECA_WARNING("CPU cores are unavailable, performance will be degraded. "
-            "This can occur when running more MPI ranks than there are CPU "
-            "cores. Launching 1 thread on core 0.")
+        affinity.push_back(base_core_id);
+
+        return -1;
     }
 
     // stop now if we are not binding threads to cores

--- a/python/teca_py_core.i
+++ b/python/teca_py_core.i
@@ -970,8 +970,8 @@ PyObject *thread_parameters(MPI_Comm comm,
     {
         // caller requested automatic load balancing but this,
         // failed.
-        TECA_PY_ERROR(PyExc_RuntimeError,
-            "Automatic load balancing failed")
+        PyErr_Format(PyExc_RuntimeError,
+            "Failed to detect thread parameters.");
         return nullptr;
     }
 

--- a/test/travis_ci/ctest_linux.sh
+++ b/test/travis_ci/ctest_linux.sh
@@ -19,6 +19,8 @@ then
     export NETCDF_BUILD_TYPE="netcdf_mpi"
 fi
 
+cat /proc/cpuinfo
+
 export PATH=.:${PATH}
 export PYTHONPATH=${DASHROOT}/build/lib
 export LD_LIBRARY_PATH=${DASHROOT}/build/lib

--- a/test/travis_ci/install_osx.sh
+++ b/test/travis_ci/install_osx.sh
@@ -8,7 +8,7 @@ export PATH=/usr/local/bin:$PATH
 # these days. hence this list isn't comprehensive
 brew update
 brew unlink python@2
-brew install mpich swig svn udunits openssl python@3.8
+brew install mpich swig svn udunits openssl python@3.8 curl
 brew unlink python
 brew link --force python@3.8
 

--- a/test/travis_ci/install_osx.sh
+++ b/test/travis_ci/install_osx.sh
@@ -11,6 +11,7 @@ brew unlink python@2
 brew install mpich swig svn udunits openssl python@3.8 curl
 brew unlink python
 brew link --force python@3.8
+brew link curl --force
 
 # matplotlib currently doesn't have a formula
 # teca fails to locate mpi4py installed from brew


### PR DESCRIPTION
this is to address an issue on Travis CI where OS and CPUID
report different information about the available hardware.
rather than try to continue error out disabling threading and
affinity. A warning is issued.