### PR TITLE
Cf writer interval bug

### DIFF
--- a/alg/teca_tc_candidates.cxx
+++ b/alg/teca_tc_candidates.cxx
@@ -456,8 +456,9 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
     cerr << std::endl;
 #endif
     seconds_t dt(t1 - t0);
-    TECA_STATUS("teca_tc_candidates step=" << time_step
-        << " t=" << time_offset << ", dt=" << dt.count() << " sec")
+
+    TECA_STATUS("At step " << time_step << " time " << time_offset << " "
+        << n_candidates << " candidates detected in " << dt.count() << " seconds")
 
     return out_table;
 }

--- a/data/teca_calendar_util.cxx
+++ b/data/teca_calendar_util.cxx
@@ -7,14 +7,22 @@
 
 #include <algorithm>
 
+// TODO - With 23:59:59, sometimes we select the next day.  What is the right
+// end-of-day time so that all use cases are satisfied without selecting the
+// next day?
+#define END_OF_DAY_HH 23
+#define END_OF_DAY_MM 30
+#define END_OF_DAY_SS 0
+#define END_OF_DAY "23:30:00"
+
 // --------------------------------------------------------------------------
 std::ostream &operator<<(std::ostream &os,
     const teca_calendar_util::time_point &tpt)
 {
-    os << "time[" << tpt.index << "] = " << tpt.time << "("
+    os << "time[" << tpt.index << "] = " << tpt.time << ", \""
         << tpt.year << "-" << tpt.month << "-"
         << tpt.day << " " << tpt.hour << ":" << tpt.minute
-        << ":" << tpt.second << ")";
+        << ":" << tpt.second << "\"";
     return os;
 }
 
