### PR TITLE
Custom error handler

### DIFF
--- a/core/teca_common.cxx
+++ b/core/teca_common.cxx
@@ -1,5 +1,8 @@
 #include "teca_common.h"
 
+#include "teca_mpi.h"
+#include <cstdlib>
+
 namespace std
 {
 // **************************************************************************
@@ -24,3 +27,60 @@ int have_tty()
         have = isatty(fileno(stderr));
     return have;
 }
+
+
+namespace teca_error
+{
+// **************************************************************************
+void error_message(const char *msg)
+{
+    // flush any pending user output
+    std::cout.flush();
+    std::cerr.flush();
+
+    // send the error message
+    std::cerr << std::endl << msg << std::endl;
+}
+
+// **************************************************************************
+void error_message_abort(const char *msg)
+{
+    // flush any pending user output
+    std::cout.flush();
+    std::cerr.flush();
+
+    // send the error message
+    std::cerr << std::endl << msg << std::endl
+        << "aborting ... " << std::endl;
+
+    // abort
+#if defined(TECA_HAS_MPI)
+    int is_init = 0;
+    MPI_Initialized(&is_init);
+    if (is_init)
+        MPI_Abort(MPI_COMM_WORLD, -1);
+#endif
+    abort();
+}
+
+// **************************************************************************
+void set_error_handler(p_teca_error_handler handler)
+{
+    teca_error::error_handler = handler;
+}
+
+// **************************************************************************
+void set_error_message_handler()
+{
+    teca_error::error_handler = teca_error::error_message;
+}
+
+// **************************************************************************
+void set_error_message_abort_handler()
+{
+    teca_error::error_handler = teca_error::error_message_abort;
+}
+
+// global error handler instance
+p_teca_error_handler error_handler = error_message_abort;
+};

--- a/core/teca_common.h
+++ b/core/teca_common.h
@@ -31,7 +31,7 @@ extern p_teca_error_handler error_handler;
 void error_message(const char *msg);
 
 /** An error handler that flushes stdout and stderr streams, and sends msg to
- * the stderr before aborting. When MPI is in use MPI_Abort is invokde. This
+ * the stderr before aborting. When MPI is in use MPI_Abort is invoked. This
  * implements the behavior after TECA 4.1.0
  */
 void error_message_abort(const char *msg);

--- a/core/teca_common.h
+++ b/core/teca_common.h
@@ -1,14 +1,57 @@
 #ifndef teca_common_h
 #define teca_common_h
 
+/// @file
+
 #include "teca_config.h"
 #include "teca_parallel_id.h"
 
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 #include <cstdio>
 #include <string>
 #include <vector>
+
+/** The call signature for the error handler. The error handler will be passed
+ * a string describing the error.
+ */
+using p_teca_error_handler = void (*) (const char*);
+
+/// global error handling hooks
+namespace teca_error
+{
+/// The global error handler instance.
+extern p_teca_error_handler error_handler;
+
+/** An error handler that flushes stdout and stderr streams, and sends msg to
+ * the stderr before returing. This implements the behavior up to and including
+ * TECA 4.1.0
+ */
+void error_message(const char *msg);
+
+/** An error handler that flushes stdout and stderr streams, and sends msg to
+ * the stderr before aborting. When MPI is in use MPI_Abort is invokde. This
+ * implements the behavior after TECA 4.1.0
+ */
+void error_message_abort(const char *msg);
+
+/** Install a custom error haandler. The error handler must have the following
+ * signature.
+ *
+ * void error_handler(const char *msg);
+ *
+ */
+void set_error_handler(p_teca_error_handler handler);
+
+/// Install the teca_error::error_message error handler
+void set_error_message_handler();
+
+/// Install the teca_error::error_message_abort error handler
+void set_error_message_abort_handler();
+};
+
+/// @cond
 
 // the operator<< overloads have to be namespace std in order for
 // boost to find them. they are needed for mutitoken program options
@@ -50,6 +93,7 @@ std::ostream &operator<<(std::ostream &os, const num_t (& data)[len])
  */
 int have_tty();
 
+
 #define ANSI_RED "\033[1;31;40m"
 #define ANSI_GREEN "\033[1;32;40m"
 #define ANSI_YELLOW "\033[1;33;40m"
@@ -59,6 +103,12 @@ int have_tty();
 #define BEGIN_HL(_color) (have_tty()?_color:"")
 #define END_HL (have_tty()?ANSI_OFF:"")
 
