### PR TITLE
revise error handling

### DIFF
--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -198,7 +198,7 @@ std::vector<teca_metadata> teca_2d_component_area::get_upstream_request(
     std::string component_var;
     if (this->get_component_variable(component_var))
     {
-        TECA_ERROR("component_variable was not specified")
+        TECA_FATAL_ERROR("component_variable was not specified")
         return up_reqs;
     }
 
@@ -237,7 +237,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
             input_data[0]);
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a cartesian_mesh")
+        TECA_FATAL_ERROR("empty input, or not a cartesian_mesh")
         return nullptr;
     }
 
@@ -251,7 +251,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
     std::string component_var;
     if (this->get_component_variable(component_var))
     {
-        TECA_ERROR("component_variable was not specified")
+        TECA_FATAL_ERROR("component_variable was not specified")
         return nullptr;
     }
 
@@ -259,7 +259,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
         = out_mesh->get_point_arrays()->get(component_var);
     if (!component_array)
     {
-        TECA_ERROR("label variable \"" << component_var
+        TECA_FATAL_ERROR("label variable \"" << component_var
             << "\" is not in the input")
         return nullptr;
     }
@@ -275,7 +275,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
     unsigned long nz = extent[5] - extent[4] + 1;
     if (nz != 1)
     {
-        TECA_ERROR("This calculation requires 2D data. The current dataset "
+        TECA_FATAL_ERROR("This calculation requires 2D data. The current dataset "
             "extents are [" << extent[0] << ", " << extent[1] << ", "
             << extent[2] << ", " << extent[3] << ", " << extent[4] << ", "
             << extent[5] << "]")
@@ -298,7 +298,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
     {
         if (in_metadata.get("background_id", bg_id))
         {
-            TECA_ERROR("Metadata is missing the key \"background_id\". "
+            TECA_FATAL_ERROR("Metadata is missing the key \"background_id\". "
                 "One should specify it via the \"background_id\" algorithm "
                 "property")
             return nullptr;

--- a/alg/teca_apply_binary_mask.cxx
+++ b/alg/teca_apply_binary_mask.cxx
@@ -184,7 +184,7 @@ std::vector<teca_metadata> teca_apply_binary_mask::get_upstream_request(
     // get the name of the mask array
     if (this->mask_variable.empty())
     {
-        TECA_ERROR("A mask variable was not specified")
+        TECA_FATAL_ERROR("A mask variable was not specified")
         return up_reqs;
     }
 
@@ -245,7 +245,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
         = std::dynamic_pointer_cast<const teca_mesh>(input_data[0]);
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to apply mask. Dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("Failed to apply mask. Dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -258,7 +258,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
     // check that a masking variable has been provided
     if (this->mask_variable.empty())
     {
-        TECA_ERROR("The mask_variable name was not specified")
+        TECA_FATAL_ERROR("The mask_variable name was not specified")
         return nullptr;
     }
 
@@ -267,7 +267,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
         = in_mesh->get_point_arrays()->get(this->mask_variable);
     if (!mask_array)
     {
-        TECA_ERROR("The mask_variable \"" << this->mask_variable
+        TECA_FATAL_ERROR("The mask_variable \"" << this->mask_variable
             << "\" was requested but is not present in the input data.")
         return nullptr;
     }
@@ -286,7 +286,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
                 = in_mesh->get_point_arrays()->get(input_var);
             if (!input_array)
             {
-                TECA_ERROR("The masked_variable \"" << input_var
+                TECA_FATAL_ERROR("The masked_variable \"" << input_var
                     << "\" was requested but is not present in the input data.")
                 return nullptr;
             }

--- a/alg/teca_apply_tempest_remap.cxx
+++ b/alg/teca_apply_tempest_remap.cxx
@@ -180,7 +180,7 @@ teca_metadata teca_apply_tempest_remap::get_output_metadata(
                     {
                         // _FillValue must be present in this case, if not you can't
                         // use a target_mask_variable
-                        TECA_ERROR("Failed to get _FillValue for the target mask \""
+                        TECA_FATAL_ERROR("Failed to get _FillValue for the target mask \""
                             << this->target_mask_variable << "\"")
                         return teca_metadata();
                     }
@@ -265,7 +265,7 @@ teca_apply_tempest_remap::get_upstream_request(unsigned int port,
         }
         else
         {
-            TECA_ERROR("Neither the source or target data has "
+            TECA_FATAL_ERROR("Neither the source or target data has "
                 "a variable named \"" << array << "\"")
             return up_reqs;
         }
@@ -333,7 +333,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
     if (!src_mesh)
     {
-        TECA_ERROR("The source dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("The source dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -346,7 +346,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
     if (!tgt_mesh)
     {
-        TECA_ERROR("The target dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("The target dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -362,7 +362,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
         if (!tgt_valid)
         {
-            TECA_ERROR("Failed to get the target mask \"" << this->target_mask_variable
+            TECA_FATAL_ERROR("Failed to get the target mask \"" << this->target_mask_variable
                 << "_valid\". Include teca_valid_value_mask in the upstream pipeline.")
             return nullptr;
         }
@@ -374,14 +374,14 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
     if (!rmp_coll)
     {
-        TECA_ERROR("dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("dataset is not a teca_mesh")
         return nullptr;
     }
 
     const_p_teca_variant_array row = rmp_coll->get(this->row_variable);
     if (!row)
     {
-        TECA_ERROR("Failed to get row indices no array named \""
+        TECA_FATAL_ERROR("Failed to get row indices no array named \""
             << this->row_variable << "\"")
         return nullptr;
     }
@@ -389,7 +389,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
     const_p_teca_variant_array col = rmp_coll->get(this->column_variable);
     if (!col)
     {
-        TECA_ERROR("Failed to get column indices no array named \""
+        TECA_FATAL_ERROR("Failed to get column indices no array named \""
             << this->column_variable << "\"")
         return nullptr;
     }
@@ -397,7 +397,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
     const_p_teca_variant_array weights = rmp_coll->get(this->weights_variable);
     if (!weights)
     {
-        TECA_ERROR("Failed to get the weights no array names \""
+        TECA_FATAL_ERROR("Failed to get the weights no array names \""
             << this->weights_variable << "\"")
         return nullptr;
     }
@@ -454,7 +454,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
             const_p_teca_variant_array src_data = src_mesh->get_point_arrays()->get(array);
             if (!src_data)
             {
-                TECA_ERROR("Failed to get \"" << array << "\" from the source mesh")
+                TECA_FATAL_ERROR("Failed to get \"" << array << "\" from the source mesh")
                 return nullptr;
             }
 
@@ -463,7 +463,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
             /*if (!src_valid)
             {
-                TECA_ERROR("Failed to get \"" << array << "_valid\" from the source mesh."
+                TECA_FATAL_ERROR("Failed to get \"" << array << "_valid\" from the source mesh."
                     " Include teca_valid_value_mask in the upstream pipeline")
                 return nullptr;
             }*/
@@ -510,7 +510,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
                             NT_DATA src_fill_value = NT_DATA(0);
                             if (src_array_atts.get("_FillValue", src_fill_value))
                             {
-                                TECA_ERROR("Failed to get the _FillValue for \"" << array << "\"")
+                                TECA_FATAL_ERROR("Failed to get the _FillValue for \"" << array << "\"")
                                 return nullptr;
                             }
 #if defined(CHAR_VALID_VALUE_MASK)
@@ -575,7 +575,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
                         if (src_array_atts.get("_FillValue", fill_value) &&
                             tgt_mask_atts.get("_FillValue", fill_value))
                         {
-                            TECA_ERROR("Failed to get the _FillValue from \"" << array
+                            TECA_FATAL_ERROR("Failed to get the _FillValue from \"" << array
                                 << "\" and \"" << this->target_mask_variable << "\"")
                             return nullptr;
                         }

--- a/alg/teca_bayesian_ar_detect.cxx
+++ b/alg/teca_bayesian_ar_detect.cxx
@@ -755,21 +755,21 @@ teca_metadata teca_bayesian_ar_detect::get_output_metadata(
 
             if (!parameter_table)
             {
-                TECA_ERROR("metadata pipeline failure")
+                TECA_FATAL_ERROR("metadata pipeline failure")
             }
             else if (!parameter_table->has_column(this->min_ivt_variable))
             {
-                TECA_ERROR("metadata missing percentile column \""
+                TECA_FATAL_ERROR("metadata missing percentile column \""
                     << this->min_ivt_variable << "\"")
             }
             else if (!parameter_table->get_column(this->min_component_area_variable))
             {
-                TECA_ERROR("metadata missing area column \""
+                TECA_FATAL_ERROR("metadata missing area column \""
                     << this->min_component_area_variable << "\"")
             }
             else if (!parameter_table->get_column(this->hwhm_latitude_variable))
             {
-                TECA_ERROR("metadata missing hwhm column \""
+                TECA_FATAL_ERROR("metadata missing hwhm column \""
                     << this->hwhm_latitude_variable << "\"")
             }
             else
@@ -805,7 +805,7 @@ teca_metadata teca_bayesian_ar_detect::get_output_metadata(
 
         if (num_params < 1)
         {
-            TECA_ERROR("Invalid parameter table, must have at least one row")
+            TECA_FATAL_ERROR("Invalid parameter table, must have at least one row")
             return teca_metadata();
         }
     }
@@ -872,7 +872,7 @@ std::vector<teca_metadata> teca_bayesian_ar_detect::get_upstream_request(
     // get the name of the array to request
     if (this->ivt_variable.empty())
     {
-        TECA_ERROR("A water vapor variable was not specified")
+        TECA_FATAL_ERROR("A water vapor variable was not specified")
         return up_reqs;
     }
 
@@ -911,7 +911,7 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
     // check the thread pool
     if (!this->internals->queue)
     {
-        TECA_ERROR("thread pool has not been created. Did you forget "
+        TECA_FATAL_ERROR("thread pool has not been created. Did you forget "
             "to call set_thread_pool_size?")
         return nullptr;
     }
@@ -919,7 +919,7 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
     // check the parameter table
     if (!this->internals->parameter_table)
     {
-        TECA_ERROR("empty parameter table input")
+        TECA_FATAL_ERROR("empty parameter table input")
         return nullptr;
     }
 
@@ -931,7 +931,7 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
         std::dynamic_pointer_cast<teca_cartesian_mesh>(in_data);
     if (!in_mesh)
     {
-        TECA_ERROR("empty mesh input, or not a cartesian_mesh")
+        TECA_FATAL_ERROR("empty mesh input, or not a cartesian_mesh")
         return nullptr;
     }
 
@@ -940,14 +940,14 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
     std::string index_request_key;
     if (in_md.get("index_request_key", index_request_key))
     {
-        TECA_ERROR("Dataset metadata is missing the index_request_key key")
+        TECA_FATAL_ERROR("Dataset metadata is missing the index_request_key key")
         return nullptr;
     }
 
     unsigned long index = 0;
     if (in_md.get(index_request_key, index))
     {
-        TECA_ERROR("Dataset metadata is missing the \""
+        TECA_FATAL_ERROR("Dataset metadata is missing the \""
             << index_request_key << "\" key")
         return nullptr;
     }
@@ -956,7 +956,7 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
     if (in_mesh->get_time(time) &&
         request.get("time", time))
     {
-        TECA_ERROR("request missing \"time\"")
+        TECA_FATAL_ERROR("request missing \"time\"")
         return nullptr;
     }
 
@@ -1077,7 +1077,7 @@ const_p_teca_dataset teca_bayesian_ar_detect::execute(
 
     if (!out_mesh)
     {
-        TECA_ERROR("Pipeline execution failed")
+        TECA_FATAL_ERROR("Pipeline execution failed")
         return nullptr;
     }
 

--- a/alg/teca_binary_segmentation.cxx
+++ b/alg/teca_binary_segmentation.cxx
@@ -167,7 +167,7 @@ int teca_binary_segmentation::get_threshold_variable(
 {
     if (this->threshold_variable.empty())
     {
-        TECA_ERROR("Threshold variable is not set")
+        TECA_FATAL_ERROR("Threshold variable is not set")
         return -1;
     }
 
@@ -188,7 +188,7 @@ teca_metadata teca_binary_segmentation::get_output_metadata(
 
     if (this->threshold_variable.empty())
     {
-        TECA_ERROR("a threshold_variable has not been set")
+        TECA_FATAL_ERROR("a threshold_variable has not been set")
         return teca_metadata();
     }
 
@@ -245,7 +245,7 @@ std::vector<teca_metadata> teca_binary_segmentation::get_upstream_request(
     std::string threshold_var;
     if (this->get_threshold_variable(threshold_var))
     {
-        TECA_ERROR("A threshold variable was not specified")
+        TECA_FATAL_ERROR("A threshold variable was not specified")
         return up_reqs;
     }
 
@@ -287,7 +287,7 @@ const_p_teca_dataset teca_binary_segmentation::execute(
             input_data[0]);
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a cartesian_mesh")
+        TECA_FATAL_ERROR("empty input, or not a cartesian_mesh")
         return nullptr;
     }
 
@@ -301,7 +301,7 @@ const_p_teca_dataset teca_binary_segmentation::execute(
     std::string threshold_var;
     if (this->get_threshold_variable(threshold_var))
     {
-        TECA_ERROR("A threshold variable was not specified")
+        TECA_FATAL_ERROR("A threshold variable was not specified")
         return nullptr;
     }
 
@@ -309,7 +309,7 @@ const_p_teca_dataset teca_binary_segmentation::execute(
         = out_mesh->get_point_arrays()->get(threshold_var);
     if (!input_array)
     {
-        TECA_ERROR("threshold variable \"" << threshold_var
+        TECA_FATAL_ERROR("threshold variable \"" << threshold_var
             << "\" is not in the input")
         return nullptr;
     }
@@ -336,7 +336,7 @@ const_p_teca_dataset teca_binary_segmentation::execute(
 
         if ((low < 0.0) || (high > 100.0))
         {
-            TECA_ERROR("The threshold values are " << low << ", " << high << ". "
+            TECA_FATAL_ERROR("The threshold values are " << low << ", " << high << ". "
               "In percentile mode the threshold values must be between 0 and 100")
             return nullptr;
         }
@@ -364,7 +364,7 @@ const_p_teca_dataset teca_binary_segmentation::execute(
         }
         else
         {
-            TECA_ERROR("Invalid threshold mode")
+            TECA_FATAL_ERROR("Invalid threshold mode")
             return nullptr;
         }
         )

--- a/alg/teca_cartesian_mesh_coordinate_transform.cxx
+++ b/alg/teca_cartesian_mesh_coordinate_transform.cxx
@@ -286,8 +286,6 @@ void teca_cartesian_mesh_coordinate_transform::set_properties(
 }
 #endif
 
-
-
 // --------------------------------------------------------------------------
 teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
     unsigned int port, const std::vector<teca_metadata> &input_md)
@@ -322,7 +320,7 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
     // check that bounds for each cooridnate axes are specified
     if (this->target_bounds.size() != 6)
     {
-        TECA_ERROR("Invalid target_bounds. " << this->target_bounds.size()
+        TECA_FATAL_ERROR("Invalid target_bounds. " << this->target_bounds.size()
             << "  were specified while 6 are needed.")
         return teca_metadata();
     }
@@ -340,7 +338,7 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
         || !(y_in = this->internals->coordinates_in.get("y"))
         || !(z_in = this->internals->coordinates_in.get("z")))
     {
-        TECA_ERROR("The input metadata has invalid coordinates")
+        TECA_FATAL_ERROR("The input metadata has invalid coordinates")
         this->internals->clear();
         return teca_metadata();
     }
@@ -356,7 +354,7 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
         || internals_t::validate_target_bounds('y', y_in, tgt_bounds + 2)
         || internals_t::validate_target_bounds('z', z_in, tgt_bounds + 4))
     {
-        TECA_ERROR("Invalid bounds requested")
+        TECA_FATAL_ERROR("Invalid bounds requested")
         this->internals->clear();
         return teca_metadata();
     }
@@ -391,7 +389,7 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
         || this->internals->coordinates_in.get("y_variable", y_axis_variable_in)
         || this->internals->coordinates_in.get("z_variable", z_axis_variable_in))
     {
-        TECA_ERROR("Failed to get the coordinate axis variables")
+        TECA_FATAL_ERROR("Failed to get the coordinate axis variables")
         this->internals->clear();
         return teca_metadata();
     }
@@ -424,7 +422,7 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
         || atts.get(y_axis_variable_in, this->internals->y_axis_attributes_out)
         || atts.get(z_axis_variable_in, this->internals->z_axis_attributes_out))
     {
-        TECA_ERROR("Failed to get the coordinate variables attributes")
+        TECA_FATAL_ERROR("Failed to get the coordinate variables attributes")
         this->internals->clear();
         return teca_metadata();
     }
@@ -531,7 +529,7 @@ teca_cartesian_mesh_coordinate_transform::get_upstream_request(
             || !(y_in = this->internals->coordinates_in.get("y"))
             || !(z_in = this->internals->coordinates_in.get("z")))
         {
-            TECA_ERROR("The input metadata has invalid coordinates")
+            TECA_FATAL_ERROR("The input metadata has invalid coordinates")
             return up_reqs;
         }
 
@@ -544,7 +542,7 @@ teca_cartesian_mesh_coordinate_transform::get_upstream_request(
             || !(y_out = this->internals->coordinates_out.get("y"))
             || !(z_out = this->internals->coordinates_out.get("z")))
         {
-            TECA_ERROR("The input metadata has invalid coordinates")
+            TECA_FATAL_ERROR("The input metadata has invalid coordinates")
             return up_reqs;
         }
 
@@ -553,7 +551,7 @@ teca_cartesian_mesh_coordinate_transform::get_upstream_request(
         unsigned long extent[6] = {0ul};
         if (teca_coordinate_util::bounds_to_extent(bounds, x_out, y_out, z_out, extent))
         {
-            TECA_ERROR("The requested bounds " << bounds[0] << ", " << bounds[1]
+            TECA_FATAL_ERROR("The requested bounds " << bounds[0] << ", " << bounds[1]
                 << ", " << bounds[2] << ", "  << bounds[3] << ", " << bounds[4]
                 << ", " << bounds[5] << "] were not found in the transformed coordinates")
             return up_reqs;
@@ -599,7 +597,7 @@ const_p_teca_dataset teca_cartesian_mesh_coordinate_transform::execute(
 
     if (!in_target)
     {
-        TECA_ERROR("invalid input dataset")
+        TECA_FATAL_ERROR("invalid input dataset")
         return nullptr;
     }
 
@@ -612,7 +610,7 @@ const_p_teca_dataset teca_cartesian_mesh_coordinate_transform::execute(
         || !(y_out = this->internals->coordinates_out.get("y"))
         || !(z_out = this->internals->coordinates_out.get("z")))
     {
-        TECA_ERROR("The cached metadata has invalid coordinates")
+        TECA_FATAL_ERROR("The cached metadata has invalid coordinates")
         return nullptr;
     }
 

--- a/alg/teca_cartesian_mesh_regrid.cxx
+++ b/alg/teca_cartesian_mesh_regrid.cxx
@@ -337,7 +337,7 @@ std::vector<teca_metadata> teca_cartesian_mesh_regrid::get_upstream_request(
         else if (find(src_0, src_1, *it) != src_1)
             source_arrays.push_back(*it);
         else
-            TECA_ERROR("\"" << *it << "\" was not in target nor source")
+            TECA_FATAL_ERROR("\"" << *it << "\" was not in target nor source")
     }
 
     target_req.set("arrays", target_arrays);
@@ -352,7 +352,7 @@ std::vector<teca_metadata> teca_cartesian_mesh_regrid::get_upstream_request(
         || !(target_y = target_coords.get("y"))
         || !(target_z = target_coords.get("z")))
     {
-        TECA_ERROR("failed to locate target mesh coordinates")
+        TECA_FATAL_ERROR("failed to locate target mesh coordinates")
         return up_reqs;
     }
 
@@ -377,7 +377,7 @@ std::vector<teca_metadata> teca_cartesian_mesh_regrid::get_upstream_request(
             teca_coordinate_util::validate_extent(target_x->size(),
                 target_y->size(), target_z->size(), target_extent, true))
         {
-            TECA_ERROR("invalid bounds requested [" << request_bounds[0]  << ", "
+            TECA_FATAL_ERROR("invalid bounds requested [" << request_bounds[0]  << ", "
                 << request_bounds[1] << ", " << request_bounds[2] << ", "
                 << request_bounds[3] << ", " << request_bounds[4] << ", "
                 << request_bounds[5] << "]")
@@ -401,7 +401,7 @@ std::vector<teca_metadata> teca_cartesian_mesh_regrid::get_upstream_request(
     if (input_md[md_src].get("coordinates", source_coords)
         || !(source_z = source_coords.get("z")))
     {
-        TECA_ERROR("failed to locate source mesh coordinates")
+        TECA_FATAL_ERROR("failed to locate source mesh coordinates")
         return up_reqs;
     }
 
@@ -455,7 +455,7 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
 
     if (!in_target || !source)
     {
-        TECA_ERROR("invalid input. target invalid "
+        TECA_FATAL_ERROR("invalid input. target invalid "
             << !in_target << " source invalid " << !source )
         return nullptr;
     }
@@ -495,7 +495,7 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
             }
             else
             {
-                TECA_ERROR("Array \"" << *it
+                TECA_FATAL_ERROR("Array \"" << *it
                     << "\" is neither present in source or target mesh")
                 return nullptr;
             }
@@ -614,13 +614,13 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
                             p_source_yc, p_source_zc, p_source_a, source_ihi, source_jhi,
                             source_khi, source_nx, source_ny, source_nz))
                         {
-                            TECA_ERROR("Failed to move \"" << source_arrays[i] << "\"")
+                            TECA_FATAL_ERROR("Failed to move \"" << source_arrays[i] << "\"")
                             return nullptr;
                         }
                         )
                     else
                     {
-                        TECA_ERROR("Unsupported array type " << source_a->get_class_name())
+                        TECA_FATAL_ERROR("Unsupported array type " << source_a->get_class_name())
                     }
 
                     target_ac->set(source_arrays[i], target_a);
@@ -628,12 +628,12 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
                 )
             else
             {
-                TECA_ERROR("Unupported coordinate type " << source_xc->get_class_name())
+                TECA_FATAL_ERROR("Unupported coordinate type " << source_xc->get_class_name())
             }
             )
         else
         {
-            TECA_ERROR("Unupported coordinate type " << target_xc->get_class_name())
+            TECA_FATAL_ERROR("Unupported coordinate type " << target_xc->get_class_name())
         }
     }
 

--- a/alg/teca_cartesian_mesh_source.cxx
+++ b/alg/teca_cartesian_mesh_source.cxx
@@ -500,13 +500,13 @@ teca_metadata teca_cartesian_mesh_source::get_output_metadata(
 
     if (this->whole_extents.size() != 8)
     {
-        TECA_ERROR("invalid whole extents were specified")
+        TECA_FATAL_ERROR("invalid whole extents were specified")
         return teca_metadata();
     }
 
     if (this->bounds.size() != 8)
     {
-        TECA_ERROR("invalid bounds were specified")
+        TECA_FATAL_ERROR("invalid bounds were specified")
         return teca_metadata();
     }
 
@@ -622,7 +622,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
     teca_metadata coords;
     if (this->internals->metadata.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return nullptr;
     }
 
@@ -630,7 +630,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
     if (!(in_x = coords.get("x")) || !(in_y = coords.get("y"))
         || !(in_z = coords.get("z")) || !(in_t = coords.get("t")))
     {
-        TECA_ERROR("metadata is missing coordinate arrays")
+        TECA_FATAL_ERROR("metadata is missing coordinate arrays")
         return nullptr;
     }
 
@@ -638,7 +638,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
     unsigned long md_whole_extent[6] = {0};
     if (this->internals->metadata.get("whole_extent", md_whole_extent, 6))
     {
-        TECA_ERROR("metadata is missing \"whole_extent\"")
+        TECA_FATAL_ERROR("metadata is missing \"whole_extent\"")
         return nullptr;
     }
 
@@ -664,7 +664,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
             teca_coordinate_util::validate_extent(in_x->size(),
                 in_y->size(), in_z->size(), req_extent, true))
         {
-            TECA_ERROR("invalid bounds requested.")
+            TECA_FATAL_ERROR("invalid bounds requested.")
             return nullptr;
         }
     }
@@ -675,21 +675,21 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
     std::string request_key;
     if (request.get("index_request_key", request_key))
     {
-        TECA_ERROR("Request is missing the \"index_request_key\"")
+        TECA_FATAL_ERROR("Request is missing the \"index_request_key\"")
         return nullptr;
     }
 
     unsigned long req_index = 0;
     if (request.get(request_key, req_index))
     {
-        TECA_ERROR("Request is missing \"" << request_key << "\"")
+        TECA_FATAL_ERROR("Request is missing \"" << request_key << "\"")
         return nullptr;
     }
 
     // check that the we have a time value for the requested index.
     if (req_index >= in_t->size())
     {
-        TECA_ERROR("The requested index " << req_index
+        TECA_FATAL_ERROR("The requested index " << req_index
             << " is out of bounds [0, " << in_t->size() << "]")
         return nullptr;
     }

--- a/alg/teca_cartesian_mesh_subset.cxx
+++ b/alg/teca_cartesian_mesh_subset.cxx
@@ -84,7 +84,7 @@ teca_metadata teca_cartesian_mesh_subset::get_output_metadata(
         || !(x = coords.get("x")) || !(y = coords.get("y"))
         || !(z = coords.get("z")))
     {
-        TECA_ERROR("Input metadata has invalid coordinates")
+        TECA_FATAL_ERROR("Input metadata has invalid coordinates")
         return teca_metadata();
     }
 
@@ -94,7 +94,7 @@ teca_metadata teca_cartesian_mesh_subset::get_output_metadata(
         teca_coordinate_util::validate_extent(x->size(),
             y->size(), z->size(), this->extent.data(), true))
     {
-        TECA_ERROR("Failed to convert bounds to extent")
+        TECA_FATAL_ERROR("Failed to convert bounds to extent")
         return teca_metadata();
     }
 
@@ -136,7 +136,7 @@ const_p_teca_dataset teca_cartesian_mesh_subset::execute(
 
     if (!in_target)
     {
-        TECA_ERROR("invalid input dataset")
+        TECA_FATAL_ERROR("invalid input dataset")
         return nullptr;
     }
 

--- a/alg/teca_component_area_filter.cxx
+++ b/alg/teca_component_area_filter.cxx
@@ -168,7 +168,7 @@ std::vector<teca_metadata> teca_component_area_filter::get_upstream_request(
     // get the name of the array to request
     if (this->component_variable.empty())
     {
-        TECA_ERROR("The component variable was not specified")
+        TECA_FATAL_ERROR("The component variable was not specified")
         return up_reqs;
     }
 
@@ -214,7 +214,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
             input_data[0]);
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a cartesian_mesh")
+        TECA_FATAL_ERROR("empty input, or not a cartesian_mesh")
         return nullptr;
     }
 
@@ -227,7 +227,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
     // get the input array
     if (this->component_variable.empty())
     {
-        TECA_ERROR("The component variable was not specified")
+        TECA_FATAL_ERROR("The component variable was not specified")
         return nullptr;
     }
 
@@ -236,7 +236,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
     if (!labels_in)
     {
-        TECA_ERROR("labels variable \"" << this->component_variable
+        TECA_FATAL_ERROR("labels variable \"" << this->component_variable
             << "\" is not in the input")
         return nullptr;
     }
@@ -250,7 +250,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
     if (!ids_in)
     {
-        TECA_ERROR("Metadata missing component ids")
+        TECA_FATAL_ERROR("Metadata missing component ids")
         return nullptr;
     }
 
@@ -261,7 +261,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
     if (!areas_in)
     {
-        TECA_ERROR("Metadata missing component areas")
+        TECA_FATAL_ERROR("Metadata missing component areas")
         return nullptr;
     }
 
@@ -293,7 +293,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
     {
         if (in_metadata.get("background_id", mask_value))
         {
-            TECA_ERROR("Metadata is missing the key \"background_id\". "
+            TECA_FATAL_ERROR("Metadata is missing the key \"background_id\". "
                 "One should specify it via the \"mask_value\" algorithm "
                 "property")
             return nullptr;

--- a/alg/teca_component_statistics.cxx
+++ b/alg/teca_component_statistics.cxx
@@ -98,7 +98,7 @@ const_p_teca_dataset teca_component_statistics::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("dataset is not a teca_cartesian_mesh")
+        TECA_FATAL_ERROR("dataset is not a teca_cartesian_mesh")
         return nullptr;
     }
 
@@ -121,7 +121,7 @@ const_p_teca_dataset teca_component_statistics::execute(
     p_teca_variant_array component_ids = dsmd.get("component_ids");
     if (!component_ids)
     {
-        TECA_ERROR("No component ids present")
+        TECA_FATAL_ERROR("No component ids present")
         return nullptr;
     }
 

--- a/alg/teca_connected_components.cxx
+++ b/alg/teca_connected_components.cxx
@@ -318,7 +318,7 @@ std::vector<teca_metadata> teca_connected_components::get_upstream_request(
     std::string segmentation_var = this->get_segmentation_variable(request);
     if (segmentation_var.empty())
     {
-        TECA_ERROR("A segmentation variable was not specified")
+        TECA_FATAL_ERROR("A segmentation variable was not specified")
         return up_reqs;
     }
 
@@ -359,7 +359,7 @@ const_p_teca_dataset teca_connected_components::execute(
             input_data[0]);
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a cartesian_mesh")
+        TECA_FATAL_ERROR("empty input, or not a cartesian_mesh")
         return nullptr;
     }
 
@@ -373,7 +373,7 @@ const_p_teca_dataset teca_connected_components::execute(
     std::string segmentation_var = this->get_segmentation_variable(request);
     if (segmentation_var.empty())
     {
-        TECA_ERROR("A segmentation variable was not specified")
+        TECA_FATAL_ERROR("A segmentation variable was not specified")
         return nullptr;
     }
 
@@ -381,7 +381,7 @@ const_p_teca_dataset teca_connected_components::execute(
         = out_mesh->get_point_arrays()->get(segmentation_var);
     if (!input_array)
     {
-        TECA_ERROR("The segmentation variable \"" << segmentation_var
+        TECA_FATAL_ERROR("The segmentation variable \"" << segmentation_var
             << "\" is not in the input")
         return nullptr;
     }

--- a/alg/teca_dataset_diff.cxx
+++ b/alg/teca_dataset_diff.cxx
@@ -99,14 +99,14 @@ teca_metadata teca_dataset_diff::get_output_metadata(
     std::string initializer_key;
     if (input_md[0].get("index_initializer_key", initializer_key))
     {
-        TECA_ERROR("Input 0 metadata is missing index_initializer_key")
+        TECA_FATAL_ERROR("Input 0 metadata is missing index_initializer_key")
         return teca_metadata();
     }
 
     unsigned long n_indices_0 = 0;
     if (input_md[0].get(initializer_key, n_indices_0))
     {
-        TECA_ERROR("Input 0 metadata is missing its intializer \""
+        TECA_FATAL_ERROR("Input 0 metadata is missing its intializer \""
             << initializer_key << "\"")
         return teca_metadata();
     }
@@ -119,14 +119,14 @@ teca_metadata teca_dataset_diff::get_output_metadata(
     // get input 1 initializer
     if (input_md[1].get("index_initializer_key", initializer_key))
     {
-        TECA_ERROR("Input 1 metadata is missing index_initializer_key")
+        TECA_FATAL_ERROR("Input 1 metadata is missing index_initializer_key")
         return teca_metadata();
     }
 
     unsigned long n_indices_1 = 0;
     if (input_md[1].get(initializer_key, n_indices_1))
     {
-        TECA_ERROR("Input 0 metadata is missing its intializer \""
+        TECA_FATAL_ERROR("Input 0 metadata is missing its intializer \""
             << initializer_key << "\"")
         return teca_metadata();
     }
@@ -154,7 +154,7 @@ std::vector<teca_metadata> teca_dataset_diff::get_upstream_request(
     unsigned long test_id = 0;
     if (request.get("test_id", test_id))
     {
-        TECA_ERROR("Request is missing the index_request_key test_id")
+        TECA_FATAL_ERROR("Request is missing the index_request_key test_id")
         return up_reqs;
     }
 
@@ -162,7 +162,7 @@ std::vector<teca_metadata> teca_dataset_diff::get_upstream_request(
     std::string request_key;
     if (input_md[0].get("index_request_key", request_key))
     {
-        TECA_ERROR("Input 0 metadata is missing index_request_key")
+        TECA_FATAL_ERROR("Input 0 metadata is missing index_request_key")
         return up_reqs;
     }
 
@@ -175,7 +175,7 @@ std::vector<teca_metadata> teca_dataset_diff::get_upstream_request(
     // get input 1 request key
     if (input_md[1].get("index_request_key", request_key))
     {
-        TECA_ERROR("Input 1 metadata is missing index_request_key")
+        TECA_FATAL_ERROR("Input 1 metadata is missing index_request_key")
         return up_reqs;
     }
 
@@ -221,26 +221,26 @@ const_p_teca_dataset teca_dataset_diff::execute(
     // We need exactly two non-NULL inputs to compute a difference.
     if (!ds0)
     {
-        TECA_ERROR("Input dataset 1 is NULL.")
+        TECA_FATAL_ERROR("Input dataset 1 is NULL.")
         return nullptr;
     }
 
     if (!ds1)
     {
-        TECA_ERROR("Input dataset 2 is NULL.")
+        TECA_FATAL_ERROR("Input dataset 2 is NULL.")
         return nullptr;
     }
 
     // If one dataset is empty but not the other, the datasets differ.
     if (ds0->empty() && !ds1->empty())
     {
-        TECA_ERROR("dataset 1 is empty, 2 is not.")
+        TECA_FATAL_ERROR("dataset 1 is empty, 2 is not.")
         return nullptr;
     }
 
     if (!ds0->empty() && ds1->empty())
     {
-        TECA_ERROR("dataset 2 is empty, 1 is not.")
+        TECA_FATAL_ERROR("dataset 2 is empty, 1 is not.")
         return nullptr;
     }
 
@@ -249,7 +249,7 @@ const_p_teca_dataset teca_dataset_diff::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Both the reference and test datasets are empty")
+            TECA_FATAL_ERROR("Both the reference and test datasets are empty")
         }
         return nullptr;
     }
@@ -262,7 +262,7 @@ const_p_teca_dataset teca_dataset_diff::execute(
             std::dynamic_pointer_cast<const teca_table>(ds0),
             std::dynamic_pointer_cast<const teca_table>(ds1)))
         {
-            TECA_ERROR("Failed to compare tables.");
+            TECA_FATAL_ERROR("Failed to compare tables.");
             return nullptr;
         }
     }
@@ -272,7 +272,7 @@ const_p_teca_dataset teca_dataset_diff::execute(
             std::dynamic_pointer_cast<const teca_cartesian_mesh>(ds0),
             std::dynamic_pointer_cast<const teca_cartesian_mesh>(ds1)))
         {
-            TECA_ERROR("Failed to compare cartesian_meshes.");
+            TECA_FATAL_ERROR("Failed to compare cartesian_meshes.");
             return nullptr;
         }
     }
@@ -282,7 +282,7 @@ const_p_teca_dataset teca_dataset_diff::execute(
             std::dynamic_pointer_cast<const teca_curvilinear_mesh>(ds0),
             std::dynamic_pointer_cast<const teca_curvilinear_mesh>(ds1)))
         {
-            TECA_ERROR("Failed to compare curvilinear_meshes.");
+            TECA_FATAL_ERROR("Failed to compare curvilinear_meshes.");
             return nullptr;
         }
     }
@@ -292,13 +292,13 @@ const_p_teca_dataset teca_dataset_diff::execute(
             std::dynamic_pointer_cast<const teca_arakawa_c_grid>(ds0),
             std::dynamic_pointer_cast<const teca_arakawa_c_grid>(ds1)))
         {
-            TECA_ERROR("Failed to compare arakawa_c_grids.");
+            TECA_FATAL_ERROR("Failed to compare arakawa_c_grids.");
             return nullptr;
         }
     }
     else
     {
-        TECA_ERROR("Unsupported dataset type \""
+        TECA_FATAL_ERROR("Unsupported dataset type \""
             << ds0->get_class_name() << "\"")
         return nullptr;
     }
@@ -341,7 +341,7 @@ int teca_dataset_diff::compare_tables(
                 oss << (oss.tellp()?", \"":"\"") << colname << "\"";
         }
 
-        TECA_ERROR("The baseline table has " << ncols1
+        TECA_FATAL_ERROR("The baseline table has " << ncols1
             << " columns while test table has " << ncols2
             << " columns. Columns " << oss.str() << " are missing")
         return -1;
@@ -349,7 +349,7 @@ int teca_dataset_diff::compare_tables(
 
     if (table1->get_number_of_rows() != table2->get_number_of_rows())
     {
-        TECA_ERROR("The baseline table has " << table1->get_number_of_rows()
+        TECA_FATAL_ERROR("The baseline table has " << table1->get_number_of_rows()
             << " rows while test table has " << table2->get_number_of_rows()
             << " rows.")
         return -1;
@@ -380,7 +380,7 @@ int teca_dataset_diff::compare_tables(
         if (!teca_coordinate_util::equal(col1, col2,
             absTol, relTol, errorNo, errorStr))
         {
-            TECA_ERROR("difference in column " << col << " \""
+            TECA_FATAL_ERROR("difference in column " << col << " \""
                 << col_name << "\". " << errorStr)
             return -1;
         }
@@ -407,7 +407,7 @@ int teca_dataset_diff::compare_array_collections(
     {
         if (!data_arrays->has(reference_arrays->get_name(i)))
         {
-            TECA_ERROR("data array collection does not have array \""
+            TECA_FATAL_ERROR("data array collection does not have array \""
                  << reference_arrays->get_name(i)
                  << "\" from the reference array collection.")
             return -1;
@@ -438,7 +438,7 @@ int teca_dataset_diff::compare_array_collections(
         if (!teca_coordinate_util::equal(a1, a2,
             absTol, relTol, errorNo, errorStr))
         {
-            TECA_ERROR("Difference in array " << i << " \"" << name << "\". "
+            TECA_FATAL_ERROR("Difference in array " << i << " \"" << name << "\". "
                 << errorStr)
             return -1;
         }
@@ -471,7 +471,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in point arrays")
+        TECA_FATAL_ERROR("difference in point arrays")
         return -1;
     }
 
@@ -484,7 +484,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in cell arrays")
+        TECA_FATAL_ERROR("difference in cell arrays")
         return -1;
     }
 
@@ -497,7 +497,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in x-edge arrays")
+        TECA_FATAL_ERROR("difference in x-edge arrays")
         return -1;
     }
 
@@ -509,7 +509,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in y-edge arrays")
+        TECA_FATAL_ERROR("difference in y-edge arrays")
         return -1;
     }
 
@@ -521,7 +521,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in z-edge arrays")
+        TECA_FATAL_ERROR("difference in z-edge arrays")
         return -1;
     }
 
@@ -534,7 +534,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in x-face arrays")
+        TECA_FATAL_ERROR("difference in x-face arrays")
         return -1;
     }
 
@@ -546,7 +546,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in y-face arrays")
+        TECA_FATAL_ERROR("difference in y-face arrays")
         return -1;
     }
 
@@ -558,7 +558,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in z-face arrays")
+        TECA_FATAL_ERROR("difference in z-face arrays")
         return -1;
     }
 
@@ -571,7 +571,7 @@ int teca_dataset_diff::compare_meshes(
     }
     if (this->compare_array_collections(arrays1, arrays2))
     {
-        TECA_ERROR("difference in information arrays")
+        TECA_FATAL_ERROR("difference in information arrays")
         return -1;
     }
 
@@ -598,7 +598,7 @@ int teca_dataset_diff::compare_cartesian_meshes(
     }
     if (this->compare_meshes(reference_mesh, data_mesh))
     {
-        TECA_ERROR("Difference in mesh")
+        TECA_FATAL_ERROR("Difference in mesh")
         return -1;
     }
 
@@ -622,7 +622,7 @@ int teca_dataset_diff::compare_cartesian_meshes(
     if (!teca_coordinate_util::equal(coord1,
         data_mesh->get_x_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in x coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in x coordinates. " << errorStr)
         return -1;
     }
 
@@ -638,7 +638,7 @@ int teca_dataset_diff::compare_cartesian_meshes(
     if (!teca_coordinate_util::equal(coord1,
         data_mesh->get_y_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in y coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in y coordinates. " << errorStr)
         return -1;
     }
 
@@ -654,7 +654,7 @@ int teca_dataset_diff::compare_cartesian_meshes(
     if (!teca_coordinate_util::equal(coord1,
         data_mesh->get_z_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in z coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in z coordinates. " << errorStr)
         return -1;
     }
 
@@ -681,7 +681,7 @@ int teca_dataset_diff::compare_curvilinear_meshes(
     }
     if (this->compare_meshes(reference_mesh, data_mesh))
     {
-        TECA_ERROR("Difference in mesh")
+        TECA_FATAL_ERROR("Difference in mesh")
         return -1;
     }
 
@@ -702,7 +702,7 @@ int teca_dataset_diff::compare_curvilinear_meshes(
     if (!teca_coordinate_util::equal(reference_mesh->get_x_coordinates(),
         data_mesh->get_x_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in x coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in x coordinates. " << errorStr)
         return -1;
     }
 
@@ -716,7 +716,7 @@ int teca_dataset_diff::compare_curvilinear_meshes(
     if (!teca_coordinate_util::equal(reference_mesh->get_y_coordinates(),
         data_mesh->get_y_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in y coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in y coordinates. " << errorStr)
         return -1;
     }
 
@@ -730,7 +730,7 @@ int teca_dataset_diff::compare_curvilinear_meshes(
     if (!teca_coordinate_util::equal(reference_mesh->get_z_coordinates(),
         data_mesh->get_z_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in z coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in z coordinates. " << errorStr)
         return -1;
     }
 
@@ -757,7 +757,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     }
     if (this->compare_meshes(reference_mesh, data_mesh))
     {
-        TECA_ERROR("Difference in mesh")
+        TECA_FATAL_ERROR("Difference in mesh")
         return -1;
     }
 
@@ -778,7 +778,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_m_x_coordinates(),
         data_mesh->get_m_x_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in m_x coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in m_x coordinates. " << errorStr)
         return -1;
     }
 
@@ -792,7 +792,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_m_y_coordinates(),
         data_mesh->get_m_y_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in m_y coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in m_y coordinates. " << errorStr)
         return -1;
     }
 
@@ -806,7 +806,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_u_x_coordinates(),
         data_mesh->get_u_x_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in u_x coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in u_x coordinates. " << errorStr)
         return -1;
     }
 
@@ -820,7 +820,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_u_y_coordinates(),
         data_mesh->get_u_y_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in u_y coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in u_y coordinates. " << errorStr)
         return -1;
     }
 
@@ -834,7 +834,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_v_x_coordinates(),
         data_mesh->get_v_x_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in v_x coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in v_x coordinates. " << errorStr)
         return -1;
     }
 
@@ -848,7 +848,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_v_y_coordinates(),
         data_mesh->get_v_y_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in v_y coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in v_y coordinates. " << errorStr)
         return -1;
     }
 
@@ -862,7 +862,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_m_z_coordinates(),
         data_mesh->get_m_z_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in m_z coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in m_z coordinates. " << errorStr)
         return -1;
     }
 
@@ -876,7 +876,7 @@ int teca_dataset_diff::compare_arakawa_c_grids(
     if (!teca_coordinate_util::equal(reference_mesh->get_w_z_coordinates(),
         data_mesh->get_w_z_coordinates(), absTol, relTol, errorNo, errorStr))
     {
-        TECA_ERROR("difference in w_z coordinates. " << errorStr)
+        TECA_FATAL_ERROR("difference in w_z coordinates. " << errorStr)
         return -1;
     }
 

--- a/alg/teca_derived_quantity.cxx
+++ b/alg/teca_derived_quantity.cxx
@@ -71,7 +71,7 @@ int teca_derived_quantity::set_name(const std::string &name)
         "teca_derived_quantity(%s)", name.c_str()) >=
         static_cast<int>(sizeof(this->class_name)))
     {
-        TECA_ERROR("name is too long for the current buffer size "
+        TECA_FATAL_ERROR("name is too long for the current buffer size "
             << sizeof(this->class_name))
         return -1;
     }

--- a/alg/teca_descriptive_statistics.cxx
+++ b/alg/teca_descriptive_statistics.cxx
@@ -215,7 +215,7 @@ const_p_teca_dataset teca_descriptive_statistics::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("dataset is not a teca_cartesian_mesh")
+        TECA_FATAL_ERROR("dataset is not a teca_cartesian_mesh")
         return nullptr;
     }
     // dependent variables
@@ -316,7 +316,7 @@ const_p_teca_dataset teca_descriptive_statistics::execute(
             = in_mesh->get_point_arrays()->get(dep_var_name);
         if (!dep_var)
         {
-            TECA_ERROR("dependent variable " << i << " \""
+            TECA_FATAL_ERROR("dependent variable " << i << " \""
                 << dep_var_name << "\" not present.")
             return nullptr;
         }

--- a/alg/teca_elevation_mask.cxx
+++ b/alg/teca_elevation_mask.cxx
@@ -117,7 +117,7 @@ teca_metadata teca_elevation_mask::get_output_metadata(
     unsigned int n_mask_vars = this->mask_variables.size();
     if (n_mask_vars == 0)
     {
-        TECA_ERROR("The names of the mask_variables were not provided")
+        TECA_FATAL_ERROR("The names of the mask_variables were not provided")
         return teca_metadata();
     }
 
@@ -179,13 +179,13 @@ std::vector<teca_metadata> teca_elevation_mask::get_upstream_request(
     // get the names of the arrays we need to request
     if (this->mesh_height_variable.empty())
     {
-        TECA_ERROR("The mesh_height_variable was not specified")
+        TECA_FATAL_ERROR("The mesh_height_variable was not specified")
         return up_reqs;
     }
 
     if (this->surface_elevation_variable.empty())
     {
-        TECA_ERROR("The surface_elevation_variable was not specified")
+        TECA_FATAL_ERROR("The surface_elevation_variable was not specified")
         return up_reqs;
     }
 
@@ -197,7 +197,7 @@ std::vector<teca_metadata> teca_elevation_mask::get_upstream_request(
         unsigned long req_extent[6];
         if (request.get("extent", req_extent, 6))
         {
-            TECA_ERROR("Neither bounds nor extent were specified in the request")
+            TECA_FATAL_ERROR("Neither bounds nor extent were specified in the request")
             return up_reqs;
         }
 
@@ -209,7 +209,7 @@ std::vector<teca_metadata> teca_elevation_mask::get_upstream_request(
         if (md.get("coordinates", coords) ||
             !(x = coords.get("x")) || !(y = coords.get("y")))
         {
-            TECA_ERROR("Failed to get mesh coordinates")
+            TECA_FATAL_ERROR("Failed to get mesh coordinates")
             return up_reqs;
         }
 
@@ -245,7 +245,7 @@ std::vector<teca_metadata> teca_elevation_mask::get_upstream_request(
     std::string req_key;
     if (elev_md.get("index_request_key", req_key))
     {
-        TECA_ERROR("Metadata is missing \"index_request_key\"")
+        TECA_FATAL_ERROR("Metadata is missing \"index_request_key\"")
         return up_reqs;
     }
 
@@ -285,7 +285,7 @@ const_p_teca_dataset teca_elevation_mask::execute(
     // check for an error upstream
     if ((input_data.size() != 2) || !input_data[0] || !input_data[1])
     {
-        TECA_ERROR("Invalid inputs detected")
+        TECA_FATAL_ERROR("Invalid inputs detected")
         return nullptr;
     }
 
@@ -295,7 +295,7 @@ const_p_teca_dataset teca_elevation_mask::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Data to mask on input port 0 is not a"
+        TECA_FATAL_ERROR("Data to mask on input port 0 is not a"
             " teca_cartesian_mesh. Got " << input_data[0]->get_class_name())
         return nullptr;
     }
@@ -315,7 +315,7 @@ const_p_teca_dataset teca_elevation_mask::execute(
 
     if (!mesh_height)
     {
-        TECA_ERROR("Mesh to mask is missing the height field \""
+        TECA_FATAL_ERROR("Mesh to mask is missing the height field \""
             << this->mesh_height_variable << "\"")
         return nullptr;
     }
@@ -326,7 +326,7 @@ const_p_teca_dataset teca_elevation_mask::execute(
 
     if (!in_elev)
     {
-        TECA_ERROR("Data to mask on input port 0 is not a"
+        TECA_FATAL_ERROR("Data to mask on input port 0 is not a"
             " teca_cartesian_mesh. Got " << input_data[0]->get_class_name())
         return nullptr;
     }
@@ -340,7 +340,7 @@ const_p_teca_dataset teca_elevation_mask::execute(
 
     if (!surface_elev)
     {
-        TECA_ERROR("Surface elevation data has no array \""
+        TECA_FATAL_ERROR("Surface elevation data has no array \""
             << this->surface_elevation_variable << "\"")
         return nullptr;
     }

--- a/alg/teca_evaluate_expression.cxx
+++ b/alg/teca_evaluate_expression.cxx
@@ -173,7 +173,7 @@ const_p_teca_dataset teca_evaluate_expression::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Input is empty or not a table")
+            TECA_FATAL_ERROR("Input is empty or not a table")
         }
         return nullptr;
     }
@@ -193,7 +193,7 @@ const_p_teca_dataset teca_evaluate_expression::execute(
 
     if (!variables)
     {
-        TECA_ERROR("input was not a table nor a mesh")
+        TECA_FATAL_ERROR("input was not a table nor a mesh")
         return nullptr;
     }
 
@@ -205,7 +205,7 @@ const_p_teca_dataset teca_evaluate_expression::execute(
     // verify that we have a valid expression
     if (this->postfix_expression.empty())
     {
-        TECA_ERROR("An expression was not provided.")
+        TECA_FATAL_ERROR("An expression was not provided.")
         return nullptr;
     }
 
@@ -216,7 +216,7 @@ const_p_teca_dataset teca_evaluate_expression::execute(
         operator_resolver_t>(result, this->postfix_expression.c_str(),
             operand_resolver))
     {
-        TECA_ERROR("failed to evaluate the expression \""
+        TECA_FATAL_ERROR("failed to evaluate the expression \""
             << this->expression << "\"")
         return nullptr;
     }
@@ -233,7 +233,7 @@ const_p_teca_dataset teca_evaluate_expression::execute(
     // verify that we have the name to store the result
     if (this->result_variable.empty())
     {
-        TECA_ERROR("A name for the result was not provided.")
+        TECA_FATAL_ERROR("A name for the result was not provided.")
         return nullptr;
     }
 

--- a/alg/teca_face_to_cell_centering.cxx
+++ b/alg/teca_face_to_cell_centering.cxx
@@ -168,7 +168,7 @@ teca_metadata teca_face_to_cell_centering::get_output_metadata(
     teca_metadata atrs;
     if (out_md.get("attributes", atrs))
     {
-        TECA_ERROR("failed to get array attributes")
+        TECA_FATAL_ERROR("failed to get array attributes")
         return teca_metadata();
     }
 
@@ -176,7 +176,7 @@ teca_metadata teca_face_to_cell_centering::get_output_metadata(
     std::vector<std::string> arrays;
     if (out_md.get("variables", arrays))
     {
-        TECA_ERROR("failed to get array names")
+        TECA_FATAL_ERROR("failed to get array names")
         return teca_metadata();
     }
 
@@ -190,7 +190,7 @@ teca_metadata teca_face_to_cell_centering::get_output_metadata(
         teca_metadata array_atrs;
         if (atrs.get(array_name, array_atrs))
         {
-            TECA_ERROR("failed to get the attributes for array "
+            TECA_FATAL_ERROR("failed to get the attributes for array "
                 << i << " \"" << array_name << "\"")
             return teca_metadata();
         }
@@ -199,7 +199,7 @@ teca_metadata teca_face_to_cell_centering::get_output_metadata(
         int centering = teca_array_attributes::invalid_value;
         if (array_atrs.get("centering", centering))
         {
-            TECA_ERROR("failed to get the centering for array "
+            TECA_FATAL_ERROR("failed to get the centering for array "
                 << i << " \"" << array_name << "\"")
             return teca_metadata();
         }
@@ -256,7 +256,7 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("teca_arakawa_c_grid is required")
+        TECA_FATAL_ERROR("teca_arakawa_c_grid is required")
         return nullptr;
     }
 

--- a/alg/teca_indexed_dataset_cache.cxx
+++ b/alg/teca_indexed_dataset_cache.cxx
@@ -132,7 +132,7 @@ std::vector<teca_metadata> teca_indexed_dataset_cache::get_upstream_request(
     // force the user to set the cache size
     if (this->max_cache_size == 0)
     {
-        TECA_ERROR("max_cache_size is 0, you must set the"
+        TECA_FATAL_ERROR("max_cache_size is 0, you must set the"
             " cache size before use.")
         return up_reqs;
     }
@@ -141,14 +141,14 @@ std::vector<teca_metadata> teca_indexed_dataset_cache::get_upstream_request(
     std::string request_key;
     if (request.get("index_request_key", request_key))
     {
-        TECA_ERROR("Failed to locate the index_request_key")
+        TECA_FATAL_ERROR("Failed to locate the index_request_key")
         return up_reqs;
     }
 
     index_t index = 0;
     if (request.get(request_key, index))
     {
-        TECA_ERROR("Failed to get the requested index using the"
+        TECA_FATAL_ERROR("Failed to get the requested index using the"
             " index_request_key \"" << request_key << "\"")
         return up_reqs;
     }
@@ -214,14 +214,14 @@ const_p_teca_dataset teca_indexed_dataset_cache::execute(
     std::string request_key;
     if (request.get("index_request_key", request_key))
     {
-        TECA_ERROR("Failed to locate the index_request_key")
+        TECA_FATAL_ERROR("Failed to locate the index_request_key")
         return nullptr;
     }
 
     index_t index = 0;
     if (request.get(request_key, index))
     {
-        TECA_ERROR("Failed to get the requested index using the"
+        TECA_FATAL_ERROR("Failed to get the requested index using the"
             " index_request_key \"" << request_key << "\"")
         return nullptr;
     }
@@ -235,7 +235,7 @@ const_p_teca_dataset teca_indexed_dataset_cache::execute(
     data_map_t::iterator it = this->internals->m_data.find(index);
     if (it == this->internals->m_data.end())
     {
-        TECA_ERROR("The cache is in an invalid state")
+        TECA_FATAL_ERROR("The cache is in an invalid state")
         return nullptr;
     }
     elem = it->second;

--- a/alg/teca_integrated_vapor_transport.cxx
+++ b/alg/teca_integrated_vapor_transport.cxx
@@ -207,7 +207,7 @@ teca_metadata teca_integrated_vapor_transport::get_output_metadata(
         teca_metadata attributes;
         if (md.get("attributes", attributes))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes are misisng")
             return teca_metadata();
         }
@@ -215,7 +215,7 @@ teca_metadata teca_integrated_vapor_transport::get_output_metadata(
         teca_metadata u_atts;
         if (attributes.get(this->wind_u_variable, u_atts))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes for \"" << this->wind_u_variable
                 << "\" are misisng")
             return teca_metadata();
@@ -224,7 +224,7 @@ teca_metadata teca_integrated_vapor_transport::get_output_metadata(
         int type_code = 0;
         if (u_atts.get("type_code", type_code))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes for \"" << this->wind_u_variable
                 << "\" is misisng a \"type_code\"")
             return teca_metadata();
@@ -292,7 +292,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to compute IVT because a cartesian mesh is required.")
+        TECA_FATAL_ERROR("Failed to compute IVT because a cartesian mesh is required.")
         return nullptr;
     }
 
@@ -300,7 +300,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
     unsigned long extent[6] = {0};
     if (in_mesh->get_extent(extent))
     {
-        TECA_ERROR("Failed to compute IVT because mesh extent is missing.")
+        TECA_FATAL_ERROR("Failed to compute IVT because mesh extent is missing.")
         return nullptr;
     }
 
@@ -312,13 +312,13 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
     const_p_teca_variant_array p = in_mesh->get_z_coordinates();
     if (!p)
     {
-        TECA_ERROR("Failed to compute IVT because pressure coordinates are missing")
+        TECA_FATAL_ERROR("Failed to compute IVT because pressure coordinates are missing")
         return nullptr;
     }
 
     if (p->size() < 2)
     {
-        TECA_ERROR("Failed to compute IVT because z dimensions "
+        TECA_FATAL_ERROR("Failed to compute IVT because z dimensions "
             << p->size() << " < 2 as required by the integration method")
         return nullptr;
     }
@@ -329,7 +329,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
 
     if (!wind_u)
     {
-        TECA_ERROR("Failed to compute IVT because longitudinal wind \""
+        TECA_FATAL_ERROR("Failed to compute IVT because longitudinal wind \""
             << this->wind_u_variable << "\" is missing")
         return nullptr;
     }
@@ -342,7 +342,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
 
     if (!wind_v)
     {
-        TECA_ERROR("Failed to compute IVT because latitudinal wind \""
+        TECA_FATAL_ERROR("Failed to compute IVT because latitudinal wind \""
             << this->wind_v_variable << "\" is missing")
         return nullptr;
     }
@@ -355,7 +355,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
 
     if (!q)
     {
-        TECA_ERROR("Failed to compute IVT because specific humidity \""
+        TECA_FATAL_ERROR("Failed to compute IVT because specific humidity \""
             << this->specific_humidity_variable << "\" is missing")
         return nullptr;
     }
@@ -371,7 +371,7 @@ const_p_teca_dataset teca_integrated_vapor_transport::execute(
 
     if (!out_mesh)
     {
-        TECA_ERROR("Failed to compute IVT because the output mesh was "
+        TECA_FATAL_ERROR("Failed to compute IVT because the output mesh was "
             "not constructed")
         return nullptr;
     }

--- a/alg/teca_integrated_water_vapor.cxx
+++ b/alg/teca_integrated_water_vapor.cxx
@@ -173,7 +173,7 @@ teca_metadata teca_integrated_water_vapor::get_output_metadata(
         teca_metadata attributes;
         if (md.get("attributes", attributes))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes are misisng")
             return teca_metadata();
         }
@@ -181,7 +181,7 @@ teca_metadata teca_integrated_water_vapor::get_output_metadata(
         teca_metadata hus_atts;
         if (attributes.get(this->specific_humidity_variable, hus_atts))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes for \"" << this->specific_humidity_variable
                 << "\" are misisng")
             return teca_metadata();
@@ -190,7 +190,7 @@ teca_metadata teca_integrated_water_vapor::get_output_metadata(
         int type_code = 0;
         if (hus_atts.get("type_code", type_code))
         {
-            TECA_ERROR("Failed to determine output data type "
+            TECA_FATAL_ERROR("Failed to determine output data type "
                 "because attributes for \"" << this->specific_humidity_variable
                 << "\" is misisng a \"type_code\"")
             return teca_metadata();
@@ -247,7 +247,7 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to compute IWV because a cartesian mesh is required.")
+        TECA_FATAL_ERROR("Failed to compute IWV because a cartesian mesh is required.")
         return nullptr;
     }
 
@@ -255,7 +255,7 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
     unsigned long extent[6] = {0};
     if (in_mesh->get_extent(extent))
     {
-        TECA_ERROR("Failed to compute IWV because mesh extent is missing.")
+        TECA_FATAL_ERROR("Failed to compute IWV because mesh extent is missing.")
         return nullptr;
     }
 
@@ -267,13 +267,13 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
     const_p_teca_variant_array p = in_mesh->get_z_coordinates();
     if (!p)
     {
-        TECA_ERROR("Failed to compute IWV because pressure coordinates are missing")
+        TECA_FATAL_ERROR("Failed to compute IWV because pressure coordinates are missing")
         return nullptr;
     }
 
     if (p->size() < 2)
     {
-        TECA_ERROR("Failed to compute IWV because z dimensions "
+        TECA_FATAL_ERROR("Failed to compute IWV because z dimensions "
             << p->size() << " < 2 as required by the integration method")
         return nullptr;
     }
@@ -284,7 +284,7 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
 
     if (!q)
     {
-        TECA_ERROR("Failed to compute IWV because specific humidity \""
+        TECA_FATAL_ERROR("Failed to compute IWV because specific humidity \""
             << this->specific_humidity_variable << "\" is missing")
         return nullptr;
     }
@@ -300,7 +300,7 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
 
     if (!out_mesh)
     {
-        TECA_ERROR("Failed to compute IWV because the output mesh was "
+        TECA_FATAL_ERROR("Failed to compute IWV because the output mesh was "
             "not constructed")
         return nullptr;
     }

--- a/alg/teca_l2_norm.cxx
+++ b/alg/teca_l2_norm.cxx
@@ -176,7 +176,7 @@ teca_metadata teca_l2_norm::get_output_metadata(
 
     if (this->component_0_variable.empty())
     {
-        TECA_ERROR("The component_0_variable was not set")
+        TECA_FATAL_ERROR("The component_0_variable was not set")
         return teca_metadata();
     }
 
@@ -238,7 +238,7 @@ std::vector<teca_metadata> teca_l2_norm::get_upstream_request(
     std::string comp_0_var = this->get_component_0_variable(request);
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component 0 array was not specified")
+        TECA_FATAL_ERROR("component 0 array was not specified")
         return up_reqs;
     }
 
@@ -288,7 +288,7 @@ const_p_teca_dataset teca_l2_norm::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to compute l2 norm. dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("Failed to compute l2 norm. dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -296,7 +296,7 @@ const_p_teca_dataset teca_l2_norm::execute(
     std::string comp_0_var = this->get_component_0_variable(request);
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component 0 array was not specified")
+        TECA_FATAL_ERROR("component 0 array was not specified")
         return nullptr;
     }
 
@@ -309,7 +309,7 @@ const_p_teca_dataset teca_l2_norm::execute(
         = in_mesh->get_point_arrays()->get(comp_0_var);
     if (!c0)
     {
-        TECA_ERROR("component 0 array \"" << comp_0_var
+        TECA_FATAL_ERROR("component 0 array \"" << comp_0_var
             << "\" not present.")
         return nullptr;
     }
@@ -319,7 +319,7 @@ const_p_teca_dataset teca_l2_norm::execute(
     if (!comp_1_var.empty() &&
         !(c1 = in_mesh->get_point_arrays()->get(comp_1_var)))
     {
-        TECA_ERROR("component 1 array \"" << comp_1_var
+        TECA_FATAL_ERROR("component 1 array \"" << comp_1_var
             << "\" requested but not present.")
         return nullptr;
     }
@@ -328,7 +328,7 @@ const_p_teca_dataset teca_l2_norm::execute(
     if (!comp_2_var.empty() &&
         !(c2 = in_mesh->get_point_arrays()->get(comp_2_var)))
     {
-        TECA_ERROR("component 1 array \"" << comp_2_var
+        TECA_FATAL_ERROR("component 1 array \"" << comp_2_var
             << "\" requested but not present.")
         return nullptr;
     }

--- a/alg/teca_laplacian.cxx
+++ b/alg/teca_laplacian.cxx
@@ -298,7 +298,7 @@ std::vector<teca_metadata> teca_laplacian::get_upstream_request(
     std::string comp_0_var = this->get_component_0_variable(request);
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component 0 array was not specified")
+        TECA_FATAL_ERROR("component 0 array was not specified")
         return up_reqs;
     }
 
@@ -341,7 +341,7 @@ const_p_teca_dataset teca_laplacian::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("teca_cartesian_mesh is required")
+        TECA_FATAL_ERROR("teca_cartesian_mesh is required")
         return nullptr;
     }
 
@@ -350,7 +350,7 @@ const_p_teca_dataset teca_laplacian::execute(
 
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component_0_variable was not specified")
+        TECA_FATAL_ERROR("component_0_variable was not specified")
         return nullptr;
     }
 
@@ -359,7 +359,7 @@ const_p_teca_dataset teca_laplacian::execute(
 
     if (!comp_0)
     {
-        TECA_ERROR("requested array \"" << comp_0_var << "\" not present.")
+        TECA_FATAL_ERROR("requested array \"" << comp_0_var << "\" not present.")
         return nullptr;
     }
 
@@ -369,7 +369,7 @@ const_p_teca_dataset teca_laplacian::execute(
 
     if (!lon || !lat)
     {
-        TECA_ERROR("lat lon mesh cooridinates not present.")
+        TECA_FATAL_ERROR("lat lon mesh cooridinates not present.")
         return nullptr;
     }
 

--- a/alg/teca_latitude_damper.cxx
+++ b/alg/teca_latitude_damper.cxx
@@ -205,7 +205,7 @@ std::vector<teca_metadata> teca_latitude_damper::get_upstream_request(
     std::vector<std::string> damped_vars;
     if (this->get_damped_variables(damped_vars))
     {
-        TECA_ERROR("No variables to damp specified")
+        TECA_FATAL_ERROR("No variables to damp specified")
         return up_reqs;
     }
 
@@ -252,7 +252,7 @@ const_p_teca_dataset teca_latitude_damper::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a mesh")
+        TECA_FATAL_ERROR("empty input, or not a mesh")
         return nullptr;
     }
 
@@ -267,7 +267,7 @@ const_p_teca_dataset teca_latitude_damper::execute(
     std::vector<std::string> damped_vars;
     if (this->get_damped_variables(damped_vars))
     {
-        TECA_ERROR("No variable specified to damp")
+        TECA_FATAL_ERROR("No variable specified to damp")
         return nullptr;
     }
 
@@ -306,7 +306,7 @@ const_p_teca_dataset teca_latitude_damper::execute(
                 = out_mesh->get_point_arrays()->get(damped_vars[i]);
             if (!input_array)
             {
-                TECA_ERROR("damper variable \"" << damped_vars[i]
+                TECA_FATAL_ERROR("damper variable \"" << damped_vars[i]
                     << "\" is not in the input")
                 return nullptr;
             }

--- a/alg/teca_mask.cxx
+++ b/alg/teca_mask.cxx
@@ -86,7 +86,7 @@ std::vector<teca_metadata> teca_mask::get_upstream_request(
     std::vector<std::string> mask_vars = this->get_mask_variables(request);
     if (mask_vars.empty())
     {
-        TECA_ERROR("A threshold variable was not specified")
+        TECA_FATAL_ERROR("A threshold variable was not specified")
         return up_reqs;
     }
 
@@ -122,7 +122,7 @@ const_p_teca_dataset teca_mask::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("empty input, or not a mesh")
+        TECA_FATAL_ERROR("empty input, or not a mesh")
         return nullptr;
     }
 
@@ -137,7 +137,7 @@ const_p_teca_dataset teca_mask::execute(
     std::vector<std::string> mask_vars = this->get_mask_variables(request);
     if (mask_vars.empty())
     {
-        TECA_ERROR("A mask variable was not specified")
+        TECA_FATAL_ERROR("A mask variable was not specified")
         return nullptr;
     }
 
@@ -163,7 +163,7 @@ const_p_teca_dataset teca_mask::execute(
 
     if (std::isnan(mask_val))
     {
-        TECA_ERROR("A mask value was not specified")
+        TECA_FATAL_ERROR("A mask value was not specified")
         return nullptr;
     }
 
@@ -175,7 +175,7 @@ const_p_teca_dataset teca_mask::execute(
             = out_mesh->get_point_arrays()->get(mask_vars[i]);
         if (!input_array)
         {
-            TECA_ERROR("mask variable \"" << mask_vars[i]
+            TECA_FATAL_ERROR("mask variable \"" << mask_vars[i]
                 << "\" is not in the input")
             return nullptr;
         }

--- a/alg/teca_normalize_coordinates.cxx
+++ b/alg/teca_normalize_coordinates.cxx
@@ -491,7 +491,7 @@ teca_metadata teca_normalize_coordinates::get_output_metadata(
     teca_metadata coords;
     if (out_md.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing coordinates");
+        TECA_FATAL_ERROR("metadata is missing coordinates");
         return teca_metadata();
     }
 
@@ -499,7 +499,7 @@ teca_metadata teca_normalize_coordinates::get_output_metadata(
     if (!(in_x = coords.get("x")) || !(in_y = coords.get("y"))
         || !(in_z = coords.get("z")))
     {
-        TECA_ERROR("coordinates metadata is missing axes arrays")
+        TECA_FATAL_ERROR("coordinates metadata is missing axes arrays")
         return teca_metadata();
     }
 
@@ -510,7 +510,7 @@ teca_metadata teca_normalize_coordinates::get_output_metadata(
     if (this->enable_periodic_shift_x &&
         internals::periodic_shift_x(out_x, shift_map, in_x, shifted_x))
     {
-        TECA_ERROR("Failed to apply periodic shift to the x-axis")
+        TECA_FATAL_ERROR("Failed to apply periodic shift to the x-axis")
         return teca_metadata();
     }
 
@@ -520,7 +520,7 @@ teca_metadata teca_normalize_coordinates::get_output_metadata(
     if (this->enable_y_axis_ascending &&
         internals::ascending_order_y(out_y, in_y, reordered_y))
     {
-        TECA_ERROR("Failed to put the y-axis in ascending order")
+        TECA_FATAL_ERROR("Failed to put the y-axis in ascending order")
         return teca_metadata();
     }
 
@@ -535,7 +535,7 @@ teca_metadata teca_normalize_coordinates::get_output_metadata(
             unsigned long whole_extent[6];
             if (out_md.get("whole_extent", whole_extent, 6))
             {
-                TECA_ERROR("Failed to get the input whole_extent")
+                TECA_FATAL_ERROR("Failed to get the input whole_extent")
                 return teca_metadata();
             }
             whole_extent[1] -= 1;
@@ -591,7 +591,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     teca_metadata coords;
     if (input_md[0].get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return up_reqs;
     }
 
@@ -599,7 +599,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     if (!(in_x = coords.get("x")) || !(in_y = coords.get("y"))
         || !(z = coords.get("z")))
     {
-        TECA_ERROR("metadata is missing coordinate arrays")
+        TECA_FATAL_ERROR("metadata is missing coordinate arrays")
         return up_reqs;
     }
 
@@ -610,7 +610,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     if (this->enable_periodic_shift_x &&
         internals::periodic_shift_x(out_x, shift_map, in_x, shifted_x))
     {
-        TECA_ERROR("Failed to apply periodic shift to the x-axis")
+        TECA_FATAL_ERROR("Failed to apply periodic shift to the x-axis")
         return up_reqs;
     }
 
@@ -618,7 +618,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     p_teca_unsigned_long_array inv_shift_map;
     if (shifted_x && internals::inv_periodic_shift_x(inv_shift_map, out_x))
     {
-        TECA_ERROR("Failed to compute the inverse shifty map")
+        TECA_FATAL_ERROR("Failed to compute the inverse shifty map")
         return up_reqs;
     }
 
@@ -628,7 +628,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     if (this->enable_y_axis_ascending &&
         internals::ascending_order_y(out_y, in_y, reordered_y))
     {
-        TECA_ERROR("Failed to put the y-axis in ascending order")
+        TECA_FATAL_ERROR("Failed to put the y-axis in ascending order")
         return up_reqs;
     }
 
@@ -643,7 +643,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     unsigned long whole_extent[6] = {0};
     if (input_md[0].get("whole_extent", whole_extent, 6))
     {
-        TECA_ERROR("metadata is missing \"whole_extent\"")
+        TECA_FATAL_ERROR("metadata is missing \"whole_extent\"")
         return up_reqs;
     }
 
@@ -683,7 +683,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
     if (!teca_coordinate_util::same_orientation(bounds, req_bounds) ||
         !teca_coordinate_util::covers(bounds, req_bounds))
     {
-        TECA_ERROR("Invalid request. The requested bounds ["
+        TECA_FATAL_ERROR("Invalid request. The requested bounds ["
             <<  req_bounds[0] << ", " << req_bounds[1] << ", "
             <<  req_bounds[2] << ", " << req_bounds[3] << ", "
             <<  req_bounds[4] << ", " << req_bounds[5]
@@ -743,7 +743,7 @@ std::vector<teca_metadata> teca_normalize_coordinates::get_upstream_request(
         teca_coordinate_util::validate_extent(in_x->size(),
             in_y->size(), z->size(), extent_out, true))
     {
-        TECA_ERROR("invalid bounds requested.")
+        TECA_FATAL_ERROR("invalid bounds requested.")
         return up_reqs;
     }
 
@@ -791,7 +791,7 @@ const_p_teca_dataset teca_normalize_coordinates::execute(unsigned int port,
 
     if (!in_mesh)
     {
-        TECA_ERROR("The input dataset is not a teca_cartesian_mesh")
+        TECA_FATAL_ERROR("The input dataset is not a teca_cartesian_mesh")
         return nullptr;
     }
 
@@ -818,7 +818,7 @@ const_p_teca_dataset teca_normalize_coordinates::execute(unsigned int port,
     if (this->enable_periodic_shift_x &&
         internals::periodic_shift_x(out_x, shift_map, in_x, shifted_x))
     {
-        TECA_ERROR("Failed to apply periodic shift to the x-axis")
+        TECA_FATAL_ERROR("Failed to apply periodic shift to the x-axis")
         return nullptr;
     }
 
@@ -860,7 +860,7 @@ const_p_teca_dataset teca_normalize_coordinates::execute(unsigned int port,
         if (internals::periodic_shift_x(out_mesh->get_point_arrays(),
             attributes, shift_map, extent_in, extent_out))
         {
-            TECA_ERROR("Failed to apply periodic shift in the x direction")
+            TECA_FATAL_ERROR("Failed to apply periodic shift in the x direction")
             return nullptr;
         }
     }
@@ -871,7 +871,7 @@ const_p_teca_dataset teca_normalize_coordinates::execute(unsigned int port,
     if (this->enable_y_axis_ascending &&
         internals::ascending_order_y(out_y, in_y, reordered_y))
     {
-        TECA_ERROR("Failed to put the y-axis in ascending order")
+        TECA_FATAL_ERROR("Failed to put the y-axis in ascending order")
         return nullptr;
     }
 
@@ -893,7 +893,7 @@ const_p_teca_dataset teca_normalize_coordinates::execute(unsigned int port,
         if (internals::ascending_order_y(out_mesh->get_point_arrays(),
             attributes, extent_out))
         {
-            TECA_ERROR("Failed to put point arrays into ascending order")
+            TECA_FATAL_ERROR("Failed to put point arrays into ascending order")
             return nullptr;
         }
     }

--- a/alg/teca_rename_variables.cxx
+++ b/alg/teca_rename_variables.cxx
@@ -82,7 +82,7 @@ teca_metadata teca_rename_variables::get_output_metadata(
     // validate the user provided values.
     if (this->original_variable_names.size() != this->new_variable_names.size())
     {
-        TECA_ERROR("Each variable to rename must have a "
+        TECA_FATAL_ERROR("Each variable to rename must have a "
             " corresponding output_variable_name.")
         return teca_metadata();
     }
@@ -93,7 +93,7 @@ teca_metadata teca_rename_variables::get_output_metadata(
     std::set<std::string> out_vars;
     if (out_md.get("variables", out_vars))
     {
-        TECA_ERROR("Failed to get the list of variables")
+        TECA_FATAL_ERROR("Failed to get the list of variables")
         return teca_metadata();
     }
 
@@ -103,7 +103,7 @@ teca_metadata teca_rename_variables::get_output_metadata(
         std::set<std::string>::iterator it = out_vars.find(this->original_variable_names[i]);
         if (it == out_vars.end())
         {
-            TECA_ERROR("No such variable \"" << this->original_variable_names[i]
+            TECA_FATAL_ERROR("No such variable \"" << this->original_variable_names[i]
                 << "\" to rename")
             return teca_metadata();
         }
@@ -116,7 +116,7 @@ teca_metadata teca_rename_variables::get_output_metadata(
     teca_metadata attributes;
     if (out_md.get("attributes", attributes))
     {
-        TECA_ERROR("Failed to get attributes")
+        TECA_FATAL_ERROR("Failed to get attributes")
         return teca_metadata();
     }
 
@@ -127,7 +127,7 @@ teca_metadata teca_rename_variables::get_output_metadata(
         teca_metadata atts;
         if (attributes.get(var_name, atts))
         {
-            TECA_ERROR("Failed to get attributes for \"" << var_name << "\"")
+            TECA_FATAL_ERROR("Failed to get attributes for \"" << var_name << "\"")
             return teca_metadata();
         }
 
@@ -196,7 +196,7 @@ const_p_teca_dataset teca_rename_variables::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("The input dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("The input dataset is not a teca_mesh")
         return nullptr;
     }
 

--- a/alg/teca_simple_moving_average.cxx
+++ b/alg/teca_simple_moving_average.cxx
@@ -96,14 +96,14 @@ std::vector<teca_metadata> teca_simple_moving_average::get_upstream_request(
     long active_step;
     if (request.get("time_step", active_step))
     {
-        TECA_ERROR("request is missing \"time_step\"")
+        TECA_FATAL_ERROR("request is missing \"time_step\"")
         return up_reqs;
     }
 
     long num_steps;
     if (input_md[0].get("number_of_time_steps", num_steps))
     {
-        TECA_ERROR("input is missing \"number_of_time_steps\"")
+        TECA_FATAL_ERROR("input is missing \"number_of_time_steps\"")
         return up_reqs;
     }
 
@@ -118,7 +118,7 @@ std::vector<teca_metadata> teca_simple_moving_average::get_upstream_request(
         case centered:
             {
             if (this->filter_width % 2 == 0)
-                TECA_ERROR("\"filter_width\" should be odd for centered calculation")
+                TECA_FATAL_ERROR("\"filter_width\" should be odd for centered calculation")
             long delta = this->filter_width/2;
             first = active_step - delta;
             last = active_step + delta;
@@ -129,7 +129,7 @@ std::vector<teca_metadata> teca_simple_moving_average::get_upstream_request(
             last = active_step + this->filter_width - 1;
             break;
         default:
-            TECA_ERROR("Invalid \"filter_type\" " << this->filter_type)
+            TECA_FATAL_ERROR("Invalid \"filter_type\" " << this->filter_type)
             return up_reqs;
     }
     first = std::max(0l, first);
@@ -174,7 +174,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
 
     if (!out_mesh)
     {
-        TECA_ERROR("input data[0] is not a teca_mesh")
+        TECA_FATAL_ERROR("input data[0] is not a teca_mesh")
         return nullptr;
     }
 
@@ -185,7 +185,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to average. dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("Failed to average. dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -245,7 +245,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
     unsigned long active_step;
     if (request.get("time_step", active_step))
     {
-        TECA_ERROR("request is missing \"time_step\"")
+        TECA_FATAL_ERROR("request is missing \"time_step\"")
         return nullptr;
     }
 
@@ -258,7 +258,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
         unsigned long step;
         if (in_mesh->get_metadata().get("time_step", step))
         {
-            TECA_ERROR("input dataset metadata missing \"time_step\"")
+            TECA_FATAL_ERROR("input dataset metadata missing \"time_step\"")
             return nullptr;
         }
 

--- a/alg/teca_table_calendar.cxx
+++ b/alg/teca_table_calendar.cxx
@@ -109,7 +109,7 @@ const_p_teca_dataset teca_table_calendar::execute(
     (void)request;
 #if !defined(TECA_HAS_UDUNITS)
     (void)input_data;
-    TECA_ERROR("Calendaring features are not present")
+    TECA_FATAL_ERROR("Calendaring features are not present")
     return nullptr;
 #else
     // get the input table
@@ -128,7 +128,7 @@ const_p_teca_dataset teca_table_calendar::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Input is empty or not a table")
+            TECA_FATAL_ERROR("Input is empty or not a table")
         }
         return nullptr;
     }
@@ -137,14 +137,14 @@ const_p_teca_dataset teca_table_calendar::execute(
     std::string units = this->units;
     if (units.empty() && (in_table->get_time_units(units) || units.empty()))
     {
-        TECA_ERROR("Units are missing")
+        TECA_FATAL_ERROR("Units are missing")
         return nullptr;
     }
 
     std::string calendar = this->calendar;
     if (calendar.empty() && (in_table->get_calendar(calendar) || calendar.empty()))
     {
-        TECA_ERROR("Calendar is missing")
+        TECA_FATAL_ERROR("Calendar is missing")
         return nullptr;
     }
 
@@ -152,7 +152,7 @@ const_p_teca_dataset teca_table_calendar::execute(
     const_p_teca_variant_array time = in_table->get_column(this->time_column);
     if (!time)
     {
-        TECA_ERROR("column \"" << this->time_column
+        TECA_FATAL_ERROR("column \"" << this->time_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -278,7 +278,7 @@ const_p_teca_dataset teca_table_calendar::execute(
                 &curr_day, &curr_hour, &curr_minute, &curr_second,
                 units.c_str(), calendar.c_str()))
             {
-                TECA_ERROR("Failed to compute the date at row " << i)
+                TECA_FATAL_ERROR("Failed to compute the date at row " << i)
                 return nullptr;
             }
 

--- a/alg/teca_table_region_mask.cxx
+++ b/alg/teca_table_region_mask.cxx
@@ -101,7 +101,7 @@ int teca_table_region_mask::load_cyclone_basin(const std::string &name)
         this->region_starts, this->region_x_coordinates,
         this->region_y_coordinates, tmpi, tmps, tmps))
     {
-        TECA_ERROR("invalid basin name \"" << name << "\"")
+        TECA_FATAL_ERROR("invalid basin name \"" << name << "\"")
         return -1;
     }
     return 0;
@@ -134,7 +134,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Input is empty or not a table")
+            TECA_FATAL_ERROR("Input is empty or not a table")
         }
         return nullptr;
     }
@@ -143,7 +143,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
     unsigned long n_regions = this->region_sizes.size();
     if (!n_regions)
     {
-        TECA_ERROR("no regions to filter by specified")
+        TECA_FATAL_ERROR("no regions to filter by specified")
         return nullptr;
     }
 
@@ -152,7 +152,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
         in_table->get_column(this->x_coordinate_column);
     if (!x)
     {
-        TECA_ERROR("x coordinate column \"" << this->x_coordinate_column
+        TECA_FATAL_ERROR("x coordinate column \"" << this->x_coordinate_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -161,7 +161,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
         in_table->get_column(this->y_coordinate_column);
     if (!y)
     {
-        TECA_ERROR("y coordinate column \"" << this->y_coordinate_column
+        TECA_FATAL_ERROR("y coordinate column \"" << this->y_coordinate_column
             << "\" is not in the table")
         return nullptr;
     }

--- a/alg/teca_table_remove_rows.cxx
+++ b/alg/teca_table_remove_rows.cxx
@@ -84,7 +84,7 @@ void teca_table_remove_rows::set_mask_expression(const std::string &expr)
     char *pfix_expr = teca_parser::infix_to_postfix(expr.c_str(), &dep_vars);
     if (!pfix_expr)
     {
-        TECA_ERROR("failed to convert \"" << expr << "\" to postfix")
+        TECA_FATAL_ERROR("failed to convert \"" << expr << "\" to postfix")
         return;
     }
 
@@ -123,7 +123,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Input is empty or not a table")
+            TECA_FATAL_ERROR("Input is empty or not a table")
         }
         return nullptr;
     }
@@ -139,7 +139,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
     // verify that we have a valid expression
     if (this->postfix_expression.empty())
     {
-        TECA_ERROR("An expression was not provided.")
+        TECA_FATAL_ERROR("An expression was not provided.")
         return nullptr;
     }
 
@@ -150,7 +150,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
         operator_resolver_t>(mask, this->postfix_expression.c_str(),
             operand_resolver))
     {
-        TECA_ERROR("failed to evaluate the mask expression \""
+        TECA_FATAL_ERROR("failed to evaluate the mask expression \""
             << this->mask_expression << "\"")
         return nullptr;
     }

--- a/alg/teca_table_sort.cxx
+++ b/alg/teca_table_sort.cxx
@@ -121,7 +121,7 @@ const_p_teca_dataset teca_table_sort::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("empty input")
+            TECA_FATAL_ERROR("empty input")
         }
         return nullptr;
     }
@@ -134,7 +134,7 @@ const_p_teca_dataset teca_table_sort::execute(
         index_col = in_table->get_column(this->index_column);
     if (!index_col)
     {
-        TECA_ERROR("Failed to locate column to sort by \""
+        TECA_FATAL_ERROR("Failed to locate column to sort by \""
             <<  this->index_column << "\"")
         return nullptr;
     }

--- a/alg/teca_table_to_stream.cxx
+++ b/alg/teca_table_to_stream.cxx
@@ -92,7 +92,7 @@ void teca_table_to_stream::set_stream(const std::string &s)
     }
     else
     {
-        TECA_ERROR("unknown stream requested \"" << s << "\"")
+        TECA_FATAL_ERROR("unknown stream requested \"" << s << "\"")
     }
 }
 
@@ -141,7 +141,7 @@ const_p_teca_dataset teca_table_to_stream::execute(
 
     if (!this->stream)
     {
-        TECA_ERROR("output stream not set")
+        TECA_FATAL_ERROR("output stream not set")
         return nullptr;
     }
 
@@ -161,7 +161,7 @@ const_p_teca_dataset teca_table_to_stream::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("empty input")
+            TECA_FATAL_ERROR("empty input")
         }
         return nullptr;
     }

--- a/alg/teca_tc_candidates.cxx
+++ b/alg/teca_tc_candidates.cxx
@@ -235,7 +235,7 @@ std::vector<teca_metadata> teca_tc_candidates::get_upstream_request(
     teca_metadata coords;
     if (md.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return up_reqs;
     }
 
@@ -243,14 +243,14 @@ std::vector<teca_metadata> teca_tc_candidates::get_upstream_request(
     p_teca_variant_array lon;
     if (!(lat = coords.get("y")) || !(lon = coords.get("x")))
     {
-        TECA_ERROR("metadata missing lat lon coordinates")
+        TECA_FATAL_ERROR("metadata missing lat lon coordinates")
         return up_reqs;
     }
 
     std::vector<unsigned long> extent(6, 0l);
     if (this->get_active_extent(lat, lon, extent))
     {
-        TECA_ERROR("failed to determine the active extent")
+        TECA_FATAL_ERROR("failed to determine the active extent")
         return up_reqs;
     }
 
@@ -294,7 +294,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!input_data.size())
     {
-        TECA_ERROR("empty input")
+        TECA_FATAL_ERROR("empty input")
         return nullptr;
     }
 
@@ -303,7 +303,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
         = std::dynamic_pointer_cast<const teca_cartesian_mesh>(input_data[0]);
     if (!mesh)
     {
-        TECA_ERROR("teca_cartesian_mesh is required")
+        TECA_FATAL_ERROR("teca_cartesian_mesh is required")
         return nullptr;
     }
 
@@ -313,7 +313,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!x || !y)
     {
-        TECA_ERROR("mesh coordinates are missing.")
+        TECA_FATAL_ERROR("mesh coordinates are missing.")
         return nullptr;
     }
 
@@ -346,7 +346,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!surface_wind_speed)
     {
-        TECA_ERROR("Dataset missing wind speed variable \""
+        TECA_FATAL_ERROR("Dataset missing wind speed variable \""
             << this->surface_wind_speed_variable << "\"")
         return nullptr;
     }
@@ -357,7 +357,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!vorticity_850mb)
     {
-        TECA_ERROR("Dataset missing vorticity_850mb variable \""
+        TECA_FATAL_ERROR("Dataset missing vorticity_850mb variable \""
             << this->vorticity_850mb_variable << "\"")
         return nullptr;
     }
@@ -368,7 +368,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!core_temperature)
     {
-        TECA_ERROR("Dataset missing core_temperature variable \""
+        TECA_FATAL_ERROR("Dataset missing core_temperature variable \""
             << this->core_temperature_variable << "\"")
         return nullptr;
     }
@@ -379,7 +379,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     if (!sea_level_pressure)
     {
-        TECA_ERROR("Dataset missing sea_level_pressure variable \""
+        TECA_FATAL_ERROR("Dataset missing sea_level_pressure variable \""
             << this->sea_level_pressure_variable << "\"")
         return nullptr;
     }
@@ -388,7 +388,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
     const_p_teca_variant_array thickness;
     if (!(thickness = mesh->get_point_arrays()->get(this->thickness_variable)))
     {
-        TECA_ERROR("Dataset missing thickness variable \""
+        TECA_FATAL_ERROR("Dataset missing thickness variable \""
             << this->thickness_variable << "\"")
         return nullptr;
     }
@@ -430,7 +430,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
                 T, P, th, lat, lon, nlat, nlon, this->minimizer_iterations,
                 time_step, candidates.get()))
             {
-                TECA_ERROR("GFDL TC detector encountered an error")
+                TECA_FATAL_ERROR("GFDL TC detector encountered an error")
                 return nullptr;
             }
             t1 = std::chrono::high_resolution_clock::now();

--- a/alg/teca_tc_classify.cxx
+++ b/alg/teca_tc_classify.cxx
@@ -133,7 +133,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("Input is empty or not a table")
+            TECA_FATAL_ERROR("Input is empty or not a table")
         }
         return nullptr;
     }
@@ -142,20 +142,20 @@ const_p_teca_dataset teca_tc_classify::execute(
     std::string calendar;
     if ((in_table->get_calendar(calendar)) && calendar.empty())
     {
-        TECA_ERROR("Calendar is missing")
+        TECA_FATAL_ERROR("Calendar is missing")
         return nullptr;
     }
 
     std::string time_units;
     if ((in_table->get_time_units(time_units)) && time_units.empty())
     {
-        TECA_ERROR("time units are missing")
+        TECA_FATAL_ERROR("time units are missing")
         return nullptr;
     }
 
     if (time_units.find("days since") == std::string::npos)
     {
-        TECA_ERROR("Conversion for \"" << time_units << "\" not implemented")
+        TECA_FATAL_ERROR("Conversion for \"" << time_units << "\" not implemented")
         return nullptr;
     }
 
@@ -166,7 +166,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!track_ids)
     {
-        TECA_ERROR("column \"" << this->track_id_column
+        TECA_FATAL_ERROR("column \"" << this->track_id_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -177,7 +177,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!x)
     {
-        TECA_ERROR("column \"" << this->x_coordinate_column
+        TECA_FATAL_ERROR("column \"" << this->x_coordinate_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -187,7 +187,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!y)
     {
-        TECA_ERROR("column \"" << this->y_coordinate_column
+        TECA_FATAL_ERROR("column \"" << this->y_coordinate_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -198,7 +198,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!time)
     {
-        TECA_ERROR("column \"" << this->time_column
+        TECA_FATAL_ERROR("column \"" << this->time_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -209,7 +209,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!surface_wind)
     {
-        TECA_ERROR("column \"" << this->surface_wind_column
+        TECA_FATAL_ERROR("column \"" << this->surface_wind_column
             << "\" is not in the table")
         return nullptr;
     }
@@ -220,7 +220,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     if (!sea_level_pressure)
     {
-        TECA_ERROR("column \"" << this->sea_level_pressure_column
+        TECA_FATAL_ERROR("column \"" << this->sea_level_pressure_column
             << "\" is not in the table")
         return nullptr;
     }

--- a/alg/teca_tc_trajectory.cxx
+++ b/alg/teca_tc_trajectory.cxx
@@ -340,7 +340,7 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("empty input or not a table")
+            TECA_FATAL_ERROR("empty input or not a table")
         }
         return nullptr;
     }
@@ -356,7 +356,7 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     {
         if (!candidates->has_column(req_cols[i]))
         {
-            TECA_ERROR("Candidate table missing \"" << req_cols[i] << "\"")
+            TECA_FATAL_ERROR("Candidate table missing \"" << req_cols[i] << "\"")
             return nullptr;
         }
     }
@@ -408,7 +408,7 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     storm_tracks->get_time_units(time_units);
     if (time_units.find("days since") == std::string::npos)
     {
-        TECA_ERROR("Conversion for \"" << time_units << "\" not implemented")
+        TECA_FATAL_ERROR("Conversion for \"" << time_units << "\" not implemented")
         return nullptr;
     }
 
@@ -417,7 +417,7 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     // check that there are some candidates to work with.
     if (n_rows < 1)
     {
-        TECA_ERROR("Failed to form TC tracks because there were no candiates")
+        TECA_FATAL_ERROR("Failed to form TC tracks because there were no candiates")
         return nullptr;
     }
 
@@ -471,7 +471,7 @@ const_p_teca_dataset teca_tc_trajectory::execute(
                 p_wind_max, p_vort_max, p_psl_min, p_have_twc, p_have_thick,
                 p_twc_max, p_thick_max, n_rows, storm_tracks, n_tracks))
             {
-                TECA_ERROR("Failed to form tracks")
+                TECA_FATAL_ERROR("Failed to form tracks")
                 return nullptr;
             }
             )

--- a/alg/teca_tc_wind_radii.cxx
+++ b/alg/teca_tc_wind_radii.cxx
@@ -690,7 +690,7 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
 
         if (!storm_table)
         {
-            TECA_ERROR("metadata pipeline failure")
+            TECA_FATAL_ERROR("metadata pipeline failure")
         }
 
         // column need to build random access data structures
@@ -699,32 +699,32 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
 
         if (!storm_ids)
         {
-            TECA_ERROR("storm index column \""
+            TECA_FATAL_ERROR("storm index column \""
             << this->storm_id_column << "\" not found")
         }
         // these columns are needed to compute the storm size
         else
         if (!storm_table->has_column(this->storm_x_coordinate_column))
         {
-            TECA_ERROR("storm x coordinates column \""
+            TECA_FATAL_ERROR("storm x coordinates column \""
                 << this->storm_x_coordinate_column << "\" not found")
         }
         else
         if (!storm_table->has_column(this->storm_y_coordinate_column))
         {
-            TECA_ERROR("storm y coordinates column \""
+            TECA_FATAL_ERROR("storm y coordinates column \""
                 << this->storm_y_coordinate_column << "\" not found")
         }
         else
         if (!storm_table->has_column(this->storm_wind_speed_column))
         {
-            TECA_ERROR("storm wind speed column \""
+            TECA_FATAL_ERROR("storm wind speed column \""
                 << this->storm_wind_speed_column << "\" not found")
         }
         else
         if (!storm_table->has_column(this->storm_time_column))
         {
-            TECA_ERROR("storm time column \""
+            TECA_FATAL_ERROR("storm time column \""
                 << this->storm_time_column << "\" not found")
         }
         // things are ok, take a reference
@@ -769,7 +769,7 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
     // must have at least one time storm
     if (this->internals->number_of_storms < 1)
     {
-        TECA_ERROR("Invalid index \"" << this->storm_id_column << "\"")
+        TECA_FATAL_ERROR("Invalid index \"" << this->storm_id_column << "\"")
         this->internals->clear();
         return teca_metadata();
     }
@@ -930,7 +930,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
     unsigned long storm_id = 0;
     if (request.get("storm_id", storm_id))
     {
-        TECA_ERROR("Failed to get the storm id")
+        TECA_FATAL_ERROR("Failed to get the storm id")
         return nullptr;
     }
 
@@ -972,7 +972,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
 
             if (!mesh)
             {
-                TECA_ERROR("input " << k << " is empty or not a cartesian mesh")
+                TECA_FATAL_ERROR("input " << k << " is empty or not a cartesian mesh")
                 return nullptr;
             }
 
@@ -1043,7 +1043,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                                 rad_all, wind_all);
                         break;
                     default:
-                        TECA_ERROR("Invalid profile type \"" << this->profile_type << "\"")
+                        TECA_FATAL_ERROR("Invalid profile type \"" << this->profile_type << "\"")
                         return nullptr;
                     }
 

--- a/alg/teca_unpack_data.cxx
+++ b/alg/teca_unpack_data.cxx
@@ -120,14 +120,14 @@ teca_metadata teca_unpack_data::get_output_metadata(
     std::vector<std::string> variables;
     if (out_md.get("variables", variables))
     {
-        TECA_ERROR("Failed to get the list of variables")
+        TECA_FATAL_ERROR("Failed to get the list of variables")
         return teca_metadata();
     }
 
     teca_metadata attributes;
     if (out_md.get("attributes", attributes))
     {
-        TECA_ERROR("Failed to get the array attributes")
+        TECA_FATAL_ERROR("Failed to get the array attributes")
         return teca_metadata();
     }
 
@@ -193,14 +193,14 @@ std::vector<teca_metadata> teca_unpack_data::get_upstream_request(
     std::set<std::string> variables;
     if (md.get("variables", variables))
     {
-        TECA_ERROR("Metadata issue. variables is missing")
+        TECA_FATAL_ERROR("Metadata issue. variables is missing")
         return up_reqs;
     }
 
     teca_metadata attributes;
     if (md.get("attributes", attributes))
     {
-        TECA_ERROR("Failed to get the array attributes")
+        TECA_FATAL_ERROR("Failed to get the array attributes")
         return up_reqs;
     }
 
@@ -261,7 +261,7 @@ const_p_teca_dataset teca_unpack_data::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Input dataset is not a teca_mesh")
+        TECA_FATAL_ERROR("Input dataset is not a teca_mesh")
         return nullptr;
     }
 
@@ -273,7 +273,7 @@ const_p_teca_dataset teca_unpack_data::execute(
     teca_metadata attributes;
     if (out_mesh->get_attributes(attributes))
     {
-        TECA_ERROR("Failed to get attributes")
+        TECA_FATAL_ERROR("Failed to get attributes")
         return nullptr;
     }
 
@@ -310,7 +310,7 @@ const_p_teca_dataset teca_unpack_data::execute(
             teca_variant_array_factory::New(this->output_data_type);
         if (!out_array)
         {
-            TECA_ERROR("Failed to allocate the output array")
+            TECA_FATAL_ERROR("Failed to allocate the output array")
             return nullptr;
         }
 

--- a/alg/teca_valid_value_mask.cxx
+++ b/alg/teca_valid_value_mask.cxx
@@ -98,14 +98,14 @@ teca_metadata teca_valid_value_mask::get_output_metadata(
     std::vector<std::string> variables(this->mask_arrays);
     if (variables.empty() && out_md.get("variables", variables))
     {
-        TECA_ERROR("Failed to get the list of variables")
+        TECA_FATAL_ERROR("Failed to get the list of variables")
         return teca_metadata();
     }
 
     teca_metadata attributes;
     if (out_md.get("attributes", attributes))
     {
-        TECA_ERROR("Failed to get the array attributes")
+        TECA_FATAL_ERROR("Failed to get the array attributes")
         return teca_metadata();
     }
 
@@ -233,7 +233,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Empty input dataset or not a teca_mesh")
+        TECA_FATAL_ERROR("Empty input dataset or not a teca_mesh")
         return nullptr;
     }
 
@@ -265,7 +265,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
     teca_metadata attributes;
     if (md.get("attributes", attributes))
     {
-        TECA_ERROR("Failed to get the array attributes")
+        TECA_FATAL_ERROR("Failed to get the array attributes")
         return nullptr;
     }
 
@@ -279,7 +279,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
         teca_metadata array_atts;
         if (attributes.get(array_name, array_atts))
         {
-            TECA_ERROR("The mask for array \"" << array_name
+            TECA_FATAL_ERROR("The mask for array \"" << array_name
                 << "\" not computed. The array has no attributes")
             return nullptr;
         }
@@ -289,7 +289,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
         unsigned int centering = 0;
         if (array_atts.get("centering", centering))
         {
-            TECA_ERROR("Mask for array \"" << array_name << "\" not computed."
+            TECA_FATAL_ERROR("Mask for array \"" << array_name << "\" not computed."
                 " Attributes are missing centering metadata")
             return nullptr;
         }
@@ -297,7 +297,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
         p_teca_array_collection arrays = out_mesh->get_arrays(centering);
         if (!arrays)
         {
-            TECA_ERROR("Mask for array \"" << array_name << "\" not computed."
+            TECA_FATAL_ERROR("Mask for array \"" << array_name << "\" not computed."
                 " Failed to get the array collection with centering " << centering)
             return nullptr;
         }
@@ -306,7 +306,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
         p_teca_variant_array array = arrays->get(array_name);
         if (!array)
         {
-            TECA_ERROR("Mask for array \"" << array_name << "\" not computed."
+            TECA_FATAL_ERROR("Mask for array \"" << array_name << "\" not computed."
                 " No array named \"" << array_name << "\"")
             return nullptr;
         }

--- a/alg/teca_vertical_coordinate_transform.cxx
+++ b/alg/teca_vertical_coordinate_transform.cxx
@@ -127,7 +127,7 @@ teca_metadata teca_vertical_coordinate_transform::get_output_metadata(
     teca_metadata coords;
     if (out_md.get("coordinates", coords))
     {
-        TECA_ERROR("metadata issue, missing coordinate metadata")
+        TECA_FATAL_ERROR("metadata issue, missing coordinate metadata")
         return teca_metadata();
     }
 
@@ -135,7 +135,7 @@ teca_metadata teca_vertical_coordinate_transform::get_output_metadata(
     teca_metadata atrs;
     if (out_md.get("attributes", atrs))
     {
-        TECA_ERROR("failed to get array attributes")
+        TECA_FATAL_ERROR("failed to get array attributes")
         return teca_metadata();
     }
 
@@ -152,7 +152,7 @@ teca_metadata teca_vertical_coordinate_transform::get_output_metadata(
             teca_metadata ps_atts;
             if (atrs.get("PSFC", ps_atts))
             {
-                TECA_ERROR("failed to get PSFC attributes")
+                TECA_FATAL_ERROR("failed to get PSFC attributes")
                 return teca_metadata();
             }
             atrs.set("ZPDM", ps_atts);
@@ -161,7 +161,7 @@ teca_metadata teca_vertical_coordinate_transform::get_output_metadata(
         }
         default:
         {
-            TECA_ERROR("Invlaid mode " << this->mode)
+            TECA_FATAL_ERROR("Invlaid mode " << this->mode)
             return teca_metadata();
         }
     }
@@ -201,7 +201,7 @@ teca_vertical_coordinate_transform::get_upstream_request(
             break;
         }
         default:
-            TECA_ERROR("Invlaid mode " << this->mode)
+            TECA_FATAL_ERROR("Invlaid mode " << this->mode)
             return up_reqs;
     }
 
@@ -237,7 +237,7 @@ const_p_teca_dataset teca_vertical_coordinate_transform::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("teca_arakawa_c_grid is required")
+        TECA_FATAL_ERROR("teca_arakawa_c_grid is required")
         return nullptr;
     }
 
@@ -266,14 +266,14 @@ const_p_teca_dataset teca_vertical_coordinate_transform::execute(
             const_p_teca_variant_array pt = in_mesh->get_information_arrays()->get("P_TOP");
             if (!pt)
             {
-                TECA_ERROR("Failed to get P_TOP")
+                TECA_FATAL_ERROR("Failed to get P_TOP")
                 return nullptr;
             }
 
             const_p_teca_variant_array ps = in_mesh->get_cell_arrays()->get("PSFC");
             if (!ps)
             {
-                TECA_ERROR("Failed to get PSFC")
+                TECA_FATAL_ERROR("Failed to get PSFC")
                 return nullptr;
             }
 
@@ -323,7 +323,7 @@ const_p_teca_dataset teca_vertical_coordinate_transform::execute(
         }
         default:
         {
-            TECA_ERROR("Invlaid mode " << this->mode)
+            TECA_FATAL_ERROR("Invlaid mode " << this->mode)
             return nullptr;
         }
     }

--- a/alg/teca_vertical_reduction.cxx
+++ b/alg/teca_vertical_reduction.cxx
@@ -66,7 +66,7 @@ teca_metadata teca_vertical_reduction::get_output_metadata(
 
     if (this->derived_variables.empty())
     {
-        TECA_ERROR("A derived variable was not specififed")
+        TECA_FATAL_ERROR("A derived variable was not specififed")
         return teca_metadata();
     }
 
@@ -90,7 +90,7 @@ teca_metadata teca_vertical_reduction::get_output_metadata(
     unsigned long whole_extent[6] = {0};
     if (out_md.get("whole_extent", whole_extent, 6))
     {
-        TECA_ERROR("Metadata is missing whole_whole_extent")
+        TECA_FATAL_ERROR("Metadata is missing whole_whole_extent")
         return teca_metadata();
     }
 
@@ -132,7 +132,7 @@ std::vector<teca_metadata> teca_vertical_reduction::get_upstream_request(
     if (teca_coordinate_util::get_cartesian_mesh_extent(md,
         whole_extent, bounds))
     {
-        TECA_ERROR("Failed to get input data set extent")
+        TECA_FATAL_ERROR("Failed to get input data set extent")
         return up_reqs;
     }
 
@@ -167,7 +167,7 @@ std::vector<teca_metadata> teca_vertical_reduction::get_upstream_request(
     std::set<std::string> variables;
     if (md.get("variables", variables))
     {
-        TECA_ERROR("Metadata issue. variables is missing")
+        TECA_FATAL_ERROR("Metadata issue. variables is missing")
         return up_reqs;
     }
 
@@ -222,7 +222,7 @@ const_p_teca_dataset teca_vertical_reduction::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("teca_mesh is required")
+        TECA_FATAL_ERROR("teca_mesh is required")
         return nullptr;
     }
 

--- a/alg/teca_vorticity.cxx
+++ b/alg/teca_vorticity.cxx
@@ -254,14 +254,14 @@ std::vector<teca_metadata> teca_vorticity::get_upstream_request(
     std::string comp_0_var = this->get_component_0_variable(request);
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component 0 array was not specified")
+        TECA_FATAL_ERROR("component 0 array was not specified")
         return up_reqs;
     }
 
     std::string comp_1_var = this->get_component_1_variable(request);
     if (comp_1_var.empty())
     {
-        TECA_ERROR("component 0 array was not specified")
+        TECA_FATAL_ERROR("component 0 array was not specified")
         return up_reqs;
     }
 
@@ -305,7 +305,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("teca_cartesian_mesh is required")
+        TECA_FATAL_ERROR("teca_cartesian_mesh is required")
         return nullptr;
     }
 
@@ -314,7 +314,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (comp_0_var.empty())
     {
-        TECA_ERROR("component_0_variable was not specified")
+        TECA_FATAL_ERROR("component_0_variable was not specified")
         return nullptr;
     }
 
@@ -323,7 +323,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (!comp_0)
     {
-        TECA_ERROR("requested array \"" << comp_0_var << "\" not present.")
+        TECA_FATAL_ERROR("requested array \"" << comp_0_var << "\" not present.")
         return nullptr;
     }
 
@@ -332,7 +332,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (comp_1_var.empty())
     {
-        TECA_ERROR("component_1_variable was not specified")
+        TECA_FATAL_ERROR("component_1_variable was not specified")
         return nullptr;
     }
 
@@ -341,7 +341,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (!comp_1)
     {
-        TECA_ERROR("requested array \"" << comp_1_var << "\" not present.")
+        TECA_FATAL_ERROR("requested array \"" << comp_1_var << "\" not present.")
         return nullptr;
     }
 
@@ -351,7 +351,7 @@ const_p_teca_dataset teca_vorticity::execute(
 
     if (!lon || !lat)
     {
-        TECA_ERROR("lat lon mesh cooridinates not present.")
+        TECA_FATAL_ERROR("lat lon mesh cooridinates not present.")
         return nullptr;
     }
 

--- a/apps/teca_bayesian_ar_detect.cpp
+++ b/apps/teca_bayesian_ar_detect.cpp
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Only one of --compute_ivt and compute_ivt_magnitude can "
+            TECA_FATAL_ERROR("Only one of --compute_ivt and compute_ivt_magnitude can "
                 "be specified. --compute_ivt implies --compute_ivt_magnitude")
         }
         return -1;
@@ -573,7 +573,7 @@ int main(int argc, char **argv)
     if (!opt_vals["file_layout"].defaulted() &&
         cf_writer->set_layout(opt_vals["file_layout"].as<std::string>()))
     {
-        TECA_ERROR("An invalid file layout was provided \""
+        TECA_FATAL_ERROR("An invalid file layout was provided \""
             << opt_vals["file_layout"].as<std::string>() << "\"")
         return -1;
     }
@@ -594,7 +594,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("missing file name pattern for netcdf writer. "
+            TECA_FATAL_ERROR("missing file name pattern for netcdf writer. "
                 "See --help for a list of command line options.")
         }
         return -1;
@@ -612,7 +612,7 @@ int main(int argc, char **argv)
         teca_metadata atrs;
         if (md.get("attributes", atrs))
         {
-            TECA_ERROR("metadata missing attributes")
+            TECA_FATAL_ERROR("metadata missing attributes")
             return -1;
         }
 
@@ -623,7 +623,7 @@ int main(int argc, char **argv)
            || time_atts.get("calendar", calendar)
            || time_atts.get("units", units))
         {
-            TECA_ERROR("failed to determine the calendaring parameters")
+            TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
         p_teca_variant_array time;
         if (md.get("coordinates", coords) || !(time = coords.get("t")))
         {
-            TECA_ERROR("failed to determine time coordinate")
+            TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -643,7 +643,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, true, true, calendar,
                  units, start_date, first_step))
             {
-                TECA_ERROR("Failed to locate time step for start date \""
+                TECA_FATAL_ERROR("Failed to locate time step for start date \""
                     <<  start_date << "\"")
                 return -1;
             }
@@ -658,7 +658,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, false, true, calendar,
                  units, end_date, last_step))
             {
-                TECA_ERROR("Failed to locate time step for end date \""
+                TECA_FATAL_ERROR("Failed to locate time step for end date \""
                     <<  end_date << "\"")
                 return -1;
             }

--- a/apps/teca_cartesian_mesh_diff.cpp
+++ b/apps/teca_cartesian_mesh_diff.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     p_teca_algorithm test_reader = teca_cartesian_mesh_reader_factory::New(test_file);
     if (!test_reader)
     {
-        TECA_ERROR("the test file format was not recognized from \""
+        TECA_FATAL_ERROR("the test file format was not recognized from \""
             << test_file << "\"")
         return -1;
     }
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     if (!ref_reader && !ref_writer)
     {
-        TECA_ERROR("the refence file format was not recognized from \""
+        TECA_FATAL_ERROR("the refence file format was not recognized from \""
             << ref_file << "\"")
         return -1;
     }
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-           TECA_ERROR("Error parsing command line options. See --help "
+           TECA_FATAL_ERROR("Error parsing command line options. See --help "
                "for a list of supported options. " << e.what())
         }
         return -1;

--- a/apps/teca_cf_restripe.cpp
+++ b/apps/teca_cf_restripe.cpp
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
     if (!opt_vals["file_layout"].defaulted() &&
         cf_writer->set_layout(opt_vals["file_layout"].as<std::string>()))
     {
-        TECA_ERROR("An invalid file layout was provided \""
+        TECA_FATAL_ERROR("An invalid file layout was provided \""
             << opt_vals["file_layout"].as<std::string>() << "\"")
         return -1;
     }
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
         bounds = opt_vals["bounds"].as<std::vector<double>>();
         if (bounds.size() != 6)
         {
-            TECA_ERROR("An invlaid bounds specification was provided in"
+            TECA_FATAL_ERROR("An invlaid bounds specification was provided in"
                 " --bounds, size != 6. Use: --bounds x0 x1 y0 y1 z0 z1")
             return -1;
         }
@@ -267,14 +267,14 @@ int main(int argc, char **argv)
             dims = opt_vals["dims"].as<std::vector<unsigned long>>();
             if (dims.size() != 3)
             {
-                TECA_ERROR("An invlaid dimension specification was provided in"
+                TECA_FATAL_ERROR("An invlaid dimension specification was provided in"
                     " --dims, size != 3. Use: --dims nx ny nz")
                 return -1;
             }
         }
         else
         {
-            TECA_ERROR("The --regrid option requires that --dims"
+            TECA_FATAL_ERROR("The --regrid option requires that --dims"
                 " also be specified")
             return -1;
         }
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("missing file name pattern for the NetCDF CF writer. "
+            TECA_FATAL_ERROR("missing file name pattern for the NetCDF CF writer. "
                 "See --help for a list of command line options.")
         }
         return -1;
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
         // point centered arrrays
         if (atts.empty() && md.get("attributes", atts))
         {
-            TECA_ERROR("metadata missing attributes")
+            TECA_FATAL_ERROR("metadata missing attributes")
             return -1;
         }
 
@@ -381,7 +381,7 @@ int main(int argc, char **argv)
         if (atts.empty() && md.get("attributes", atts))
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("metadata missing attributes")
+                TECA_FATAL_ERROR("metadata missing attributes")
             return -1;
         }
 
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
            || time_atts.get("units", units))
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("failed to determine the calendaring parameters")
+                TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -399,7 +399,7 @@ int main(int argc, char **argv)
         if (md.get("coordinates", coords) || !(time = coords.get("t")))
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("failed to determine time coordinate")
+                TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
                  units, start_date, first_step))
             {
                 if (mpi_man.get_comm_rank() == 0)
-                    TECA_ERROR("Failed to locate time step for start date \""
+                    TECA_FATAL_ERROR("Failed to locate time step for start date \""
                         <<  start_date << "\"")
                 return -1;
             }
@@ -428,7 +428,7 @@ int main(int argc, char **argv)
                  units, end_date, last_step))
             {
                 if (mpi_man.get_comm_rank() == 0)
-                    TECA_ERROR("Failed to locate time step for end date \""
+                    TECA_FATAL_ERROR("Failed to locate time step for end date \""
                         <<  end_date << "\"")
                 return -1;
             }
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
             if (regrid_src->set_spatial_bounds(md))
             {
                 if (mpi_man.get_comm_rank() == 0)
-                    TECA_ERROR("Failed to determine target mesh bounds from the"
+                    TECA_FATAL_ERROR("Failed to determine target mesh bounds from the"
                         " input metadata. Use --bounds to specify them manually.")
                 return -1;
             }
@@ -497,7 +497,7 @@ int main(int argc, char **argv)
         if (!opt_vals.count("original_name"))
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("--original_name is required when renaming variables")
+                TECA_FATAL_ERROR("--original_name is required when renaming variables")
             return -1;
         }
 
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
         if (!opt_vals.count("new_name"))
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("--new_name is required when renaming variables")
+                TECA_FATAL_ERROR("--new_name is required when renaming variables")
             return -1;
         }
 
@@ -517,7 +517,7 @@ int main(int argc, char **argv)
         if (original_name.size() != new_name.size())
         {
             if (mpi_man.get_comm_rank() == 0)
-                TECA_ERROR("--original_name and --new_name must have the same"
+                TECA_FATAL_ERROR("--original_name and --new_name must have the same"
                     " number of values")
             return -1;
 

--- a/apps/teca_integrated_vapor_transport.cpp
+++ b/apps/teca_integrated_vapor_transport.cpp
@@ -262,7 +262,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("At least one of --write_ivt or --write_ivt_magnitude "
+            TECA_FATAL_ERROR("At least one of --write_ivt or --write_ivt_magnitude "
                 " must be set.")
         }
         return -1;
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
     if (!opt_vals["file_layout"].defaulted() &&
         cf_writer->set_layout(opt_vals["file_layout"].as<std::string>()))
     {
-        TECA_ERROR("An invalid file layout was provided \""
+        TECA_FATAL_ERROR("An invalid file layout was provided \""
             << opt_vals["file_layout"].as<std::string>() << "\"")
         return -1;
     }
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("missing file name pattern for netcdf writer. "
+            TECA_FATAL_ERROR("missing file name pattern for netcdf writer. "
                 "See --help for a list of command line options.")
         }
         return -1;
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
         teca_metadata atrs;
         if (md.get("attributes", atrs))
         {
-            TECA_ERROR("metadata missing attributes")
+            TECA_FATAL_ERROR("metadata missing attributes")
             return -1;
         }
 
@@ -499,7 +499,7 @@ int main(int argc, char **argv)
            || time_atts.get("calendar", calendar)
            || time_atts.get("units", units))
         {
-            TECA_ERROR("failed to determine the calendaring parameters")
+            TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
         p_teca_variant_array time;
         if (md.get("coordinates", coords) || !(time = coords.get("t")))
         {
-            TECA_ERROR("failed to determine time coordinate")
+            TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -519,7 +519,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, true, true, calendar,
                  units, start_date, first_step))
             {
-                TECA_ERROR("Failed to locate time step for start date \""
+                TECA_FATAL_ERROR("Failed to locate time step for start date \""
                     <<  start_date << "\"")
                 return -1;
             }
@@ -534,7 +534,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, false, true, calendar,
                  units, end_date, last_step))
             {
-                TECA_ERROR("Failed to locate time step for end date \""
+                TECA_FATAL_ERROR("Failed to locate time step for end date \""
                     <<  end_date << "\"")
                 return -1;
             }

--- a/apps/teca_integrated_water_vapor.cpp
+++ b/apps/teca_integrated_water_vapor.cpp
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
     if (!opt_vals["file_layout"].defaulted() &&
         cf_writer->set_layout(opt_vals["file_layout"].as<std::string>()))
     {
-        TECA_ERROR("An invalid file layout was provided \""
+        TECA_FATAL_ERROR("An invalid file layout was provided \""
             << opt_vals["file_layout"].as<std::string>() << "\"")
         return -1;
     }
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("missing file name pattern for netcdf writer. "
+            TECA_FATAL_ERROR("missing file name pattern for netcdf writer. "
                 "See --help for a list of command line options.")
         }
         return -1;
@@ -392,7 +392,7 @@ int main(int argc, char **argv)
         teca_metadata atrs;
         if (md.get("attributes", atrs))
         {
-            TECA_ERROR("metadata missing attributes")
+            TECA_FATAL_ERROR("metadata missing attributes")
             return -1;
         }
 
@@ -403,7 +403,7 @@ int main(int argc, char **argv)
            || time_atts.get("calendar", calendar)
            || time_atts.get("units", units))
         {
-            TECA_ERROR("failed to determine the calendaring parameters")
+            TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
         p_teca_variant_array time;
         if (md.get("coordinates", coords) || !(time = coords.get("t")))
         {
-            TECA_ERROR("failed to determine time coordinate")
+            TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -423,7 +423,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, true, true, calendar,
                  units, start_date, first_step))
             {
-                TECA_ERROR("Failed to locate time step for start date \""
+                TECA_FATAL_ERROR("Failed to locate time step for start date \""
                     <<  start_date << "\"")
                 return -1;
             }
@@ -438,7 +438,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, false, true, calendar,
                  units, end_date, last_step))
             {
-                TECA_ERROR("Failed to locate time step for end date \""
+                TECA_FATAL_ERROR("Failed to locate time step for end date \""
                     <<  end_date << "\"")
                 return -1;
             }

--- a/apps/teca_metadata_probe.cpp
+++ b/apps/teca_metadata_probe.cpp
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
     {
         if (rank == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (CMIP6 datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
         teca_metadata atrs;
         if (md.get("attributes", atrs))
         {
-            TECA_ERROR("metadata mising attributes")
+            TECA_FATAL_ERROR("metadata mising attributes")
             return -1;
         }
 
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
            || time_atts.get("calendar", calendar)
            || time_atts.get("units", units))
         {
-            TECA_ERROR("failed to determine the calendaring parameters")
+            TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
         p_teca_variant_array t;
         if (md.get("coordinates", coords) || !(t = coords.get("t")))
         {
-            TECA_ERROR("failed to determine time coordinate")
+            TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
         unsigned long n_time_steps = 0;
         if (md.get("number_of_time_steps", n_time_steps))
         {
-            TECA_ERROR("failed to deermine the number of steps")
+            TECA_FATAL_ERROR("failed to deermine the number of steps")
             return -1;
         }
 
@@ -262,11 +262,11 @@ int main(int argc, char **argv)
         if (teca_calcalcs::date(time->get(i0), &Y, &M, &D, &h, &m, &s,
             units.c_str(), calendar.c_str()))
         {
-            TECA_ERROR("failed to detmine the first available time in the file")
+            TECA_FATAL_ERROR("failed to detmine the first available time in the file")
             return -1;
         }
 #else
-        TECA_ERROR("UDUnits is required for human readable dates")
+        TECA_FATAL_ERROR("UDUnits is required for human readable dates")
 #endif
         std::ostringstream oss;
         oss << Y << "-" << M << "-" << D << " " << h << ":" << m << ":" << s;
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
         if (teca_calcalcs::date(time->get(i1), &Y, &M, &D, &h, &m, &s,
             units.c_str(), calendar.c_str()))
         {
-            TECA_ERROR("failed to detmine the last available time in the file")
+            TECA_FATAL_ERROR("failed to detmine the last available time in the file")
             return -1;
         }
 #endif
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(
                  time, true, true, calendar, units, time_i, i0))
             {
-                TECA_ERROR("Failed to locate time step for start date \""
+                TECA_FATAL_ERROR("Failed to locate time step for start date \""
                     << time_i << "\"")
                 return -1;
             }
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(
                  time, false, true, calendar, units, time_j, i1))
             {
-                TECA_ERROR("Failed to locate time step for end date \""
+                TECA_FATAL_ERROR("Failed to locate time step for end date \""
                     << time_j << "\"")
                 return -1;
             }
@@ -431,7 +431,7 @@ int main(int argc, char **argv)
                 || !(dim_names = std::dynamic_pointer_cast<teca_string_array>(atts.get("cf_dim_names"))))
             {
                 // TODO -- Michael's CAM5 sometimes triggers this with an empty array name
-                //TECA_ERROR("metadata issue in array " << i << "\"" << array << "\"")
+                //TECA_FATAL_ERROR("metadata issue in array " << i << "\"" << array << "\"")
                 continue;
             }
 

--- a/apps/teca_table_diff.cpp
+++ b/apps/teca_table_diff.cpp
@@ -44,13 +44,13 @@ int main(int argc, char **argv)
 
     if (!teca_file_util::file_exists(ref_file.c_str()))
     {
-        TECA_ERROR("no reference file to compare to");
+        TECA_FATAL_ERROR("no reference file to compare to");
         return -1;
     }
 
     if (!teca_file_util::file_exists(t_file.c_str()))
     {
-        TECA_ERROR("test file doesn't exist");
+        TECA_FATAL_ERROR("test file doesn't exist");
         return -1;
     }
 

--- a/apps/teca_tc_detect.cpp
+++ b/apps/teca_tc_detect.cpp
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -381,7 +381,7 @@ int main(int argc, char **argv)
     size_t n_var = core_temp->get_number_of_dependent_variables();
     if (n_var != 2)
     {
-        TECA_ERROR("core temperature calculation requires 2 "
+        TECA_FATAL_ERROR("core temperature calculation requires 2 "
             "variables. given " << n_var)
         return -1;
     }
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
     n_var = thickness->get_number_of_dependent_variables();
     if (n_var != 2)
     {
-        TECA_ERROR("thickness calculation requires 2 "
+        TECA_FATAL_ERROR("thickness calculation requires 2 "
             "variables. given " << n_var)
         return -1;
     }
@@ -421,7 +421,7 @@ int main(int argc, char **argv)
         teca_metadata atrs;
         if (md.get("attributes", atrs))
         {
-            TECA_ERROR("metadata mising attributes")
+            TECA_FATAL_ERROR("metadata mising attributes")
             return -1;
         }
 
@@ -432,7 +432,7 @@ int main(int argc, char **argv)
            || time_atts.get("calendar", calendar)
            || time_atts.get("units", units))
         {
-            TECA_ERROR("failed to determine the calendaring parameters")
+            TECA_FATAL_ERROR("failed to determine the calendaring parameters")
             return -1;
         }
 
@@ -440,7 +440,7 @@ int main(int argc, char **argv)
         p_teca_variant_array time;
         if (md.get("coordinates", coords) || !(time = coords.get("t")))
         {
-            TECA_ERROR("failed to determine time coordinate")
+            TECA_FATAL_ERROR("failed to determine time coordinate")
             return -1;
         }
 
@@ -452,7 +452,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, true, true, calendar,
                  units, start_date, first_step))
             {
-                TECA_ERROR("Failed to lcoate time step for start date \""
+                TECA_FATAL_ERROR("Failed to lcoate time step for start date \""
                     <<  start_date << "\"")
                 return -1;
             }
@@ -467,7 +467,7 @@ int main(int argc, char **argv)
             if (teca_coordinate_util::time_step_of(time, false, true, calendar,
                  units, end_date, last_step))
             {
-                TECA_ERROR("Failed to lcoate time step for end date \""
+                TECA_FATAL_ERROR("Failed to lcoate time step for end date \""
                     <<  end_date << "\"")
                 return -1;
             }

--- a/apps/teca_tc_trajectory.cpp
+++ b/apps/teca_tc_trajectory.cpp
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("missing file name for candidate reader. "
+            TECA_FATAL_ERROR("missing file name for candidate reader. "
                 "See --help for a list of command line options.")
         }
         return -1;

--- a/apps/teca_tc_wind_radii.cpp
+++ b/apps/teca_tc_wind_radii.cpp
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("A file with previously calculated storm tracks must be "
+            TECA_FATAL_ERROR("A file with previously calculated storm tracks must be "
                 "specified with --track_file")
         }
         return -1;
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
     {
         if (mpi_man.get_comm_rank() == 0)
         {
-            TECA_ERROR("Extacly one of --input_file or --input_regex can be specified. "
+            TECA_FATAL_ERROR("Extacly one of --input_file or --input_regex can be specified. "
                 "Use --input_file to activate the multi_cf_reader (HighResMIP datasets) "
                 "and --input_regex to activate the cf_reader (CAM like datasets)")
         }
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
         }
         else
         {
-            TECA_ERROR("invalid profile_type " << profile_type)
+            TECA_FATAL_ERROR("invalid profile_type " << profile_type)
             return -1;
         }
     }

--- a/core/teca_algorithm_executive.cxx
+++ b/core/teca_algorithm_executive.cxx
@@ -9,7 +9,7 @@ int teca_algorithm_executive::initialize(MPI_Comm comm, const teca_metadata &md)
     std::string request_key;
     if (md.get("index_request_key", request_key))
     {
-        TECA_ERROR("No index request key has been specified")
+        TECA_FATAL_ERROR("No index request key has been specified")
         return -1;
     }
 

--- a/core/teca_common.h
+++ b/core/teca_common.h
@@ -117,15 +117,25 @@ _strm                                                                   \
     << BEGIN_HL(_head_color) << _head << END_HL << " "                  \
     << BEGIN_HL(ANSI_WHITE) << "" _msg << END_HL << std::endl;
 
+/// Send a message into the stream that include MPI ranks and thread id.
+#define TECA_MESSAGE_RAW(_strm, _head, _msg)                            \
+_strm                                                                   \
+    << _head << " " << teca_parallel_id() << " [" << __FILE__           \
+    << ":" << __LINE__ << " " << TECA_VERSION_DESCR << "]" << std::endl \
+    << _head << " " << "" _msg << std::endl;
+
 /** Constructs an the error message using TECA_MESSAGE and invokes the
  * error handler.
  */
-#define TECA_ERROR(_msg)                                                \
+#define TECA_FATAL_ERROR(_msg)                                          \
 {                                                                       \
     std::ostringstream ess;                                             \
     TECA_MESSAGE(ess, "ERROR:", ANSI_RED, _msg)                         \
     teca_error::error_handler(ess.str().c_str());                       \
 }
+
+/// Constructs an error message and sends it to the stderr stream
+#define TECA_ERROR(_msg) TECA_MESSAGE(std::cerr, "ERROR:", ANSI_RED, _msg)
 
 /// Constructs a warning message and sends it to the stderr stream
 #define TECA_WARNING(_msg) TECA_MESSAGE(std::cerr, "WARNING:", ANSI_YELLOW, _msg)

--- a/core/teca_dataset_source.cxx
+++ b/core/teca_dataset_source.cxx
@@ -85,7 +85,7 @@ const_p_teca_dataset teca_dataset_source::execute(unsigned int port,
     {
         if (this->metadata.get("index_request_key", request_key))
         {
-            TECA_ERROR("The provided metadata is missing index_request_key")
+            TECA_FATAL_ERROR("The provided metadata is missing index_request_key")
             return nullptr;
         }
     }
@@ -94,14 +94,14 @@ const_p_teca_dataset teca_dataset_source::execute(unsigned int port,
     unsigned long index = 0;
     if (request.get(request_key, index))
     {
-        TECA_ERROR("Request is missing index_request_key \"" << request_key << "\"")
+        TECA_FATAL_ERROR("Request is missing index_request_key \"" << request_key << "\"")
         return nullptr;
     }
 
     unsigned long num_datasets = this->datasets.size();
     if (index >= num_datasets)
     {
-        TECA_ERROR("No " << request_key << " index " << index << " in collection of "
+        TECA_FATAL_ERROR("No " << request_key << " index " << index << " in collection of "
             << num_datasets << " source datasets")
         return nullptr;
     }

--- a/core/teca_index_executive.cxx
+++ b/core/teca_index_executive.cxx
@@ -82,13 +82,13 @@ int teca_index_executive::initialize(MPI_Comm comm, const teca_metadata &md)
     // requests we need to make and what key to use
     if (md.get("index_initializer_key", this->index_initializer_key))
     {
-        TECA_ERROR("No index initializer key has been specified")
+        TECA_FATAL_ERROR("No index initializer key has been specified")
         return -1;
     }
 
     if (md.get("index_request_key", this->index_request_key))
     {
-        TECA_ERROR("No index request key has been specified")
+        TECA_FATAL_ERROR("No index request key has been specified")
         return -1;
     }
 
@@ -96,7 +96,7 @@ int teca_index_executive::initialize(MPI_Comm comm, const teca_metadata &md)
     long n_indices = 0;
     if (md.get(this->index_initializer_key, n_indices))
     {
-        TECA_ERROR("metadata is missing the initializer key \""
+        TECA_FATAL_ERROR("metadata is missing the initializer key \""
             << this->index_initializer_key << "\"")
         return -1;
     }

--- a/core/teca_index_reduce.cxx
+++ b/core/teca_index_reduce.cxx
@@ -190,14 +190,14 @@ std::vector<teca_metadata> teca_index_reduce::get_upstream_request(
     std::string initializer_key;
     if (md.get("index_initializer_key", initializer_key))
     {
-        TECA_ERROR("No index initializer key has been specified")
+        TECA_FATAL_ERROR("No index initializer key has been specified")
         return up_req;
     }
 
     std::string request_key;
     if (md.get("index_request_key", request_key))
     {
-        TECA_ERROR("No index request key has been specified")
+        TECA_FATAL_ERROR("No index request key has been specified")
         return up_req;
     }
 
@@ -205,7 +205,7 @@ std::vector<teca_metadata> teca_index_reduce::get_upstream_request(
     long n_indeces = 0;
     if (md.get(initializer_key, n_indeces))
     {
-        TECA_ERROR("metadata is missing index initializer key")
+        TECA_FATAL_ERROR("metadata is missing index initializer key")
         return up_req;
     }
 

--- a/core/teca_programmable_reduce.cxx
+++ b/core/teca_programmable_reduce.cxx
@@ -79,7 +79,7 @@ p_teca_dataset teca_programmable_reduce::reduce(
 
     if (!this->reduce_callback)
     {
-        TECA_ERROR("a reduce callback has not been provided")
+        TECA_FATAL_ERROR("a reduce callback has not been provided")
         return nullptr;
     }
 

--- a/io/teca_array_collection_reader.cxx
+++ b/io/teca_array_collection_reader.cxx
@@ -238,7 +238,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
 
         if ((rank == 0) && !time_axis_data)
         {
-            TECA_ERROR("Failed to read the time axis")
+            TECA_FATAL_ERROR("Failed to read the time axis")
             return teca_metadata();
         }
     }
@@ -269,7 +269,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
 
         if (n_files == 0)
         {
-            TECA_ERROR("No files found")
+            TECA_FATAL_ERROR("No files found")
             return teca_metadata();
         }
 
@@ -280,7 +280,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
         teca_netcdf_util::netcdf_handle fh;
         if (fh.open(file.c_str(), NC_NOWRITE))
         {
-            TECA_ERROR("Failed to open " << file << std::endl << nc_strerror(ierr))
+            TECA_FATAL_ERROR("Failed to open " << file << std::endl << nc_strerror(ierr))
             return teca_metadata();
         }
 
@@ -295,7 +295,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
         if (((ierr = nc_inq_nvars(fh.get(), &n_vars)) != NC_NOERR))
         {
             this->clear_cached_metadata();
-            TECA_ERROR(
+            TECA_FATAL_ERROR(
                 << "Failed to get the number of variables in file \""
                 << file << "\"" << std::endl
                 << nc_strerror(ierr))
@@ -312,7 +312,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 "", "", "", t_axis_variable, 0, name, atts))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR("Failed to read " << i <<"th variable attributes")
+                TECA_FATAL_ERROR("Failed to read " << i <<"th variable attributes")
                 return teca_metadata();
             }
 
@@ -405,7 +405,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
             const_p_teca_variant_array t0 = teca_cf_time_axis_data::get_variant_array(elem_0);
             if (!t0)
             {
-                TECA_ERROR("Failed to read time axis")
+                TECA_FATAL_ERROR("Failed to read time axis")
                 return teca_metadata();
             }
             t_axis = t0->new_instance();
@@ -418,7 +418,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 const_p_teca_variant_array t_i = teca_cf_time_axis_data::get_variant_array(elem_i);
                 if (!t_i || !t_i->size())
                 {
-                    TECA_ERROR("File " << i << " \"" << files[i]
+                    TECA_FATAL_ERROR("File " << i << " \"" << files[i]
                         << "\" had no time values")
                     return teca_metadata();
                 }
@@ -430,7 +430,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 if (this->calendar.empty() && (has_calendar || !calendar_i.empty())
                     && (calendar_i != base_calendar))
                 {
-                    TECA_ERROR("The base calendar is \"" << base_calendar
+                    TECA_FATAL_ERROR("The base calendar is \"" << base_calendar
                         << "\" but file " << i << " \"" << files[i]
                         << "\" has the \"" << calendar_i <<  "\" calendar")
                     return teca_metadata();
@@ -461,7 +461,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                     // if there are no units present then we can not do a conversion
                     if (!has_units)
                     {
-                        TECA_ERROR("Calendaring conversion requires time units")
+                        TECA_FATAL_ERROR("Calendaring conversion requires time units")
                         return teca_metadata();
                     }
 
@@ -487,7 +487,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                             if (teca_calcalcs::date(double(p_ti[j]), &YY, &MM, &DD, &hh, &mm, &ss,
                                 units_i.c_str(), base_calendar.c_str()))
                             {
-                                TECA_ERROR("Failed to convert offset ti[" << j << "] = "
+                                TECA_FATAL_ERROR("Failed to convert offset ti[" << j << "] = "
                                     << p_ti[j] << " calendar \"" << base_calendar
                                     << "\" units \"" << units_i << "\" to time")
                                 return teca_metadata();
@@ -498,7 +498,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                             if (teca_calcalcs::coordinate(YY, MM, DD, hh, mm, ss,
                                 base_units.c_str(), base_calendar.c_str(), &offs))
                             {
-                                TECA_ERROR("Failed to convert time "
+                                TECA_FATAL_ERROR("Failed to convert time "
                                     << YY << "-" << MM << "-" << DD << " " << hh << ":"
                                     << mm << ":" << ss << " to offset in calendar \""
                                     << base_calendar << "\" units \"" << base_units
@@ -528,7 +528,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 size_t n_t_vals = this->t_values.size();
                 if (n_t_vals != t_axis->size())
                 {
-                    TECA_ERROR("Number of timesteps detected doesn't match "
+                    TECA_FATAL_ERROR("Number of timesteps detected doesn't match "
                         "the number of time values provided; " << n_t_vals
                         << " given, " << t_axis->size() << " are necessary.")
                     return teca_metadata();
@@ -547,7 +547,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
 
             if (this->calendar.empty() || this->t_units.empty())
             {
-                TECA_ERROR("The calendar and units must to be specified when "
+                TECA_FATAL_ERROR("The calendar and units must to be specified when "
                     " providing time values")
                 return teca_metadata();
             }
@@ -556,7 +556,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
             size_t n_t_vals = this->t_values.size();
             if (n_t_vals != files.size())
             {
-                TECA_ERROR("Number of files choosen doesn't match the"
+                TECA_FATAL_ERROR("Number of files choosen doesn't match the"
                     " number of time values provided; " << n_t_vals <<
                     " given, " << files.size() << " detected.")
                 return teca_metadata();
@@ -616,7 +616,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 // check whether the conversion failed
                 if(ss.fail())
                 {
-                    TECA_ERROR("Failed to infer time from filename \"" <<
+                    TECA_FATAL_ERROR("Failed to infer time from filename \"" <<
                         files[i] << "\" using format \"" <<
                         this->filename_time_template << "\"")
                     return teca_metadata();
@@ -634,7 +634,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                     if (strftime(tmp, sizeof(tmp), t_units_fmt.c_str(),
                           &current_tm) == 0)
                     {
-                        TECA_ERROR(
+                        TECA_FATAL_ERROR(
                             "failed to convert the time as a string with \""
                             << t_units_fmt << "\"")
                         return teca_metadata();
@@ -654,14 +654,14 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 if (teca_calcalcs::coordinate(year, mon, day, hour, minute,
                     second, t_units.c_str(), calendar.c_str(), &current_time))
                 {
-                    TECA_ERROR("conversion of date inferred from "
+                    TECA_FATAL_ERROR("conversion of date inferred from "
                         "filename failed");
                     return teca_metadata();
                 }
                 // add the current time to the list
                 t_values.push_back(current_time);
 #else
-                TECA_ERROR("The UDUnits package is required for this operation")
+                TECA_FATAL_ERROR("The UDUnits package is required for this operation")
                 return teca_metadata();
 #endif
             }
@@ -788,14 +788,14 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     teca_metadata coords;
     if (this->internals->metadata.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return nullptr;
     }
 
     p_teca_variant_array in_t;
     if (!(in_t = coords.get("t")))
     {
-        TECA_ERROR("metadata is missing coordinate arrays")
+        TECA_FATAL_ERROR("metadata is missing coordinate arrays")
         return nullptr;
     }
 
@@ -819,7 +819,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))
             {
-                TECA_ERROR("requested time " << t << " not found")
+                TECA_FATAL_ERROR("requested time " << t << " not found")
                 return nullptr;
             }
             )
@@ -835,7 +835,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
         }
         else if ((in_t) && in_t->size() != 1)
         {
-            TECA_ERROR("Invalid time step " << time_step
+            TECA_FATAL_ERROR("Invalid time step " << time_step
                 << " requested from data set with " << in_t->size()
                 << " steps")
             return nullptr;
@@ -852,7 +852,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     std::vector<unsigned long> step_count;
     if (this->internals->metadata.get("step_count", step_count))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata is missing \"step_count\"")
         return nullptr;
     }
@@ -872,7 +872,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     if (this->internals->metadata.get("root", path)
         || this->internals->metadata.get("files", idx, file))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " Failed to locate file for time step " << time_step)
         return nullptr;
     }
@@ -883,7 +883,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     teca_netcdf_util::netcdf_handle fh;
     if (fh.open(file_path, NC_NOWRITE))
     {
-        TECA_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
+        TECA_FATAL_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
         return nullptr;
     }
     int file_id = fh.get();
@@ -898,7 +898,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     teca_metadata atrs;
     if (this->internals->metadata.get("attributes", atrs))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata missing \"attributes\"")
         return nullptr;
     }
@@ -951,7 +951,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
             || atts.get("have_mesh_dim", have_mesh_dim, 4)
             || atts.get("mesh_dim_active", mesh_dim_active, 4))
         {
-            TECA_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
+            TECA_FATAL_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
             continue;
         }
 
@@ -998,7 +998,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
 #endif
             if ((ierr = nc_get_vara(file_id,  id, &starts[0], &counts[0], a->get())) != NC_NOERR)
             {
-                TECA_ERROR("time_step=" << time_step
+                TECA_FATAL_ERROR("time_step=" << time_step
                     << " Failed to read variable \"" << arrays[i] << "\" "
                     << file << std::endl << nc_strerror(ierr))
                 continue;

--- a/io/teca_cartesian_mesh_reader.cxx
+++ b/io/teca_cartesian_mesh_reader.cxx
@@ -154,7 +154,7 @@ teca_metadata teca_cartesian_mesh_reader::get_output_metadata(unsigned int port,
         if (!(this->internals->mesh =
             teca_cartesian_mesh_reader_internals::read_cartesian_mesh(this->file_name)))
         {
-            TECA_ERROR("Failed to read the mesh from \"" << this->file_name << "\"")
+            TECA_FATAL_ERROR("Failed to read the mesh from \"" << this->file_name << "\"")
             return teca_metadata();
         }
     }

--- a/io/teca_cartesian_mesh_writer.cxx
+++ b/io/teca_cartesian_mesh_writer.cxx
@@ -731,7 +731,7 @@ const_p_teca_dataset teca_cartesian_mesh_writer::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("empty input")
+            TECA_FATAL_ERROR("empty input")
         }
         return nullptr;
     }
@@ -741,14 +741,14 @@ const_p_teca_dataset teca_cartesian_mesh_writer::execute(
     std::string index_request_key;
     if (md.get("index_request_key", index_request_key))
     {
-        TECA_ERROR("Dataset metadata is missing the index_request_key key")
+        TECA_FATAL_ERROR("Dataset metadata is missing the index_request_key key")
         return nullptr;
     }
 
     unsigned long index = 0;
     if (md.get(index_request_key, index))
     {
-        TECA_ERROR("Dataset metadata is missing the \""
+        TECA_FATAL_ERROR("Dataset metadata is missing the \""
             << index_request_key << "\" key")
         return nullptr;
     }
@@ -757,7 +757,7 @@ const_p_teca_dataset teca_cartesian_mesh_writer::execute(
     if (mesh->get_time(time) &&
         request.get("time", time))
     {
-        TECA_ERROR("request missing \"time\"")
+        TECA_FATAL_ERROR("request missing \"time\"")
         return nullptr;
     }
 
@@ -771,7 +771,7 @@ const_p_teca_dataset teca_cartesian_mesh_writer::execute(
         if (out_file.rfind(".vtr") != std::string::npos)
         {
 #if !defined(TECA_HAS_VTK) || !defined(TECA_HAS_PARAVIEW)
-            TECA_ERROR("writing to vtr format requires VTK or ParaView")
+            TECA_FATAL_ERROR("writing to vtr format requires VTK or ParaView")
             return nullptr;
 #else
             fmt = format_vtr;
@@ -808,7 +808,7 @@ const_p_teca_dataset teca_cartesian_mesh_writer::execute(
             internals::write_vtr(mesh, this->file_name, index, time, this->binary);
             break;
         default:
-            TECA_ERROR("Invalid output format")
+            TECA_FATAL_ERROR("Invalid output format")
             return nullptr;
     }
 

--- a/io/teca_cf_reader.cxx
+++ b/io/teca_cf_reader.cxx
@@ -267,7 +267,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
         if ((rank == 0) && !time_axis_data)
         {
-            TECA_ERROR("Failed to read the time axis")
+            TECA_FATAL_ERROR("Failed to read the time axis")
             return teca_metadata();
         }
     }
@@ -298,7 +298,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
         if (n_files == 0)
         {
-            TECA_ERROR("No files found")
+            TECA_FATAL_ERROR("No files found")
             return teca_metadata();
         }
 
@@ -309,7 +309,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
         teca_netcdf_util::netcdf_handle fh;
         if (fh.open(file.c_str(), NC_NOWRITE))
         {
-            TECA_ERROR("Failed to open " << file << endl << nc_strerror(ierr))
+            TECA_FATAL_ERROR("Failed to open " << file << endl << nc_strerror(ierr))
             return teca_metadata();
         }
 
@@ -324,7 +324,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
         if (((ierr = nc_inq_nvars(fh.get(), &n_vars)) != NC_NOERR))
         {
             this->clear_cached_metadata();
-            TECA_ERROR(
+            TECA_FATAL_ERROR(
                 << "Failed to get the number of variables in file \""
                 << file << "\"" << endl
                 << nc_strerror(ierr))
@@ -344,7 +344,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 this->clamp_dimensions_of_one, name, atts))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to read " << i <<"th variable attributes")
                 return teca_metadata();
             }
@@ -369,7 +369,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
             x_atts.get("cf_id", x_id))
         {
             this->clear_cached_metadata();
-            TECA_ERROR(
+            TECA_FATAL_ERROR(
                 << "Failed to get the attributes for x-axis variable \""
                 << x_axis_variable << "\"")
             return teca_metadata();
@@ -385,7 +385,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
             if ((ierr = nc_get_vara(fh.get(), x_id, &x_0, &n_x, x->get())) != NC_NOERR)
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to read x axis, " << x_axis_variable << endl
                     << file << endl << nc_strerror(ierr))
                 return teca_metadata();
@@ -428,7 +428,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 y_atts.get("cf_id", y_id))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to get the attributes for y-axis variable \""
                     << y_axis_variable << "\"")
                 return teca_metadata();
@@ -444,7 +444,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 if ((ierr = nc_get_vara(fh.get(), y_id, &y_0, &n_y, y->get())) != NC_NOERR)
                 {
                     this->clear_cached_metadata();
-                    TECA_ERROR(
+                    TECA_FATAL_ERROR(
                         << "Failed to read y axis, " << y_axis_variable << endl
                         << file << endl << nc_strerror(ierr))
                     return teca_metadata();
@@ -496,7 +496,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 z_atts.get("cf_id", z_id))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to get the attributes for z-axis variable \""
                     << z_axis_variable << "\"")
                 return teca_metadata();
@@ -512,7 +512,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 if ((ierr = nc_get_vara(fh.get(), z_id, &z_0, &n_z, z->get())) != NC_NOERR)
                 {
                     this->clear_cached_metadata();
-                    TECA_ERROR(
+                    TECA_FATAL_ERROR(
                         << "Failed to read z axis, " << z_axis_variable << endl
                         << file << endl << nc_strerror(ierr))
                     return teca_metadata();
@@ -636,7 +636,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
             const_p_teca_variant_array t0 = teca_cf_time_axis_data::get_variant_array(elem_0);
             if (!t0)
             {
-                TECA_ERROR("Failed to read time axis")
+                TECA_FATAL_ERROR("Failed to read time axis")
                 return teca_metadata();
             }
             t_axis = t0->new_instance();
@@ -649,7 +649,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 const_p_teca_variant_array t_i = teca_cf_time_axis_data::get_variant_array(elem_i);
                 if (!t_i || !t_i->size())
                 {
-                    TECA_ERROR("File " << i << " \"" << files[i]
+                    TECA_FATAL_ERROR("File " << i << " \"" << files[i]
                         << "\" had no time values")
                     return teca_metadata();
                 }
@@ -661,7 +661,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 if (this->calendar.empty() && (has_calendar || !calendar_i.empty())
                     && (calendar_i != base_calendar))
                 {
-                    TECA_ERROR("The base calendar is \"" << base_calendar
+                    TECA_FATAL_ERROR("The base calendar is \"" << base_calendar
                         << "\" but file " << i << " \"" << files[i]
                         << "\" has the \"" << calendar_i <<  "\" calendar")
                     return teca_metadata();
@@ -692,7 +692,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                     // if there are no units present then we can not do a conversion
                     if (!has_units)
                     {
-                        TECA_ERROR("Calendaring conversion requires time units")
+                        TECA_FATAL_ERROR("Calendaring conversion requires time units")
                         return teca_metadata();
                     }
 
@@ -718,7 +718,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                             if (teca_calcalcs::date(double(p_ti[j]), &YY, &MM, &DD, &hh, &mm, &ss,
                                 units_i.c_str(), base_calendar.c_str()))
                             {
-                                TECA_ERROR("Failed to convert offset ti[" << j << "] = "
+                                TECA_FATAL_ERROR("Failed to convert offset ti[" << j << "] = "
                                     << p_ti[j] << " calendar \"" << base_calendar
                                     << "\" units \"" << units_i << "\" to time")
                                 return teca_metadata();
@@ -729,7 +729,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                             if (teca_calcalcs::coordinate(YY, MM, DD, hh, mm, ss,
                                 base_units.c_str(), base_calendar.c_str(), &offs))
                             {
-                                TECA_ERROR("Failed to convert time "
+                                TECA_FATAL_ERROR("Failed to convert time "
                                     << YY << "-" << MM << "-" << DD << " " << hh << ":"
                                     << mm << ":" << ss << " to offset in calendar \""
                                     << base_calendar << "\" units \"" << base_units
@@ -759,7 +759,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 size_t n_t_vals = this->t_values.size();
                 if (n_t_vals != t_axis->size())
                 {
-                    TECA_ERROR("Number of timesteps detected doesn't match "
+                    TECA_FATAL_ERROR("Number of timesteps detected doesn't match "
                         "the number of time values provided; " << n_t_vals
                         << " given, " << t_axis->size() << " are necessary.")
                     return teca_metadata();
@@ -778,7 +778,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
             if (this->calendar.empty() || this->t_units.empty())
             {
-                TECA_ERROR("The calendar and units must to be specified when "
+                TECA_FATAL_ERROR("The calendar and units must to be specified when "
                     " providing time values")
                 return teca_metadata();
             }
@@ -787,7 +787,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
             size_t n_t_vals = this->t_values.size();
             if (n_t_vals != files.size())
             {
-                TECA_ERROR("Number of files choosen doesn't match the"
+                TECA_FATAL_ERROR("Number of files choosen doesn't match the"
                     " number of time values provided; " << n_t_vals <<
                     " given, " << files.size() << " detected.")
                 return teca_metadata();
@@ -836,7 +836,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
                 if (!strptime(files[i].c_str(), this->filename_time_template.c_str(), &current_tm))
                 {
-                    TECA_ERROR("Failed to infer time from filename \"" <<
+                    TECA_FATAL_ERROR("Failed to infer time from filename \"" <<
                         files[i] << "\" using format \"" <<
                         this->filename_time_template << "\"")
                     return teca_metadata();
@@ -854,7 +854,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                     if (strftime(tmp, sizeof(tmp), t_units_fmt.c_str(),
                           &current_tm) == 0)
                     {
-                        TECA_ERROR(
+                        TECA_FATAL_ERROR(
                             "failed to convert the time as a string with \""
                             << t_units_fmt << "\"")
                         return teca_metadata();
@@ -874,14 +874,14 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 if (teca_calcalcs::coordinate(year, mon, day, hour, minute,
                     second, t_units.c_str(), calendar.c_str(), &current_time))
                 {
-                    TECA_ERROR("conversion of date inferred from "
+                    TECA_FATAL_ERROR("conversion of date inferred from "
                         "filename failed");
                     return teca_metadata();
                 }
                 // add the current time to the list
                 t_values.push_back(current_time);
 #else
-                TECA_ERROR("The UDUnits package is required for this operation")
+                TECA_FATAL_ERROR("The UDUnits package is required for this operation")
                 return teca_metadata();
 #endif
             }
@@ -1022,7 +1022,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     teca_metadata coords;
     if (this->internals->metadata.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return nullptr;
     }
 
@@ -1030,7 +1030,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     if (!(in_x = coords.get("x")) || !(in_y = coords.get("y"))
         || !(in_z = coords.get("z")) || !(in_t = coords.get("t")))
     {
-        TECA_ERROR("metadata is missing coordinate arrays")
+        TECA_FATAL_ERROR("metadata is missing coordinate arrays")
         return nullptr;
     }
 
@@ -1065,7 +1065,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))
             {
-                TECA_ERROR("requested time " << t << " not found")
+                TECA_FATAL_ERROR("requested time " << t << " not found")
                 return nullptr;
             }
             )
@@ -1081,7 +1081,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         }
         else if ((in_t) && in_t->size() != 1)
         {
-            TECA_ERROR("Invalid time step " << time_step
+            TECA_FATAL_ERROR("Invalid time step " << time_step
                 << " requested from data set with " << in_t->size()
                 << " steps")
             return nullptr;
@@ -1091,7 +1091,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     unsigned long whole_extent[6] = {0};
     if (this->internals->metadata.get("whole_extent", whole_extent, 6))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata is missing \"whole_extent\"")
         return nullptr;
     }
@@ -1120,7 +1120,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
             if (teca_coordinate_util::validate_extent(nx_max,
                 ny_max, nz_max, extent, true))
             {
-                TECA_ERROR("An invalid extent [" << extent
+                TECA_FATAL_ERROR("An invalid extent [" << extent
                     << "] was requested. The available extent is [0, "
                     << nx_max << ", 0, " << ny_max << ", 0, " << nz_max
                     << "]")
@@ -1143,7 +1143,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         if (teca_coordinate_util::bounds_to_extent(
             bounds, in_x, in_y, in_z, extent))
         {
-            TECA_ERROR("invalid bounds requested.")
+            TECA_FATAL_ERROR("invalid bounds requested.")
             return nullptr;
         }
 
@@ -1159,7 +1159,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         if (teca_coordinate_util::validate_extent(nx_max,
             ny_max, nz_max, extent, true))
         {
-            TECA_ERROR("An invalid extent [" << extent
+            TECA_FATAL_ERROR("An invalid extent [" << extent
                 << "] was requested. The available extent is [0, "
                 << nx_max << ", 0, " << ny_max << ", 0, " << nz_max
                 << "]")
@@ -1182,7 +1182,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     std::vector<unsigned long> step_count;
     if (this->internals->metadata.get("step_count", step_count))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata is missing \"step_count\"")
         return nullptr;
     }
@@ -1202,7 +1202,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     if (this->internals->metadata.get("root", path)
         || this->internals->metadata.get("files", idx, file))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " Failed to locate file for time step " << time_step)
         return nullptr;
     }
@@ -1213,7 +1213,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     teca_netcdf_util::netcdf_handle fh;
     if (fh.open(file_path, NC_NOWRITE))
     {
-        TECA_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
+        TECA_FATAL_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
         return nullptr;
     }
     int file_id = fh.get();
@@ -1236,7 +1236,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     teca_metadata atrs;
     if (this->internals->metadata.get("attributes", atrs))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata missing \"attributes\"")
         return nullptr;
     }
@@ -1295,7 +1295,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
             || atts.get("have_mesh_dim", have_mesh_dim, 4)
             || atts.get("mesh_dim_active", mesh_dim_active, 4))
         {
-            TECA_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
+            TECA_FATAL_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
             continue;
         }
 
@@ -1393,7 +1393,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         }
         else
         {
-            TECA_ERROR("Invalid centering can't read \"" << arrays[i] << "\"")
+            TECA_FATAL_ERROR("Invalid centering can't read \"" << arrays[i] << "\"")
             continue;
         }
 
@@ -1407,7 +1407,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
 #endif
             if ((ierr = nc_get_vara(file_id,  id, &starts[0], &counts[0], a->get())) != NC_NOERR)
             {
-                TECA_ERROR("time_step=" << time_step
+                TECA_FATAL_ERROR("time_step=" << time_step
                     << " Failed to read variable \"" << arrays[i] << "\" "
                     << file << endl << nc_strerror(ierr))
                 continue;

--- a/io/teca_cf_time_axis_reader.cxx
+++ b/io/teca_cf_time_axis_reader.cxx
@@ -70,7 +70,7 @@ teca_metadata teca_cf_time_axis_reader::get_output_metadata(unsigned int,
 
                 if (teca_file_util::locate_files(tmp_path, regex, tmp_files))
                 {
-                    TECA_ERROR(
+                    TECA_FATAL_ERROR(
                         << "Failed to locate any files" << std::endl
                         << this->files_regex << std::endl
                         << tmp_path << std::endl
@@ -118,7 +118,7 @@ const_p_teca_dataset teca_cf_time_axis_reader::execute(unsigned int,
     unsigned long file_id = 0;
     if (request.get("file_id", file_id))
     {
-        TECA_ERROR("Invalid file_id " << file_id)
+        TECA_FATAL_ERROR("Invalid file_id " << file_id)
         return nullptr;
     }
 

--- a/io/teca_cf_writer.cxx
+++ b/io/teca_cf_writer.cxx
@@ -207,7 +207,7 @@ teca_metadata teca_cf_writer::get_output_metadata(unsigned int port,
     std::string up_initializer_key;
     if (md_in.get("index_initializer_key", up_initializer_key))
     {
-        TECA_ERROR("Failed to locate index_initializer_key")
+        TECA_FATAL_ERROR("Failed to locate index_initializer_key")
         return teca_metadata();
     }
 
@@ -243,21 +243,21 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
     std::string up_initializer_key;
     if (md_in.get("index_initializer_key", up_initializer_key))
     {
-        TECA_ERROR("Failed to locate index_initializer_key")
+        TECA_FATAL_ERROR("Failed to locate index_initializer_key")
         return up_reqs;
     }
 
     std::string up_request_key;
     if (md_in.get("index_request_key", up_request_key))
     {
-        TECA_ERROR("Failed to locate index_request_key")
+        TECA_FATAL_ERROR("Failed to locate index_request_key")
         return up_reqs;
     }
 
     long n_indices_up = 0;
     if (md_in.get(up_initializer_key, n_indices_up))
     {
-        TECA_ERROR("Missing index initializer \"" << up_initializer_key << "\"")
+        TECA_FATAL_ERROR("Missing index initializer \"" << up_initializer_key << "\"")
         return up_reqs;
     }
 
@@ -265,7 +265,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
     if ((this->point_arrays.size() == 0) &&
         (this->information_arrays.size() == 0))
     {
-        TECA_ERROR("The arrays to write have not been specified")
+        TECA_FATAL_ERROR("The arrays to write have not been specified")
         return up_reqs;
     }
 
@@ -284,7 +284,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
             {
                 if (md_in.get("whole_extent", extent, 6))
                 {
-                    TECA_ERROR("Failed to determine extent to write")
+                    TECA_FATAL_ERROR("Failed to determine extent to write")
                     return up_reqs;
                 }
             }
@@ -296,7 +296,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
         {
             if (md_in.get("whole_extent", extent, 6))
             {
-                TECA_ERROR("Failed to determine extent to write")
+                TECA_FATAL_ERROR("Failed to determine extent to write")
                 return up_reqs;
             }
         }
@@ -312,7 +312,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
         if (bmap->initialize(comm, this->first_step,
             this->last_step, this->steps_per_file, md_in))
         {
-            TECA_ERROR("Failed to initialize the block mapper")
+            TECA_FATAL_ERROR("Failed to initialize the block mapper")
             return up_reqs;
         }
 
@@ -326,7 +326,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
 
         if (!it)
         {
-            TECA_ERROR("Failed to create an iterator for layout "
+            TECA_FATAL_ERROR("Failed to create an iterator for layout "
                 <<  this->layout)
             return up_reqs;
         }
@@ -338,7 +338,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
         if (imap->initialize(comm,
             this->first_step, this->last_step, it, md_in))
         {
-            TECA_ERROR("Failed to initialize the interval mapper")
+            TECA_FATAL_ERROR("Failed to initialize the interval mapper")
             return up_reqs;
         }
 
@@ -358,7 +358,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
             if (layout_mgr->create(this->file_name, this->date_format, md_in,
                 this->mode_flags, this->use_unlimited_dim))
             {
-                TECA_ERROR("Failed to create file " << file_id)
+                TECA_FATAL_ERROR("Failed to create file " << file_id)
                 return -1;
             }
 
@@ -368,7 +368,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
             if (layout_mgr->define(md_in, extent, this->point_arrays,
                 this->information_arrays, this->compression_level))
             {
-                TECA_ERROR("failed to define file " << file_id)
+                TECA_FATAL_ERROR("failed to define file " << file_id)
                 return -1;
             }
 
@@ -390,7 +390,7 @@ std::vector<teca_metadata> teca_cf_writer::get_upstream_request(
     base_req.set("index_request_key", up_request_key);
     if (this->internals->mapper->get_upstream_requests(base_req, up_reqs))
     {
-        TECA_ERROR("Failed to create upstream requests")
+        TECA_FATAL_ERROR("Failed to create upstream requests")
         return up_reqs;
     }
 
@@ -433,7 +433,7 @@ const_p_teca_dataset teca_cf_writer::execute(unsigned int port,
         if (!in_mesh)
         {
             if (rank == 0)
-                TECA_ERROR("input mesh 0 is empty input or not a cartesian mesh")
+                TECA_FATAL_ERROR("input mesh 0 is empty input or not a cartesian mesh")
             return nullptr;
         }
 
@@ -447,7 +447,7 @@ const_p_teca_dataset teca_cf_writer::execute(unsigned int port,
 
         if (!layout_mgr)
         {
-            TECA_ERROR("No layout manager found for time step " << time_step)
+            TECA_FATAL_ERROR("No layout manager found for time step " << time_step)
             return nullptr;
         }
 
@@ -455,7 +455,7 @@ const_p_teca_dataset teca_cf_writer::execute(unsigned int port,
         if (layout_mgr->write(time_step, in_mesh->get_point_arrays(),
             in_mesh->get_information_arrays()))
         {
-            TECA_ERROR("Write time step " << time_step << " failed for time step")
+            TECA_FATAL_ERROR("Write time step " << time_step << " failed for time step")
             return nullptr;
         }
 
@@ -473,7 +473,7 @@ const_p_teca_dataset teca_cf_writer::execute(unsigned int port,
         if ((this->flush_files && this->flush()) ||
             this->internals->mapper->finalize())
         {
-            TECA_ERROR("Failed to finalize I/O")
+            TECA_FATAL_ERROR("Failed to finalize I/O")
             return nullptr;
         }
     }

--- a/io/teca_multi_cf_reader.cxx
+++ b/io/teca_multi_cf_reader.cxx
@@ -2223,7 +2223,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string t_variable;
             if (coords_in.get("t_variable", t_variable))
             {
-                TECA_ERROR("Failed to get the time varaible name")
+                TECA_FATAL_ERROR("Failed to get the time varaible name")
                 return teca_metadata();
             }
             coords_out.set("t_variable", t_variable);
@@ -2231,7 +2231,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             teca_metadata t_atts;
             if (atts_in.get(t_variable, t_atts))
             {
-                TECA_ERROR("Failed to get attributes for \""
+                TECA_FATAL_ERROR("Failed to get attributes for \""
                     << t_variable << "\"")
                 return teca_metadata();
             }
@@ -2240,7 +2240,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array t = coords_in.get("t");
             if (!t)
             {
-                TECA_ERROR("Failed to get the time axis")
+                TECA_FATAL_ERROR("Failed to get the time axis")
                 return teca_metadata();
             }
             coords_out.set("t", t);
@@ -2249,7 +2249,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string initializer_key;
             if (inst->metadata.get("index_initializer_key", initializer_key))
             {
-                TECA_ERROR("Failed to get the index_initializer_key")
+                TECA_FATAL_ERROR("Failed to get the index_initializer_key")
                 return teca_metadata();
             }
             this->internals->metadata.set("index_initializer_key", initializer_key);
@@ -2257,7 +2257,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string request_key;
             if (inst->metadata.get("index_request_key", request_key))
             {
-                TECA_ERROR("Failed to get the index_request_key")
+                TECA_FATAL_ERROR("Failed to get the index_request_key")
                 return teca_metadata();
             }
             this->internals->metadata.set("index_request_key", request_key);
@@ -2265,7 +2265,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             long n_indices = 0;
             if (inst->metadata.get(initializer_key, n_indices))
             {
-                TECA_ERROR("Failed to get the value of the intitializer \""
+                TECA_FATAL_ERROR("Failed to get the value of the intitializer \""
                     << initializer_key << "\"")
                 return teca_metadata();
             }
@@ -2295,7 +2295,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string x_variable;
             if (coords_in.get("x_variable", x_variable))
             {
-                TECA_ERROR("Failed to get the x-axis varaible name")
+                TECA_FATAL_ERROR("Failed to get the x-axis varaible name")
                 return teca_metadata();
             }
             coords_out.set("x_variable", x_variable);
@@ -2305,7 +2305,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
                 teca_metadata x_atts;
                 if (atts_in.get(x_variable, x_atts))
                 {
-                    TECA_ERROR("Failed to get attributes for the x-axis variable \""
+                    TECA_FATAL_ERROR("Failed to get attributes for the x-axis variable \""
                         << x_variable << "\"")
                     return teca_metadata();
                 }
@@ -2315,7 +2315,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array x = coords_in.get("x");
             if (!x)
             {
-                TECA_ERROR("Failed to get the x-axis")
+                TECA_FATAL_ERROR("Failed to get the x-axis")
                 return teca_metadata();
             }
             coords_out.set("x", x);
@@ -2324,7 +2324,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string y_variable;
             if (coords_in.get("y_variable", y_variable))
             {
-                TECA_ERROR("Failed to get the y-axis varaible name")
+                TECA_FATAL_ERROR("Failed to get the y-axis varaible name")
                 return teca_metadata();
             }
             coords_out.set("y_variable", y_variable);
@@ -2334,7 +2334,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
                 teca_metadata y_atts;
                 if (atts_in.get(y_variable, y_atts))
                 {
-                    TECA_ERROR("Failed to get attributes for the y-axis variable \""
+                    TECA_FATAL_ERROR("Failed to get attributes for the y-axis variable \""
                         << y_variable << "\"")
                     return teca_metadata();
                 }
@@ -2344,7 +2344,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array y = coords_in.get("y");
             if (!y)
             {
-                TECA_ERROR("Failed to get the y-axis")
+                TECA_FATAL_ERROR("Failed to get the y-axis")
                 return teca_metadata();
             }
             coords_out.set("y", y);
@@ -2353,7 +2353,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             std::string z_variable;
             if (coords_in.get("z_variable", z_variable))
             {
-                TECA_ERROR("Failed to get the z-axis varaible name")
+                TECA_FATAL_ERROR("Failed to get the z-axis varaible name")
                 return teca_metadata();
             }
             coords_out.set("z_variable", z_variable);
@@ -2363,7 +2363,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
                 teca_metadata z_atts;
                 if (atts_in.get(z_variable, z_atts))
                 {
-                    TECA_ERROR("Failed to get attributes for the z-axis variable \""
+                    TECA_FATAL_ERROR("Failed to get attributes for the z-axis variable \""
                         << z_variable << "\"")
                     return teca_metadata();
                 }
@@ -2373,7 +2373,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array z = coords_in.get("z");
             if (!z)
             {
-                TECA_ERROR("Failed to get the z-axis")
+                TECA_FATAL_ERROR("Failed to get the z-axis")
                 return teca_metadata();
             }
             coords_out.set("z", z);
@@ -2387,7 +2387,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array bounds = inst->metadata.get("bounds");
             if (!bounds)
             {
-                TECA_ERROR("Failed to get the mesh bounds")
+                TECA_FATAL_ERROR("Failed to get the mesh bounds")
                 return teca_metadata();
             }
             this->internals->metadata.set("bounds", bounds);
@@ -2396,7 +2396,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             p_teca_variant_array whole_extent = inst->metadata.get("whole_extent");
             if (!whole_extent)
             {
-                TECA_ERROR("Failed to get the mesh whole_extent")
+                TECA_FATAL_ERROR("Failed to get the mesh whole_extent")
                 return teca_metadata();
             }
             this->internals->metadata.set("whole_extent", whole_extent);
@@ -2415,7 +2415,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
             teca_metadata var_atts;
             if (atts_in.get(var_name, var_atts))
             {
-                TECA_ERROR("Failed to get attributes for \""
+                TECA_FATAL_ERROR("Failed to get attributes for \""
                     << var_name << "\"")
                 return teca_metadata();
             }
@@ -2433,7 +2433,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
         if ((errorNo = validator.validate_time_axis(errorStr)))
         {
             if (rank == 0)
-                TECA_ERROR("Time axis missmatch detected on a managed reader."
+                TECA_FATAL_ERROR("Time axis missmatch detected on a managed reader."
                     " The time axis must be indentical across all managed"
                     " readers. Correctness cannot be assured. " << errorStr)
             return teca_metadata();
@@ -2448,7 +2448,7 @@ teca_metadata teca_multi_cf_reader::get_output_metadata(
                 (errorNo != teca_coordinate_util::teca_validate_arrays::units_missmatch))
             {
                 if (rank == 0)
-                    TECA_ERROR("Spatial coordinate axis missmatch detected on"
+                    TECA_FATAL_ERROR("Spatial coordinate axis missmatch detected on"
                         " managed reader. The spatial coordinate axes must be"
                         " indentical across all managed readers. Correctness"
                         " cannot be assured. " << errorStr)
@@ -2522,7 +2522,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
     // none of the readers could provide the remaining arrays.
     if (!req_arrays.empty())
     {
-        TECA_ERROR("No reader provides the requested arrays " << req_arrays)
+        TECA_FATAL_ERROR("No reader provides the requested arrays " << req_arrays)
         return nullptr;
     }
 
@@ -2539,7 +2539,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
         this->internals->readers[geom_reader]->pipeline, request, geom_arrays,
         mesh_out))
     {
-        TECA_ERROR("Geometry reader \"" << geom_reader
+        TECA_FATAL_ERROR("Geometry reader \"" << geom_reader
             << "\" failed to read arrays " << geom_arrays)
         return nullptr;
     }
@@ -2550,7 +2550,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
     teca_metadata attributes;
     if (md_out.get("attributes", attributes))
     {
-        TECA_ERROR("Geometry reader \"" << geom_reader
+        TECA_FATAL_ERROR("Geometry reader \"" << geom_reader
             << "\" failed to get attributes")
         return nullptr;
     }
@@ -2576,7 +2576,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
         if (teca_multi_cf_reader_internals::read_arrays(inst->pipeline,
             request, arrays, tmp))
         {
-            TECA_ERROR("Reader \"" << key << "\" failed to read arrays " << arrays)
+            TECA_FATAL_ERROR("Reader \"" << key << "\" failed to read arrays " << arrays)
             return nullptr;
         }
 
@@ -2597,7 +2597,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
         teca_metadata atrs;
         if (md_tmp.get("attributes", atrs))
         {
-            TECA_ERROR("Reader \"" << key << " failed to get attributes")
+            TECA_FATAL_ERROR("Reader \"" << key << " failed to get attributes")
             return nullptr;
         }
 
@@ -2607,7 +2607,7 @@ const_p_teca_dataset teca_multi_cf_reader::execute(unsigned int port,
             teca_metadata array_atts;
             if (atrs.get(array_name, array_atts))
             {
-                TECA_ERROR("Reader \"" << key
+                TECA_FATAL_ERROR("Reader \"" << key
                     << "\" failed to get attributes for array \""
                     << array_name << "\"")
                 atrs.to_stream(std::cerr);

--- a/io/teca_shape_file_mask.cxx
+++ b/io/teca_shape_file_mask.cxx
@@ -130,13 +130,13 @@ teca_metadata teca_shape_file_mask::get_output_metadata(
     unsigned int n_mask_vars = this->mask_variables.size();
     if (n_mask_vars == 0)
     {
-        TECA_ERROR("The names of the mask_variables were not provided")
+        TECA_FATAL_ERROR("The names of the mask_variables were not provided")
         return teca_metadata();
     }
 
     if (this->shape_file.empty())
     {
-        TECA_ERROR("A shape file was not provided")
+        TECA_FATAL_ERROR("A shape file was not provided")
         return teca_metadata();
 
     }
@@ -146,7 +146,7 @@ teca_metadata teca_shape_file_mask::get_output_metadata(
         teca_shape_file_util::load_polygons(this->get_communicator(),
         this->shape_file, this->internals->polys, this->verbose))
     {
-        TECA_ERROR("Failed to read polygons from \"" << this->shape_file << "\"")
+        TECA_FATAL_ERROR("Failed to read polygons from \"" << this->shape_file << "\"")
         return teca_metadata();
     }
 
@@ -222,7 +222,7 @@ const_p_teca_dataset teca_shape_file_mask::execute(
 
     if (!in_mesh)
     {
-        TECA_ERROR("Failed to compute surface pressure. The dataset is"
+        TECA_FATAL_ERROR("Failed to compute surface pressure. The dataset is"
             " not a teca_mesh")
         return nullptr;
     }
@@ -234,7 +234,7 @@ const_p_teca_dataset teca_shape_file_mask::execute(
 
     if (z->size() > 1)
     {
-        TECA_ERROR("The shape file mask requires 2D data but 3D data was found")
+        TECA_FATAL_ERROR("The shape file mask requires 2D data but 3D data was found")
         return nullptr;
     }
 
@@ -258,7 +258,7 @@ const_p_teca_dataset teca_shape_file_mask::execute(
         unsigned long extent[6] = {0};
         if (teca_coordinate_util::bounds_to_extent(bounds,x, y, z, extent))
         {
-            TECA_ERROR("Failed to convert polygon " << p << " bounds ["
+            TECA_FATAL_ERROR("Failed to convert polygon " << p << " bounds ["
                 << bounds[0] << ", " << bounds[1] << ", " << bounds[2]
                 << ", " << bounds[3] << " to a valid mesh extent")
             continue;

--- a/io/teca_table_reader.cxx
+++ b/io/teca_table_reader.cxx
@@ -277,7 +277,7 @@ teca_metadata teca_table_reader::get_output_metadata(unsigned int port,
     if (!index)
     {
         this->clear_cached_metadata();
-        TECA_ERROR("Table is missing the index array \""
+        TECA_FATAL_ERROR("Table is missing the index array \""
             << this->index_column << "\"")
         return teca_metadata();
     }
@@ -297,7 +297,7 @@ teca_metadata teca_table_reader::get_output_metadata(unsigned int port,
     if (this->internals->number_of_indices < 1)
     {
         this->clear_cached_metadata();
-        TECA_ERROR("Invalid index \"" << this->index_column << "\"")
+        TECA_FATAL_ERROR("Invalid index \"" << this->index_column << "\"")
         return teca_metadata();
     }
 
@@ -320,7 +320,7 @@ teca_metadata teca_table_reader::get_output_metadata(unsigned int port,
             p_teca_variant_array md_col = this->internals->table->get_column(md_col_name);
             if (!md_col)
             {
-                TECA_ERROR("metadata column \"" << md_col_name << "\" not found")
+                TECA_FATAL_ERROR("metadata column \"" << md_col_name << "\" not found")
                 continue;
             }
             md.set(this->metadata_column_keys[i], md_col);
@@ -350,7 +350,7 @@ const_p_teca_dataset teca_table_reader::execute(unsigned int port,
         MPI_Comm_rank(this->get_communicator(), &rank);
     if ((rank == 0) && !this->internals->table)
     {
-        TECA_ERROR("Failed to read data")
+        TECA_FATAL_ERROR("Failed to read data")
         return nullptr;
     }
 #endif

--- a/io/teca_table_writer.cxx
+++ b/io/teca_table_writer.cxx
@@ -342,7 +342,7 @@ teca_metadata teca_table_writer::get_output_metadata(
     {
         if (md.get("index_request_key", this->index_request_key))
         {
-            TECA_ERROR("Failed to identify the index key")
+            TECA_FATAL_ERROR("Failed to identify the index key")
             return teca_metadata();
         }
     }
@@ -370,7 +370,7 @@ const_p_teca_dataset teca_table_writer::execute(
     {
         if (rank == 0)
         {
-            TECA_ERROR("empty input")
+            TECA_FATAL_ERROR("empty input")
         }
         return nullptr;
     }
@@ -381,14 +381,14 @@ const_p_teca_dataset teca_table_writer::execute(
     std::string index_request_key;
     if (md.get("index_request_key", index_request_key))
     {
-        TECA_ERROR("Dataset metadata is missing the index_request_key key")
+        TECA_FATAL_ERROR("Dataset metadata is missing the index_request_key key")
         return nullptr;
     }
 
     unsigned long index = 0;
     if (md.get(index_request_key, index))
     {
-        TECA_ERROR("Dataset metadata is missing the \""
+        TECA_FATAL_ERROR("Dataset metadata is missing the \""
             << index_request_key << "\" key")
         return nullptr;
     }
@@ -445,7 +445,7 @@ const_p_teca_dataset teca_table_writer::execute(
                 ext = "xlsx";
                 break;
             default:
-                TECA_ERROR("Invalid output format")
+                TECA_FATAL_ERROR("Invalid output format")
                 return nullptr;
         }
         teca_file_util::replace_extension(out_file, ext);
@@ -470,7 +470,7 @@ const_p_teca_dataset teca_table_writer::execute(
             <const teca_database>(input_data[0]);
         if (!database)
         {
-            TECA_ERROR("input must be a table or a database")
+            TECA_FATAL_ERROR("input must be a table or a database")
             return nullptr;
         }
     }
@@ -487,7 +487,7 @@ const_p_teca_dataset teca_table_writer::execute(
             const_p_teca_table table = database->get_table(i);
             if (internal::write_csv(table, out_file_i))
             {
-                TECA_ERROR("Failed to write table " << i << " \"" << name << "\"")
+                TECA_FATAL_ERROR("Failed to write table " << i << " \"" << name << "\"")
                 return nullptr;
             }
         }
@@ -504,7 +504,7 @@ const_p_teca_dataset teca_table_writer::execute(
             const_p_teca_table table = database->get_table(i);
             if (internal::write_bin(table, out_file_i))
             {
-                TECA_ERROR("Failed to write table " << i << " \"" << name << "\"")
+                TECA_FATAL_ERROR("Failed to write table " << i << " \"" << name << "\"")
                 return nullptr;
             }
         }
@@ -522,12 +522,12 @@ const_p_teca_dataset teca_table_writer::execute(
             const_p_teca_table table = database->get_table(i);
             if (internal::write_netcdf(table, out_file_i, this->row_dim_name))
             {
-                TECA_ERROR("Failed to write table " << i << " \"" << name << "\"")
+                TECA_FATAL_ERROR("Failed to write table " << i << " \"" << name << "\"")
                 return nullptr;
             }
         }
 #else
-        TECA_ERROR("Can't write table in NetCDF format because TECA "
+        TECA_FATAL_ERROR("Can't write table in NetCDF format because TECA "
             "was not compiled with NetCDF support enabled")
         return nullptr;
 #endif
@@ -544,7 +544,7 @@ const_p_teca_dataset teca_table_writer::execute(
 
         if (!workbook)
         {
-            TECA_ERROR("xlsx failed to create workbook ")
+            TECA_FATAL_ERROR("xlsx failed to create workbook ")
         }
 
         unsigned int n = database->get_number_of_tables();
@@ -557,7 +557,7 @@ const_p_teca_dataset teca_table_writer::execute(
 
             if (internal::write_xlsx(database->get_table(i), worksheet))
             {
-                TECA_ERROR("Failed to write table " << i << " \"" << name << "\"")
+                TECA_FATAL_ERROR("Failed to write table " << i << " \"" << name << "\"")
                 return nullptr;
             }
         }
@@ -565,14 +565,14 @@ const_p_teca_dataset teca_table_writer::execute(
         // close the workbook
         workbook_close(workbook);
 #else
-        TECA_ERROR("Can't write table in MS Excel xlsx format because TECA "
+        TECA_FATAL_ERROR("Can't write table in MS Excel xlsx format because TECA "
             "was not compiled with xlsx support enabled")
         return nullptr;
 #endif
     }
     else
     {
-        TECA_ERROR("invalid output format " << fmt)
+        TECA_FATAL_ERROR("invalid output format " << fmt)
         return nullptr;
     }
 

--- a/io/teca_wrf_reader.cxx
+++ b/io/teca_wrf_reader.cxx
@@ -253,7 +253,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
 
             if (teca_file_util::locate_files(path, regex, files))
             {
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to locate any files" << endl
                     << this->files_regex << endl
                     << path << endl
@@ -331,7 +331,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             teca_netcdf_util::netcdf_handle fh;
             if (fh.open(file.c_str(), NC_NOWRITE))
             {
-                TECA_ERROR("Failed to open " << file << endl << nc_strerror(ierr))
+                TECA_FATAL_ERROR("Failed to open " << file << endl << nc_strerror(ierr))
                 return teca_metadata();
             }
 
@@ -348,7 +348,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 || ((ierr = nc_inq_dimlen(fh.get(), x_dims[1], &n_y)) != NC_NOERR))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to query x axis variable \"" << m_x_axis_variable
                     << "\" in file \"" << file << "\"" << endl
                     << nc_strerror(ierr))
@@ -367,7 +367,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 || ((ierr = nc_inq_dimlen(fh.get(), z_dims[1], &n_z)) != NC_NOERR))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to query mass_vertical_coordinate variable \""
                     << m_z_axis_variable << "\" in file \""
                     << file << "\"" << endl << nc_strerror(ierr))
@@ -393,7 +393,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             if (((ierr = nc_inq_nvars(fh.get(), &n_vars)) != NC_NOERR))
             {
                 this->clear_cached_metadata();
-                TECA_ERROR(
+                TECA_FATAL_ERROR(
                     << "Failed to get the number of variables in file \""
                     << file << "\"" << endl
                     << nc_strerror(ierr))
@@ -420,7 +420,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                         &var_nc_type, &n_dims, dim_id, &n_atts)) != NC_NOERR)
                 {
                     this->clear_cached_metadata();
-                    TECA_ERROR(
+                    TECA_FATAL_ERROR(
                         << "Failed to query " << i << "th variable, "
                         << file << endl << nc_strerror(ierr))
                     return teca_metadata();
@@ -450,7 +450,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                     if ((ierr = nc_inq_dim(fh.get(), dim_id[ii], dim_name, &dim)) != NC_NOERR)
                     {
                         this->clear_cached_metadata();
-                        TECA_ERROR(
+                        TECA_FATAL_ERROR(
                             << "Failed to query " << ii << "th dimension of variable, "
                             << var_name << ", " << file << endl << nc_strerror(ierr))
                         return teca_metadata();
@@ -485,7 +485,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                         || ((ierr = nc_inq_att(fh.get(), i, att_name, &att_type, &att_len)) != NC_NOERR))
                     {
                         this->clear_cached_metadata();
-                        TECA_ERROR("Failed to query " << ii << "th attribute of variable, "
+                        TECA_FATAL_ERROR("Failed to query " << ii << "th attribute of variable, "
                             << var_name << ", " << file << endl << nc_strerror(ierr))
                         free(att_buffer);
                         return teca_metadata();
@@ -591,7 +591,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                         else
                         {
                             // handle edge and node if/when they arrise.
-                            TECA_ERROR(<< stagger << " stagger is not implemented")
+                            TECA_FATAL_ERROR(<< stagger << " stagger is not implemented")
                             return teca_metadata();
                         }
                     }
@@ -646,7 +646,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 t_axis = time_arrays[0];
                 if (!t_axis)
                 {
-                    TECA_ERROR("Failed to read time axis")
+                    TECA_FATAL_ERROR("Failed to read time axis")
                     return teca_metadata();
                 }
                 step_count.push_back(time_arrays[0]->size());
@@ -676,7 +676,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             {
                 if (this->calendar.empty() || this->t_units.empty())
                 {
-                    TECA_ERROR("calendar and units has to be specified"
+                    TECA_FATAL_ERROR("calendar and units has to be specified"
                         " for the time variable")
                     return teca_metadata();
                 }
@@ -685,7 +685,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 size_t n_t_vals = this->t_values.size();
                 if (n_t_vals != files.size())
                 {
-                    TECA_ERROR("Number of files choosen doesn't match the"
+                    TECA_FATAL_ERROR("Number of files choosen doesn't match the"
                         " number of time values provided")
                     return teca_metadata();
                 }
@@ -739,7 +739,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                     // check whether the conversion failed
                     if(ss.fail())
                     {
-                        TECA_ERROR("Failed to infer time from filename \"" <<
+                        TECA_FATAL_ERROR("Failed to infer time from filename \"" <<
                             files[i] << "\" using format \"" <<
                             this->filename_time_template << "\"")
                         return teca_metadata();
@@ -757,7 +757,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                         if (strftime(tmp, sizeof(tmp), t_units_fmt.c_str(),
                               &current_tm) == 0)
                         {
-                            TECA_ERROR(
+                            TECA_FATAL_ERROR(
                                 "failed to convert the time as a string with \""
                                 << t_units_fmt << "\"")
                             return teca_metadata();
@@ -777,14 +777,14 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                     if (teca_calcalcs::coordinate(year, mon, day, hour, minute,
                         second, t_units.c_str(), calendar.c_str(), &current_time))
                     {
-                        TECA_ERROR("conversion of date inferred from "
+                        TECA_FATAL_ERROR("conversion of date inferred from "
                             "filename failed");
                         return teca_metadata();
                     }
                     // add the current time to the list
                     t_values.push_back(current_time);
 #else
-                    TECA_ERROR("The UDUnits package is required for this operation")
+                    TECA_FATAL_ERROR("The UDUnits package is required for this operation")
                     return teca_metadata();
 #endif
                 }
@@ -821,7 +821,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 if (((ierr = nc_inq_varid(fh.get(), m_x_axis_variable.c_str(), &x_id)) != NC_NOERR)
                     || ((ierr = nc_inq_vartype(fh.get(), x_id, &x_t)) != NC_NOERR))
                 {
-                    TECA_ERROR("Failed to deduce the time axis type from "
+                    TECA_FATAL_ERROR("Failed to deduce the time axis type from "
                         << m_x_axis_variable << endl << nc_strerror(ierr))
                     return teca_metadata();
                 }
@@ -898,7 +898,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             }
             if (!cached_metadata)
             {
-                TECA_ERROR("failed to create a metadata cache")
+                TECA_FATAL_ERROR("failed to create a metadata cache")
             }
 #endif
         }
@@ -943,14 +943,14 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     teca_metadata coords;
     if (this->internals->metadata.get("coordinates", coords))
     {
-        TECA_ERROR("metadata is missing \"coordinates\"")
+        TECA_FATAL_ERROR("metadata is missing \"coordinates\"")
         return nullptr;
     }
 
     p_teca_variant_array in_t;
     if (!(in_t = coords.get("t")))
     {
-        TECA_ERROR("coordinate metadata is missing time axis")
+        TECA_FATAL_ERROR("coordinate metadata is missing time axis")
         return nullptr;
     }
 
@@ -968,7 +968,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))
             {
-                TECA_ERROR("requested time " << t << " not found")
+                TECA_FATAL_ERROR("requested time " << t << " not found")
                 return nullptr;
             }
             )
@@ -985,7 +985,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     unsigned long whole_extent[6] = {0};
     if (this->internals->metadata.get("whole_extent", whole_extent, 6))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata is missing \"whole_extent\"")
         return nullptr;
     }
@@ -1007,14 +1007,14 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
         // axes, then scan for the bounding indices in the 2d lat, lon, and 3d pd
         // arrays, and then finally apply the subset. this would need to move
         // below since at this point we haven't read the coordinate axes.
-        TECA_ERROR("bounds_to_extent not implemented for curvilinear meshes")
+        TECA_FATAL_ERROR("bounds_to_extent not implemented for curvilinear meshes")
         return nullptr;
         // bounds key was present, convert the bounds to an
         // an extent that covers them.
         /*if (teca_coordinate_util::bounds_to_extent(
             bounds, in_x, in_y, in_z, extent))
         {
-            TECA_ERROR("invalid bounds requested.")
+            TECA_FATAL_ERROR("invalid bounds requested.")
             return nullptr;
         }*/
     }
@@ -1023,7 +1023,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     teca_metadata atrs;
     if (this->internals->metadata.get("attributes", atrs))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata missing \"attributes\"")
         return nullptr;
     }
@@ -1032,7 +1032,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     std::vector<unsigned long> step_count;
     if (this->internals->metadata.get("step_count", step_count))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " metadata is missing \"step_count\"")
         return nullptr;
     }
@@ -1052,7 +1052,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     if (this->internals->metadata.get("root", path)
         || this->internals->metadata.get("files", idx, file))
     {
-        TECA_ERROR("time_step=" << time_step
+        TECA_FATAL_ERROR("time_step=" << time_step
             << " Failed to locate file for time step " << time_step)
         return nullptr;
     }
@@ -1063,7 +1063,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     teca_netcdf_util::netcdf_handle fh;
     if (fh.open(file_path, NC_NOWRITE))
     {
-        TECA_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
+        TECA_FATAL_ERROR("time_step=" << time_step << " Failed to open \"" << file << "\"")
         return nullptr;
     }
     int file_id = fh.get();
@@ -1092,7 +1092,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             || atts.get("mesh_dimension", mesh_dim)
             || atts.get("centering", centering))
         {
-            TECA_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
+            TECA_FATAL_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
             continue;
         }
 
@@ -1119,7 +1119,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
                 continue;
                 break;
             default:
-                TECA_ERROR("Invalid centering " << centering
+                TECA_FATAL_ERROR("Invalid centering " << centering
                     << " array " << i << " \"" << arrays[i])
         }
 
@@ -1152,7 +1152,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             m_x_atts.get("cf_type_code", 0, m_x_type) ||
             m_x_atts.get("cf_id", 0, m_x_id))
         {
-            TECA_ERROR("metadata issue with m_x_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with m_x_axis_variable \""
                 << m_x_axis_variable << "\"")
             return nullptr;
         }
@@ -1164,7 +1164,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             m_y_atts.get("cf_type_code", 0, m_y_type) ||
             m_y_atts.get("cf_id", 0, m_y_id))
         {
-            TECA_ERROR("metadata issue with m_y_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with m_y_axis_variable \""
                 << m_y_axis_variable << "\"")
             return nullptr;
         }
@@ -1188,7 +1188,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read the data
             if (((ierr = nc_get_vara(file_id,  m_x_id, m_x_start, m_x_count, m_x->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read m_x_axis_variable \"" << m_x_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1196,7 +1196,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
             if (((ierr = nc_get_vara(file_id,  m_y_id, m_x_start, m_x_count, m_y->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read m_y_axis_variable \"" << m_y_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1222,7 +1222,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             u_x_atts.get("cf_type_code", 0, u_x_type) ||
             u_x_atts.get("cf_id", 0, u_x_id))
         {
-            TECA_ERROR("metadata issue with u_x_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with u_x_axis_variable \""
                 << u_x_axis_variable << "\"")
             return nullptr;
         }
@@ -1234,7 +1234,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             u_y_atts.get("cf_type_code", 0, u_y_type) ||
             u_y_atts.get("cf_id", 0, u_y_id))
         {
-            TECA_ERROR("metadata issue with u_y_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with u_y_axis_variable \""
                 << u_y_axis_variable << "\"")
             return nullptr;
         }
@@ -1260,7 +1260,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read the data
             if (((ierr = nc_get_vara(file_id,  u_x_id, u_x_start, u_x_count, u_x->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read u_x_axis_variable \"" << u_x_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1268,7 +1268,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
             if (((ierr = nc_get_vara(file_id,  u_y_id, u_x_start, u_x_count, u_y->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read u_y_axis_variable \"" << u_y_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1294,7 +1294,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             v_x_atts.get("cf_type_code", 0, v_x_type) ||
             v_x_atts.get("cf_id", 0, v_x_id))
         {
-            TECA_ERROR("metadata issue with v_x_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with v_x_axis_variable \""
                 << v_x_axis_variable << "\"")
             return nullptr;
         }
@@ -1306,7 +1306,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             v_y_atts.get("cf_type_code", 0, v_y_type) ||
             v_y_atts.get("cf_id", 0, v_y_id))
         {
-            TECA_ERROR("metadata issue with v_y_axis_variable \""
+            TECA_FATAL_ERROR("metadata issue with v_y_axis_variable \""
                 << v_y_axis_variable << "\"")
             return nullptr;
         }
@@ -1333,7 +1333,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read the data
             if (((ierr = nc_get_vara(file_id,  v_x_id, v_x_start, v_x_count, v_x->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read v_x_axis_variable \"" << v_x_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1341,7 +1341,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
             if (((ierr = nc_get_vara(file_id,  v_y_id, v_x_start, v_x_count, v_y->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read v_y_axis_variable \"" << v_y_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
                 return nullptr;
@@ -1366,7 +1366,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             m_z_atts.get("cf_type_code", 0, m_z_type) ||
             m_z_atts.get("cf_id", 0, m_z_id))
         {
-            TECA_ERROR("mm_zdata issue with m_z_axis_variable \""
+            TECA_FATAL_ERROR("mm_zdata issue with m_z_axis_variable \""
                 << m_z_axis_variable << "\"")
             return nullptr;
         }
@@ -1388,7 +1388,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read the data
             if (((ierr = nc_get_vara(file_id,  m_z_id, m_z_start, m_z_count, m_z->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read m_z_axis_variable \""
                     << m_z_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
@@ -1413,7 +1413,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             w_z_atts.get("cf_type_code", 0, w_z_type) ||
             w_z_atts.get("cf_id", 0, w_z_id))
         {
-            TECA_ERROR("mw_zdata issue with w_z_axis_variable \""
+            TECA_FATAL_ERROR("mw_zdata issue with w_z_axis_variable \""
                 << w_z_axis_variable << "\"")
             return nullptr;
         }
@@ -1436,7 +1436,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read the data
             if (((ierr = nc_get_vara(file_id,  w_z_id, w_z_start, w_z_count, w_z->get())) != NC_NOERR))
             {
-                TECA_ERROR("At time_step " << time_step
+                TECA_FATAL_ERROR("At time_step " << time_step
                     << " failed to read w_z_axis_variable \""
                     << w_z_axis_variable << "\" from \""
                     << file << "\"" << endl << nc_strerror(ierr))
@@ -1515,7 +1515,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             || teca_coordinate_util::validate_centering(centering)
             || !(dims = std::dynamic_pointer_cast<teca_size_t_array>(atts.get("cf_dims"))))
         {
-            TECA_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
+            TECA_FATAL_ERROR("metadata issue can't read \"" << arrays[i] << "\"")
             continue;
         }
 
@@ -1528,7 +1528,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             if ((centering != teca_array_attributes::point_centering) &&
                 teca_coordinate_util::convert_cell_extent(var_extent, centering))
             {
-                TECA_ERROR("Failed to convert the extent for \""
+                TECA_FATAL_ERROR("Failed to convert the extent for \""
                     << arrays[i] << "\"")
                 continue;
             }
@@ -1576,7 +1576,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 #endif
                 if ((ierr = nc_get_vara(file_id,  id, &starts[0], &counts[0], a->get())) != NC_NOERR)
                 {
-                    TECA_ERROR("time_step=" << time_step
+                    TECA_FATAL_ERROR("time_step=" << time_step
                         << " Failed to read variable \"" << arrays[i] << "\" "
                         << file << endl << nc_strerror(ierr))
                     continue;
@@ -1600,7 +1600,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             std::string dim_0_name;
             if (atts.get("cf_dim_names", 0, dim_0_name))
             {
-                TECA_ERROR("Failed to get dim 0 name")
+                TECA_FATAL_ERROR("Failed to get dim 0 name")
                 return nullptr;
             }
             size_t n_vals = 1;
@@ -1634,7 +1634,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 #endif
                 if ((ierr = nc_get_vara(file_id,  id, &starts[0], &counts[0], a->get())) != NC_NOERR)
                 {
-                    TECA_ERROR("time_step=" << time_step
+                    TECA_FATAL_ERROR("time_step=" << time_step
                         << " Failed to read \"" << arrays[i] << "\" "
                         << file << endl << nc_strerror(ierr))
                     continue;

--- a/python/teca_py_algorithm.h
+++ b/python/teca_py_algorithm.h
@@ -3,6 +3,7 @@
 
 /// @file
 
+#include "teca_common.h"
 #include "teca_metadata.h"
 #include "teca_dataset.h"
 #include "teca_py_object.h"
@@ -16,19 +17,25 @@
  * verbose in an effort to help the user debug their code. package this up for
  * use in all the callbacks.
  */
-#define TECA_PY_CALLBACK_ERROR(_phase, _cb_obj)             \
-    {                                                       \
-    PyObject *cb_str = PyObject_Str(_cb_obj);               \
-    const char *cb_c_str = PyStringToCString(cb_str);       \
-                                                            \
-    TECA_ERROR("An exception ocurred when invoking the "    \
-    "user supplied Python callback \"" << cb_c_str << "\""  \
-    "for the " #_phase " execution phase. The exception "   \
-    "that occurred is:")                                    \
-                                                            \
-    PyErr_Print();                                          \
-                                                            \
-    Py_XDECREF(cb_str);                                     \
+#define TECA_PY_CALLBACK_ERROR(_phase, _cb_obj)                 \
+    {                                                           \
+    PyObject *cb_str = PyObject_Str(_cb_obj);                   \
+    const char *cb_c_str = PyStringToCString(cb_str);           \
+                                                                \
+    TECA_MESSAGE_RAW(std::cerr, "ERROR:", "An exception "       \
+    "ocurred  when invoking the user supplied Python callback " \
+    "\"" << cb_c_str << "\" for the " #_phase " execution "     \
+    "phase. The exception that occurred is:")                   \
+                                                                \
+    PyErr_Print();                                              \
+                                                                \
+    PyObject *sys_stderr = PySys_GetObject("stderr");           \
+    PyObject_CallMethod(sys_stderr, "flush", nullptr);          \
+                                                                \
+    PyObject *sys_stdout = PySys_GetObject("stdout");           \
+    PyObject_CallMethod(sys_stdout, "flush", nullptr);          \
+                                                                \
+    Py_XDECREF(cb_str);                                         \
     }
 
 /// Codes for briding teca_algorithm to Python

--- a/python/teca_py_buffer.i
+++ b/python/teca_py_buffer.i
@@ -10,7 +10,7 @@
     if(PyObject_AsReadBuffer($input,
         reinterpret_cast<const void**>(&buf), &buf_size))
     {
-        TECA_ERROR("Failed to convert to buffer")
+        TECA_PY_ERROR(PyExc_TypeError, "Failed to convert to buffer")
         return NULL;
     }
     $1 = new std::vector<c_type>(buf, buf+(buf_size/sizeof(c_type)));
@@ -34,7 +34,7 @@ but not arrays.
         Py_buffer buf;
         if (PyObject_GetBuffer($input, &buf, PyBUF_SIMPLE))
         {
-            TECA_ERROR("conversion to buffer failed")
+            TECA_PY_ERROR(PyExc_TypeError, "conversion to buffer failed")
             return NULL;
         }
         int *pbuf = static_cast<int*>(buf.buf);
@@ -42,7 +42,7 @@ but not arrays.
     }
     else
     {
-        TECA_ERROR("input doesn't support buffer protocol")
+        TECA_PY_ERROR(PyExc_TypeError, "input doesn't support buffer protocol")
         return NULL;
     }
 }*/

--- a/python/teca_py_common.i
+++ b/python/teca_py_common.i
@@ -7,16 +7,22 @@
 
 #ifndef TECA_PY_ERROR_H
 #define TECA_PY_ERROR_H
-// print an error message to std::cerr and set the interpreter 
+// print an error message to std::cerr and set the interpreter
 // up for an exception. The exception will occur now if the retrun
 // value is null or later at the next time the interpreter checks
-// the error flag. See also TECA_PY_ERROR_NOW  
-#define TECA_PY_ERROR(_type, _xmsg)                 \
-{                                                   \
-    std::ostringstream oss;                         \
-    oss << std::endl;                               \
-    TECA_MESSAGE(oss, "ERROR:", ANSI_RED, _xmsg)    \
-    PyErr_Format(_type, "%s", oss.str().c_str());   \
+// the error flag. See also TECA_PY_ERROR_NOW
+#define TECA_PY_ERROR(_type, _xmsg)                     \
+{                                                       \
+    std::ostringstream oss;                             \
+    oss << std::endl;                                   \
+    TECA_MESSAGE_RAW(oss, "ERROR:", _xmsg)              \
+    PyErr_Format(_type, "%s", oss.str().c_str());       \
+                                                        \
+    PyObject *sys_stderr = PySys_GetObject("stderr");   \
+    PyObject_CallMethod(sys_stderr, "flush", nullptr);  \
+                                                        \
+    PyObject *sys_stdout = PySys_GetObject("stdout");   \
+    PyObject_CallMethod(sys_stdout, "flush", nullptr);  \
 }
 
 // the same as TECA_PY_ERROR except forces the interpreter to

--- a/python/teca_py_iterator.h
+++ b/python/teca_py_iterator.h
@@ -73,8 +73,8 @@ bool is_type(PyObject *obj)
         {
             if (i)
             {
-                TECA_ERROR("mixed types are not supported. "
-                    " Failed at element " <<  i)
+                TECA_PY_ERROR(PyExc_TypeError, "mixed types are not "
+                    "supported. Failed at element " <<  i)
             }
             return false;
         }

--- a/python/teca_py_sequence.h
+++ b/python/teca_py_sequence.h
@@ -65,8 +65,8 @@ bool is_type(PyObject *seq)
         {
             if (i)
             {
-                TECA_ERROR("Sequences with mixed types are not supported. "
-                    " Failed at element " <<  i)
+                TECA_PY_ERROR(PyExc_TypeError, "Sequences with mixed types "
+                    " are not supported. Failed at element " <<  i)
             }
             return false;
         }


### PR DESCRIPTION
adds TECA_FATAL_ERROR that invokes the errorhandler (the default will abort). This is only used in pipeline execution phases, elsewhere TECA_ERROR is used. This will allow more contextual information to be reported before the abort.

updates the Python error reporting macros to remove ANSI color coding and flush error and output streams.

a follow up revision to #645 
resolves #648
resolves #649 