### PR TITLE
fix Cartesian mesh coordinate transform bug

### DIFF
--- a/alg/teca_cartesian_mesh_coordinate_transform.cxx
+++ b/alg/teca_cartesian_mesh_coordinate_transform.cxx
@@ -415,17 +415,19 @@ teca_metadata teca_cartesian_mesh_coordinate_transform::get_output_metadata(
     // pass the updated coordinate system
     out_md.set("coordinates", this->internals->coordinates_out);
 
-    // get the input coordinate axis attributes
+    // get the input attributes
     teca_metadata atts;
-    if (out_md.get("attributes", atts)
-        || atts.get(x_axis_variable_in, this->internals->x_axis_attributes_out)
-        || atts.get(y_axis_variable_in, this->internals->y_axis_attributes_out)
-        || atts.get(z_axis_variable_in, this->internals->z_axis_attributes_out))
+    if (out_md.get("attributes", atts))
     {
         TECA_FATAL_ERROR("Failed to get the coordinate variables attributes")
         this->internals->clear();
         return teca_metadata();
     }
+
+    // get coordinates attributes. some of these might be empty. that is OK.
+    atts.get(x_axis_variable_in, this->internals->x_axis_attributes_out);
+    atts.get(y_axis_variable_in, this->internals->y_axis_attributes_out);
+    atts.get(z_axis_variable_in, this->internals->z_axis_attributes_out);
 
     // x axis attributes
     // update the description to note the transform

--- a/io/teca_multi_cf_reader.cxx
+++ b/io/teca_multi_cf_reader.cxx
@@ -1105,7 +1105,7 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
         teca_file_util::line_buffer lines;
         if (lines.initialize(input_file.c_str()))
         {
-            TECA_ERROR("Failed to read \"" << input_file << "\"")
+            TECA_FATAL_ERROR("Failed to read \"" << input_file << "\"")
             return -1;
         }
 
@@ -1131,7 +1131,7 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
             {
                 if (teca_string_util::extract_value<std::string>(l, g_data_root))
                 {
-                    TECA_ERROR("Failed to parse \"data_root\" specifier on line " << lno)
+                    TECA_FATAL_ERROR("Failed to parse \"data_root\" specifier on line " << lno)
                     return -1;
                 }
             }
@@ -1139,7 +1139,7 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
             {
                 if (teca_string_util::extract_value<std::string>(l, g_regex))
                 {
-                    TECA_ERROR("Failed to parse \"regex\" specifier on line " << lno)
+                    TECA_FATAL_ERROR("Failed to parse \"regex\" specifier on line " << lno)
                     return -1;
                 }
             }
@@ -1154,7 +1154,7 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
                 reader_option_t opts;
                 if (teca_multi_cf_reader_internals::parse_cf_reader_section(lines, opts))
                 {
-                    TECA_ERROR("Failed to parse [cf_reader] section on line " << lno)
+                    TECA_FATAL_ERROR("Failed to parse [cf_reader] section on line " << lno)
                     return -1;
                 }
 
@@ -1202,7 +1202,7 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
 
     if (num_readers < 1)
     {
-        TECA_ERROR("No readers found in \"" << input_file << "\"")
+        TECA_FATAL_ERROR("No readers found in \"" << input_file << "\"")
         return -1;
     }
 
@@ -1223,14 +1223,14 @@ int teca_multi_cf_reader::set_input_file(const std::string &input_file)
 
     if (num_time_readers != 1)
     {
-        TECA_ERROR(<< num_time_readers << " readers provide time."
+        TECA_FATAL_ERROR(<< num_time_readers << " readers provide time."
             " One and only one reader can provide time.")
         return -1;
     }
 
     if (num_geometry_readers != 1)
     {
-        TECA_ERROR(<< num_geometry_readers << " readers provide geometry."
+        TECA_FATAL_ERROR(<< num_geometry_readers << " readers provide geometry."
             " One and only one reader can provide mesh geometry.")
         return -1;
     }


### PR DESCRIPTION
* 2D meshes always errored out because of empty z-axis variable attributes.
* makes MCF file read and parse errors fatal to prevent MPI deadlock.