@@ -333,7 +341,7 @@ int season_iterator::get_next_interval(time_point &first_step,
 
     // find the time step of the last day
     char t1[21] = {'\0'};
-    snprintf(t1, 21, "%04d-%02d-%02d 23:59:59", end_year, end_month, end_day);
+    snprintf(t1, 21, "%04d-%02d-%02d " END_OF_DAY, end_year, end_month, end_day);
 
     unsigned long i1 = 0;
     if (teca_coordinate_util::time_step_of(this->time,
@@ -344,7 +352,8 @@ int season_iterator::get_next_interval(time_point &first_step,
     }
 
     this->time->get(i1, ti);
-    last_step = time_point(i1, ti, end_year, end_month, end_day, 23, 59, 59);
+    last_step = time_point(i1, ti, end_year, end_month,
+        end_day, END_OF_DAY_HH, END_OF_DAY_MM, END_OF_DAY_SS);
 
     // move to next season
     if (this->get_next_season(sy, sm, this->year, this->month))
@@ -459,7 +468,7 @@ int year_iterator::get_next_interval(time_point &first_step,
     }
 
     char t1[21] = {'\0'};
-    snprintf(t1, 21, "%04d-12-%02d 23:59:59", this->year, n_days);
+    snprintf(t1, 21, "%04d-12-%02d " END_OF_DAY, this->year, n_days);
 
     unsigned long i1 = 0;
     if (teca_coordinate_util::time_step_of(this->time,
@@ -470,7 +479,8 @@ int year_iterator::get_next_interval(time_point &first_step,
     }
 
     this->time->get(i1, ti);
-    last_step = time_point(i1, ti, this->year, 12, n_days, 23, 59, 59);
+    last_step = time_point(i1, ti, this->year, 12,
+        n_days, END_OF_DAY_HH, END_OF_DAY_MM, END_OF_DAY_SS);
 
     // move to next year
     this->year += 1;
@@ -584,7 +594,7 @@ int month_iterator::get_next_interval(time_point &first_step,
     }
 
     char t1[21] = {'\0'};
-    snprintf(t1, 21, "%04d-%02d-%02d 23:59:59", this->year, this->month, n_days);
+    snprintf(t1, 21, "%04d-%02d-%02d " END_OF_DAY, this->year, this->month, n_days);
 
     unsigned long i1 = 0;
     if (teca_coordinate_util::time_step_of(this->time,
@@ -595,7 +605,8 @@ int month_iterator::get_next_interval(time_point &first_step,
     }
 
     this->time->get(i1, ti);
-    last_step = time_point(i1, ti, this->year, this->month, n_days, 23, 59, 59);
+    last_step = time_point(i1, ti, this->year, this->month,
+        n_days, END_OF_DAY_HH, END_OF_DAY_MM, END_OF_DAY_SS);
 
     // move to next month
     this->month += 1;
@@ -711,7 +722,7 @@ int day_iterator::get_next_interval(time_point &first_step,
 
     // find the time step of the last hour of the day
     char t1[21] = {'\0'};
-    snprintf(t1, 21, "%04d-%02d-%02d 23:59:59",
+    snprintf(t1, 21, "%04d-%02d-%02d " END_OF_DAY,
         this->year, this->month, this->day);
 
     unsigned long i1 = 0;
@@ -723,7 +734,8 @@ int day_iterator::get_next_interval(time_point &first_step,
     }
 
     this->time->get(i1, ti);
-    last_step = time_point(i1, ti, this->year, this->month, this->day, 23, 59, 59);
+    last_step = time_point(i1, ti, this->year, this->month,
+        this->day, END_OF_DAY_HH, END_OF_DAY_MM, END_OF_DAY_SS);
 
     // move to next day
     int n_days = 0;

--- a/io/teca_cf_interval_time_step_mapper.cxx
+++ b/io/teca_cf_interval_time_step_mapper.cxx
@@ -75,18 +75,25 @@ int teca_cf_interval_time_step_mapper::to_stream(std::ostream &os)
         os << std::endl
             << std::left << std::setw(8) << "file"
             << std::left << std::setw(16) << "steps"
+            << std::left << std::setw(8) << "n_steps"
             << "ranks" << std::endl;
+
+        long n_steps_total = 0;
 
         for (int i = 0; i < this->n_files; ++i)
         {
-            std::string tmp("[");
-            tmp += std::to_string(this->file_steps[i].first);
-            tmp += ", ";
-            tmp += std::to_string(this->file_steps[i].second);
-            tmp += "]";
+            std::string steps("[");
+            steps += std::to_string(this->file_steps[i].first);
+            steps += ", ";
+            steps += std::to_string(this->file_steps[i].second);
+            steps += "]";
+
+            long n_steps = this->file_steps[i].second - this->file_steps[i].first + 1;
+            n_steps_total += n_steps;
 
             os << std::left << std::setw(8) << i
-                << std::left << std::setw(16) << tmp;
+                << std::left << std::setw(16) << steps
+                << std::left << std::setw(8) << n_steps;
 
             std::set<int> &f_ranks = this->file_ranks[i];
             size_t n_f_ranks = f_ranks.size();
@@ -106,6 +113,8 @@ int teca_cf_interval_time_step_mapper::to_stream(std::ostream &os)
 
             os << std::endl;
         }
+
+        os << std::endl << "n_steps_total = " << n_steps_total << std::endl;
     }
 
     return 0;

--- a/io/teca_cf_layout_manager.cxx
+++ b/io/teca_cf_layout_manager.cxx
@@ -480,7 +480,7 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         if (is_init && ((ierr = nc_var_par_access(this->handle.get(), var_id,
             NC_INDEPENDENT)) != NC_NOERR))
         {
-            TECA_ERROR("Failed to set inidependant mode on variable \"" << name << "\"")
+            TECA_ERROR("Failed to set independent mode on variable \"" << name << "\"")
             return -1;
         }
 #if !defined(HDF5_THREAD_SAFE)
@@ -746,7 +746,8 @@ int teca_cf_layout_manager::to_stream(std::ostream &os)
        << n_franks << " file_id=" << file_id
        << " file_name=\"" << this->file_name
        << "\" first_index=" << this->first_index
-       << " n_indeces=" << this->n_indices;
+       << " n_indices=" << this->n_indices
+       << " n_written=" << this->n_written;
 
     return 0;
 }

--- a/io/teca_cf_layout_manager.h
+++ b/io/teca_cf_layout_manager.h
@@ -57,7 +57,8 @@ public:
     // return true if the file has been defined
     bool defined()  { return this->n_dims > 0; }
 
-    // TODO -- this is no longer correct
+    // TODO -- this is only true when a rank writes all of the steps
+    // to the given file.
     bool completed()
     {
         return this->n_written == this->n_indices;

--- a/io/teca_cf_writer.cxx
+++ b/io/teca_cf_writer.cxx
@@ -458,6 +458,13 @@ const_p_teca_dataset teca_cf_writer::execute(unsigned int port,
             TECA_ERROR("Write time step " << time_step << " failed for time step")
             return nullptr;
         }
+
+        if (this->verbose > 1)
+        {
+            std::ostringstream oss;
+            layout_mgr->to_stream(oss);
+            TECA_STATUS(<< oss.str())
+        }
     }
 
     // close the file when all data has been written

--- a/test/test_interval_iterator.cpp
+++ b/test/test_interval_iterator.cpp
@@ -38,6 +38,7 @@ int main(int argc, char **argv)
     }
 
     int n_intervals = 0;
+    long n_steps_total = 0;
 
     while (*it)
     {
@@ -46,10 +47,16 @@ int main(int argc, char **argv)
 
         it->get_next_interval(first_step, last_step);
 
-        std::cerr << "(" << first_step << ") to (" << last_step << ")" << std::endl;
+        long n_steps = last_step.index - first_step.index + 1;
+        n_steps_total += n_steps;
+
+        std::cerr << "From: " << first_step << " To: " << last_step
+            << " steps=" << n_steps  << std::endl;
 
         n_intervals += 1;
     }
+
+    std::cerr << n_steps_total << " steps located" << std::endl;
 
     // check the number of intervals
     if (n_intervals != n_expected)


### PR DESCRIPTION
resolves an issue where the first day of the next month/year was selected by the interval operator at the end of the previous month/year. this resulted in duplicated time steps.