+/// @endcond
+
+
+/** Send a message into the stream with an ANSI color coded message that
+ * include MPI ranks and thread id.
+ */
 #define TECA_MESSAGE(_strm, _head, _head_color, _msg)                   \
 _strm                                                                   \
     << BEGIN_HL(_head_color) << _head << END_HL                         \
@@ -67,8 +117,20 @@ _strm                                                                   \
     << BEGIN_HL(_head_color) << _head << END_HL << " "                  \
     << BEGIN_HL(ANSI_WHITE) << "" _msg << END_HL << std::endl;
 
-#define TECA_ERROR(_msg) TECA_MESSAGE(std::cerr, "ERROR:", ANSI_RED, _msg)
+/** Constructs an the error message using TECA_MESSAGE and invokes the
+ * error handler.
+ */
+#define TECA_ERROR(_msg)                                                \
+{                                                                       \
+    std::ostringstream ess;                                             \
+    TECA_MESSAGE(ess, "ERROR:", ANSI_RED, _msg)                         \
+    teca_error::error_handler(ess.str().c_str());                       \
+}
+
+/// Constructs a warning message and sends it to the stderr stream
 #define TECA_WARNING(_msg) TECA_MESSAGE(std::cerr, "WARNING:", ANSI_YELLOW, _msg)
+
+/// Constructs a status message and sends it to the stderr stream
 #define TECA_STATUS(_msg) TECA_MESSAGE(std::cerr, "STATUS:", ANSI_GREEN, _msg)
 
 #endif

--- a/python/teca_py_core.i
+++ b/python/teca_py_core.i
@@ -335,13 +335,13 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
  ***************************************************************************/
 %ignore teca_metadata::teca_metadata(teca_metadata &&);
 %ignore teca_metadata::operator=;
+%ignore teca_metadata::get; /* will replace with get_internal */
 %ignore operator<(const teca_metadata &, const teca_metadata &);
 %ignore operator&(const teca_metadata &, const teca_metadata &);
 %ignore operator==(const teca_metadata &, const teca_metadata &);
 %ignore operator!=(const teca_metadata &, const teca_metadata &);
-%ignore teca_metadata::set; /* use __setitem__ instead */
-%ignore teca_metadata::get; /* use __getitem__ instead */
 %include "teca_metadata.h"
+%rename(get) teca_metadata::get_internal;
 %extend teca_metadata
 {
     TECA_PY_STR()
@@ -368,6 +368,12 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
 
         Py_DECREF(Py_None);
         return nullptr;
+    }
+
+    /* set a property */
+    PyObject *set(const std::string &name, PyObject *value)
+    {
+        return teca_metadata___setitem__(self, name, value);
     }
 
     /* return md['name'] */
@@ -441,6 +447,12 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
         TECA_PY_ERROR(PyExc_TypeError,
             "Failed to convert value for key \"" << name << "\"")
         return nullptr;
+    }
+
+    /* get a property */
+    PyObject *get_internal(const std::string &name)
+    {
+        return teca_metadata___getitem__(self, name);
     }
 
     PyObject *append(const std::string &name, PyObject *obj)

--- a/test/test_cf_writer_bad_type.cpp
+++ b/test/test_cf_writer_bad_type.cpp
@@ -29,6 +29,9 @@ p_teca_variant_array generate_mesh_time(const const_p_teca_variant_array &x,
 
 int main(int, char **)
 {
+    // set the error handler to print and return
+    teca_error::set_error_message_handler();
+
     // this test intentionally declares a mesh array using the
     // wrong type code. this will test the error handling feature
     // in the cf_weriter.

--- a/test/test_dataset_diff.cpp
+++ b/test/test_dataset_diff.cpp
@@ -6,12 +6,14 @@
 #include "teca_table.h"
 #include "teca_test_util.h"
 #include "teca_system_interface.h"
+#include "teca_common.h"
 
 #include <iostream>
 using namespace std;
 
 int main(int argc, char **argv)
 {
+    teca_error::set_error_message_handler();
     teca_system_interface::set_stack_trace_on_error();
 
     if (argc < 2)


### PR DESCRIPTION
Adds a global error handler that will be invoked by TECA_ERROR macro. This changes the behavior from printing error messages and continuing to aborting immediately.  Consider this change a trial since aborting immediately might make diagnosing issues harder since contextual information might be left out. 

resolves #38 
resolves #527 