### PR TITLE
fused kernel in IVT alg

### DIFF
--- a/test/apps/test_integrated_vapor_transport_app.sh
+++ b/test/apps/test_integrated_vapor_transport_app.sh
@@ -35,7 +35,7 @@ ${launcher} ${app_prefix}/teca_integrated_vapor_transport               \
 ${app_prefix}/teca_cartesian_mesh_diff                                                      \
     --reference_dataset ${data_root}/test_integrated_vapor_transport_app_mcf_ref'.*\.nc'    \
     --test_dataset test_integrated_vapor_transport_app_mcf_output'.*\.nc'                   \
-    --arrays IVT_U IVT_V IVT --verbose
+    --arrays IVT_U IVT_V IVT --absolute_tolerance 5e-5 --verbose
 
 # clean up
 rm test_integrated_vapor_transport_app_mcf_output*.nc

--- a/test/apps/test_integrated_vapor_transport_app_packed_data.sh
+++ b/test/apps/test_integrated_vapor_transport_app_packed_data.sh
@@ -45,7 +45,7 @@ else
         --test_dataset test_integrated_vapor_transport_app_packed_data_output'.*\.nc'                   \
         --test_reader::x_axis_variable longitude --test_reader::y_axis_variable latitude                \
         --ref_reader::x_axis_variable longitude --ref_reader::y_axis_variable latitude                  \
-        --arrays IVT_U IVT_V IVT --verbose
+        --arrays IVT_U IVT_V IVT --absolute_tolerance 1e-6 --verbose
 
     # clean up
     rm test_integrated_vapor_transport_app_packed_data_output*.nc

--- a/test/test_integrated_vapor_transport.cpp
+++ b/test/test_integrated_vapor_transport.cpp
@@ -197,13 +197,14 @@ int main(int argc, char **argv)
         head = mask;
     }
 
+    // we need to use the index executive here to enable GPU processing
+    p_teca_index_executive exec = teca_index_executive::New();
+
     // write the test input dataset
     if (write_input)
     {
         std::string fn = std::string("test_integrated_vapor_transport_input_") +
             std::string(vv_mask ? "vv_mask" : "elev_mask") + std::string("_%t%.nc");
-
-        p_teca_index_executive exec = teca_index_executive::New();
 
         p_teca_cf_writer w = teca_cf_writer::New();
         w->set_input_connection(head->get_output_port());
@@ -224,6 +225,7 @@ int main(int argc, char **argv)
     ivt->set_wind_v_variable("v");
     ivt->set_specific_humidity_variable("q");
 
+
     // write the result
     if (write_output)
     {
@@ -232,6 +234,7 @@ int main(int argc, char **argv)
 
         p_teca_cf_writer w = teca_cf_writer::New();
         w->set_input_connection(ivt->get_output_port());
+        w->set_executive(exec);
         w->set_file_name(fn);
         w->set_thread_pool_size(1);
         w->set_point_arrays({"ivt_u", "ivt_v"});
@@ -241,6 +244,7 @@ int main(int argc, char **argv)
     // capture the result
     p_teca_dataset_capture dsc = teca_dataset_capture::New();
     dsc->set_input_connection(ivt->get_output_port());
+    dsc->set_executive(exec);
     dsc->update();
 
     const_p_teca_cartesian_mesh m =


### PR DESCRIPTION
the initial GPU implementation took the same approach as the CPU - process an x-y slab at a time. this branch tests weather we can get a speed up by letting the GPU process the entire mesh at once. In the slice by slice approach kernels are executed in serial, there are no thread safety issues. In the mesh at once approach updates to the ivt field are races and we need some locking or use atomicAdd. Also the datasets we have currenty have access to don't have many vertical levels, eg 7. this might hide some of the costs of slice by slice approach.

tests showed almost identical results, fused kernel is slightly faster over 236 time steps of 1 deg 7 levels CMIP6 dataset.

data:
```
# new
0m38.554s, 0m37.677s, 0m37.817s

# old
0m38.482s, 0m38.432s, 0m37.971s
```

MCF
```
data_root = /work2/data/teca/HighResMIP/cmip6/CMIP6_hrmcol/HighResMIP/CMIP6/HighResMIP/ECMWF/ECMWF-IFS-HR/highresSST-present/r1i1p1f1/6hrPlevPt

[cf_reader]
variables = hus
regex = %data_root%/hus/gr/v20170915/hus_.*\.nc$
provides_time
provides_geometry


[cf_reader]
variables = ua
regex = %data_root%/ua/gr/v20170915/ua_.*\.nc$

[cf_reader]
variables = va
regex = %data_root%/va/gr/v20170915/va_.*\.nc$
```

command:
```
time  /home/bloring/work/teca/teca/bin-mpich/bin/teca_integrated_vapor_transport --input_file ../bench.mcf --wind_u ua --wind_v va --specific_humidity hus --write_ivt 1 --write_ivt_magnitude 1 --n_threads 1 --output_file ivt_bench_%t%.nc --verbose
```


