### PR TITLE
Better dispatch

### DIFF
--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -308,24 +308,24 @@ const_p_teca_dataset teca_2d_component_area::execute(
     out_metadata.set("background_id", bg_id);
 
     // calculate area of components
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         xc.get(),
         _COORD,
         // the calculation is sensative to floating point precision
         // and should be made in double precision
         using NT_CALC = double;
 
-        auto sp_xc = static_cast<TT_COORD*>(xc.get())->get_cpu_accessible();
+        auto sp_xc = static_cast<const TT_COORD*>(xc.get())->get_cpu_accessible();
         const NT_COORD *p_xc = sp_xc.get();
 
-        auto sp_yc = static_cast<TT_COORD*>(yc.get())->get_cpu_accessible();
+        auto sp_yc = static_cast<const TT_COORD*>(yc.get())->get_cpu_accessible();
         const NT_COORD *p_yc = sp_yc.get();
 
-        NESTED_TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
             component_array.get(),
             _LABEL,
 
-            auto sp_labels = static_cast<TT_LABEL*>
+            auto sp_labels = static_cast<const TT_LABEL*>
                 (component_array.get())->get_cpu_accessible();
 
             const NT_LABEL *p_labels = sp_labels.get();

--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -313,7 +313,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
     out_metadata.set("background_id", bg_id);
 
     // calculate area of components
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         xc.get(), _COORD,
 
         // the calculation is sensative to floating point precision
@@ -325,7 +325,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
         assert_type<CTT_COORD>(yc);
         auto [sp_xc, p_xc, sp_yc, p_yc] = get_cpu_accessible<CTT_COORD>(xc, yc);
 
-        NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_I(
             component_array.get(), _LABEL,
 
             auto [sp_labels, p_labels] = get_cpu_accessible<CTT_LABEL>(component_array);

--- a/alg/teca_2d_component_area.cxx
+++ b/alg/teca_2d_component_area.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_cartesian_mesh.h"
 
@@ -17,6 +18,10 @@
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
 #endif
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
+
 
 namespace {
 
@@ -309,26 +314,21 @@ const_p_teca_dataset teca_2d_component_area::execute(
 
     // calculate area of components
     NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        xc.get(),
-        _COORD,
+        xc.get(), _COORD,
+
         // the calculation is sensative to floating point precision
         // and should be made in double precision
         using NT_CALC = double;
+        using TT_CALC = teca_double_array;
 
-        auto sp_xc = static_cast<const TT_COORD*>(xc.get())->get_cpu_accessible();
-        const NT_COORD *p_xc = sp_xc.get();
-
-        auto sp_yc = static_cast<const TT_COORD*>(yc.get())->get_cpu_accessible();
-        const NT_COORD *p_yc = sp_yc.get();
+        // get the cooridnate arrays
+        assert_type<CTT_COORD>(yc);
+        auto [sp_xc, p_xc, sp_yc, p_yc] = get_cpu_accessible<CTT_COORD>(xc, yc);
 
         NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-            component_array.get(),
-            _LABEL,
+            component_array.get(), _LABEL,
 
-            auto sp_labels = static_cast<const TT_LABEL*>
-                (component_array.get())->get_cpu_accessible();
-
-            const NT_LABEL *p_labels = sp_labels.get();
+            auto [sp_labels, p_labels] = get_cpu_accessible<CTT_LABEL>(component_array);
 
             unsigned int n_labels = 0;
 
@@ -348,11 +348,7 @@ const_p_teca_dataset teca_2d_component_area::execute(
                     NT_LABEL max_component_id = ::get_max_component_id(nxy, p_labels);
                     n_labels = max_component_id + 1;
 
-                    p_teca_variant_array_impl<NT_LABEL> tmp =
-                        teca_variant_array_impl<NT_LABEL>::New(n_labels);
-
-                    auto sptmp = tmp->get_cpu_accessible();
-                    NT_LABEL *ptmp = sptmp.get();
+                    auto [tmp, ptmp] = ::New<TT_LABEL>(n_labels);
 
                     for (unsigned int i = 0; i < n_labels; ++i)
                         ptmp[i] = NT_LABEL(i);
@@ -371,26 +367,15 @@ const_p_teca_dataset teca_2d_component_area::execute(
             else
             {
                 // use an associative array to handle any labels
-                //std::map<NT_LABEL, NT_COORD> result;
-                decltype(std::map<NT_LABEL, NT_CALC>()) result;
+                std::map<NT_LABEL, NT_CALC> result;
                 ::component_area(nx,ny, p_xc,p_yc, p_labels, result);
 
                 // transfer the result to the output
                 n_labels = result.size();
 
-                p_teca_variant_array_impl<NT_LABEL> component_id =
-                    teca_variant_array_impl<NT_LABEL>::New(n_labels);
+                auto [component_id, pcomponent_id] = ::New<TT_LABEL>(n_labels);
+                auto [component_area, pcomponent_area] = ::New<TT_CALC>(n_labels);
 
-                auto spcomponent_id = component_id->get_cpu_accessible();
-                NT_LABEL *pcomponent_id = spcomponent_id.get();
-
-                p_teca_variant_array_impl<NT_CALC> component_area =
-                    teca_variant_array_impl<NT_CALC>::New(n_labels);
-
-                auto spcomponent_area = component_area->get_cpu_accessible();
-                NT_CALC *pcomponent_area = spcomponent_area.get();
-
-                //std::map<NT_LABEL,NT_COORD>::iterator it = result.begin();
                 auto it = result.begin();
                 for (unsigned int i = 0; i < n_labels; ++i,++it)
                 {

--- a/alg/teca_apply_binary_mask.cxx
+++ b/alg/teca_apply_binary_mask.cxx
@@ -277,7 +277,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
     }
 
     // apply the mask
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         mask_array.get(), _MASK,
 
         auto [sp_mask, p_mask] = get_cpu_accessible<CTT_MASK>(mask_array);
@@ -302,7 +302,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
             p_teca_variant_array output_array = input_array->new_instance(n);
 
             // do the mask calculation
-            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH(
                 output_array.get(), _VAR,
 
                 auto [sp_in, p_in] = get_cpu_accessible<CTT_VAR>(input_array);

--- a/alg/teca_apply_binary_mask.cxx
+++ b/alg/teca_apply_binary_mask.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 #include "teca_mpi_util.h"
@@ -22,6 +23,8 @@
 
 using std::cerr;
 using std::endl;
+
+using namespace teca_variant_array_util;
 
 namespace internal
 {
@@ -277,6 +280,8 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         mask_array.get(), _MASK,
 
+        auto [sp_mask, p_mask] = get_cpu_accessible<CTT_MASK>(mask_array);
+
         // loop over input variables
         for (auto& input_var : masked_variables)
         {
@@ -294,29 +299,14 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
 
             // allocate the output array
             size_t n = input_array->size();
-
             p_teca_variant_array output_array = input_array->new_instance(n);
-
-            //output_array->resize(n);
 
             // do the mask calculation
             NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
                 output_array.get(), _VAR,
 
-                auto sp_in = static_cast<const TT_VAR*>
-                    (input_array.get())->get_cpu_accessible();
-
-                const NT_VAR *p_in = sp_in.get();
-
-                auto sp_mask = static_cast<const TT_MASK*>
-                    (mask_array.get())->get_cpu_accessible();
-
-                const NT_MASK *p_mask = sp_mask.get();
-
-                auto sp_out = static_cast<TT_VAR*>
-                    (output_array.get())->get_cpu_accessible();
-
-                NT_VAR *p_out = sp_out.get();
+                auto [sp_in, p_in] = get_cpu_accessible<CTT_VAR>(input_array);
+                auto [p_out] = data<TT_VAR>(output_array);
 
                 internal::apply_mask(p_out, p_mask, p_in, n);
                 )

--- a/alg/teca_apply_binary_mask.cxx
+++ b/alg/teca_apply_binary_mask.cxx
@@ -274,7 +274,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
     }
 
     // apply the mask
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         mask_array.get(), _MASK,
 
         // loop over input variables
@@ -308,7 +308,7 @@ const_p_teca_dataset teca_apply_binary_mask::execute(
 
                 const NT_VAR *p_in = sp_in.get();
 
-                auto sp_mask = static_cast<TT_MASK*>
+                auto sp_mask = static_cast<const TT_MASK*>
                     (mask_array.get())->get_cpu_accessible();
 
                 const NT_MASK *p_mask = sp_mask.get();

--- a/alg/teca_apply_tempest_remap.cxx
+++ b/alg/teca_apply_tempest_remap.cxx
@@ -479,20 +479,20 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wchar-subscripts"
-            NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH_I(
                 row.get(), _IDX,
 
                 // get the source and target mesh indices
                 auto [spr, pr] = get_cpu_accessible<CTT_IDX>(row);
                 auto [spc, pc] = get_cpu_accessible<CTT_IDX>(col);
 
-                NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_FP(
                     weights.get(), _WGT,
 
                     // get the weight matrix
                     auto [spw, pw] = get_cpu_accessible<CTT_WGT>(weights);
 
-                    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+                    NESTED_VARIANT_ARRAY_DISPATCH(
                         src_data.get(), _DATA,
 
                         // get the source and target data
@@ -538,7 +538,7 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
                 auto [sptgt_valid, ptgt_valid] = get_cpu_accessible<CTT_MASK>(tgt_valid);
 
-                NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH(
                     tgt_data.get(), _DATA,
 
                     // get the _FillValue from the source (that's what will be declared in the

--- a/alg/teca_apply_tempest_remap.cxx
+++ b/alg/teca_apply_tempest_remap.cxx
@@ -5,8 +5,10 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
+#include "teca_valid_value_mask.h"
 
 #include <algorithm>
 #include <iostream>
@@ -18,11 +20,10 @@
 #include <boost/program_options.hpp>
 #endif
 
-//#define TECA_DEBUG
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
-// this improves compile times, but the code will only work with
-// valid value masks that arr of type teca_char_array
-#define CHAR_VALID_VALUE_MASK
+//#define TECA_DEBUG
 
 // --------------------------------------------------------------------------
 teca_apply_tempest_remap::teca_apply_tempest_remap() :
@@ -479,34 +480,24 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wchar-subscripts"
             NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-                row.get(),
-                _IDX,
+                row.get(), _IDX,
 
                 // get the source and target mesh indices
-                auto spr = static_cast<const TT_IDX*>(row.get())->get_cpu_accessible();
-                const NT_IDX *pr = spr.get();
-
-                auto spc = dynamic_cast<const TT_IDX*>(col.get())->get_cpu_accessible();
-                const NT_IDX *pc = spc.get();
+                auto [spr, pr] = get_cpu_accessible<CTT_IDX>(row);
+                auto [spc, pc] = get_cpu_accessible<CTT_IDX>(col);
 
                 NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-                    weights.get(),
-                    _WGT,
+                    weights.get(), _WGT,
 
                     // get the weight matrix
-                    auto spw = static_cast<const TT_WGT*>(weights.get())->get_cpu_accessible();
-                    const NT_WGT *pw = spw.get();
+                    auto [spw, pw] = get_cpu_accessible<CTT_WGT>(weights);
 
                     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        tgt_data.get(),
-                        _DATA,
+                        src_data.get(), _DATA,
 
                         // get the source and target data
-                        auto spsrc = static_cast<const TT_DATA*>(src_data.get())->get_cpu_accessible();
-                        const NT_DATA *psrc = spsrc.get();
-
-                        auto sptgt = static_cast<TT_DATA*>(tgt_data.get())->get_cpu_accessible();
-                        NT_DATA *ptgt = sptgt.get();
+                        auto [ptgt] = data<TT_DATA>(tgt_data);
+                        auto [spsrc, psrc] = get_cpu_accessible<CTT_DATA>(src_data);
 
                         if (src_valid)
                         {
@@ -519,26 +510,11 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
                                 TECA_FATAL_ERROR("Failed to get the _FillValue for \"" << array << "\"")
                                 return nullptr;
                             }
-#if defined(CHAR_VALID_VALUE_MASK)
-                            // to improve compile times assume valid value masks are char type
-                            using NT_SRC_VVM = char;
-                            using TT_SRC_VVM = teca_variant_array_impl<NT_SRC_VVM>;
-#else
-                            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-                                src_valid.get(),
-                                _SRC_VVM,
-#endif
-                                auto spsrc_valid = static_cast<const TT_SRC_VVM*>
-                                    (src_valid.get())->get_cpu_accessible();
+                            auto [spsv, psrc_valid] = get_cpu_accessible<CTT_MASK>(src_valid);
 
-                                const NT_SRC_VVM *psrc_valid = spsrc_valid.get();
-
-                                for (unsigned long q = 0; q < n_weights; ++q)
-                                    ptgt[pr[q]] = (psrc_valid[pc[q]] ?
-                                        (ptgt[pr[q]] + pw[q] * psrc[pc[q]]) : src_fill_value);
-#if !defined(CHAR_VALID_VALUE_MASK)
-                                )
-#endif
+                            for (unsigned long q = 0; q < n_weights; ++q)
+                                ptgt[pr[q]] = (psrc_valid[pc[q]] ?
+                                    (ptgt[pr[q]] + pw[q] * psrc[pc[q]]) : src_fill_value);
                         }
                         else
                         {
@@ -551,7 +527,6 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
                     )
                 )
 #pragma GCC diagnostic pop
-
             // un-pack the result. TempestRemap packs the result one value per valid
             // mesh point. In the GOES data some mesh points are invalid. To put the
             // mapped data back into the GOES mesh we'll need to un-pack the result.
@@ -561,61 +536,41 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
                 if (!src_valid)
                     tgt_atts.get(this->target_mask_variable, tgt_mask_atts);
 
-#if defined(CHAR_VALID_VALUE_MASK)
-                // to improve compile times assume valid value masks are char type
-                using NT_MASK = char;
-                using TT_MASK = teca_variant_array_impl<NT_MASK>;
-#else
+                auto [sptgt_valid, ptgt_valid] = get_cpu_accessible<CTT_MASK>(tgt_valid);
+
                 NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-                    tgt_valid.get(),
-                    _MASK,
-#endif
-                    auto sptgt_valid = static_cast<const TT_MASK*>
-                        (tgt_valid.get())->get_cpu_accessible();
+                    tgt_data.get(), _DATA,
 
-                    const NT_MASK *ptgt_valid = sptgt_valid.get();
+                    // get the _FillValue from the source (that's what will be declared in the
+                    // NetCDF variable attriibutes), but if it is not present get it from the
+                    // mask variable's attributes.
+                    NT_DATA fill_value = NT_DATA(0);
+                    if (src_array_atts.get("_FillValue", fill_value) &&
+                        tgt_mask_atts.get("_FillValue", fill_value))
+                    {
+                        TECA_FATAL_ERROR("Failed to get the _FillValue from \"" << array
+                            << "\" and \"" << this->target_mask_variable << "\"")
+                        return nullptr;
+                    }
 
-                    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        tgt_data.get(),
-                        _DATA,
+                    // get the target data, and allocate the output
+                    auto [ptgt] = data<TT_DATA>(tgt_data);
+                    auto [tgt_out, ptgt_out] = ::New<TT_DATA>(tgt_nxyz, fill_value);
 
-                        // get the _FillValue from the source (that's what will be declared in the
-                        // NetCDF variable attriibutes), but if it is not present get it from the
-                        // mask variable's attributes.
-                        NT_DATA fill_value = NT_DATA(0);
-                        if (src_array_atts.get("_FillValue", fill_value) &&
-                            tgt_mask_atts.get("_FillValue", fill_value))
+                    for (unsigned long q = 0, p = 0; q < tgt_nxyz; ++q)
+                    {
+                        if (ptgt_valid[q])
                         {
-                            TECA_FATAL_ERROR("Failed to get the _FillValue from \"" << array
-                                << "\" and \"" << this->target_mask_variable << "\"")
-                            return nullptr;
+                            // copy the packed data into the correct location in the output
+                            ptgt_out[q] = ptgt[p];
+
+                            // queue up the next packed location
+                            ++p;
                         }
+                    }
 
-                        auto sptgt = static_cast<TT_DATA*>(tgt_data.get())->get_cpu_accessible();
-                        NT_DATA *ptgt = sptgt.get();
-
-                        using TT_DATA_OUT = teca_variant_array_impl<NT_DATA>;
-                        auto tgt_out = TT_DATA_OUT::New(tgt_nxyz, fill_value);
-                        auto sptgt_out = tgt_out->get_cpu_accessible();
-                        NT_DATA *ptgt_out = sptgt_out.get();
-
-                        for (unsigned long q = 0, p = 0; q < tgt_nxyz; ++q)
-                        {
-                            if (ptgt_valid[q])
-                            {
-                                // copy the packed data into the correct location in the output
-                                ptgt_out[q] = ptgt[p];
-
-                                // queue up the next packed location
-                                ++p;
-                            }
-                        }
-
-                        tgt_data = tgt_out;
-                        )
-#if !defined(CHAR_VALID_VALUE_MASK)
+                    tgt_data = tgt_out;
                     )
-#endif
             }
 
             // store the result in the output mesh

--- a/alg/teca_apply_tempest_remap.cxx
+++ b/alg/teca_apply_tempest_remap.cxx
@@ -478,23 +478,23 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wchar-subscripts"
-            NESTED_TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+            NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
                 row.get(),
                 _IDX,
 
                 // get the source and target mesh indices
-                auto spr = static_cast<TT_IDX*>(row.get())->get_cpu_accessible();
+                auto spr = static_cast<const TT_IDX*>(row.get())->get_cpu_accessible();
                 const NT_IDX *pr = spr.get();
 
-                auto spc = dynamic_cast<TT_IDX*>(col.get())->get_cpu_accessible();
+                auto spc = dynamic_cast<const TT_IDX*>(col.get())->get_cpu_accessible();
                 const NT_IDX *pc = spc.get();
 
-                NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+                NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
                     weights.get(),
                     _WGT,
 
                     // get the weight matrix
-                    auto spw = static_cast<TT_WGT*>(weights.get())->get_cpu_accessible();
+                    auto spw = static_cast<const TT_WGT*>(weights.get())->get_cpu_accessible();
                     const NT_WGT *pw = spw.get();
 
                     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
@@ -522,13 +522,13 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 #if defined(CHAR_VALID_VALUE_MASK)
                             // to improve compile times assume valid value masks are char type
                             using NT_SRC_VVM = char;
-                            using TT_SRC_VVM = const teca_variant_array_impl<NT_SRC_VVM>;
+                            using TT_SRC_VVM = teca_variant_array_impl<NT_SRC_VVM>;
 #else
-                            NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+                            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
                                 src_valid.get(),
                                 _SRC_VVM,
 #endif
-                                auto spsrc_valid = static_cast<TT_SRC_VVM*>
+                                auto spsrc_valid = static_cast<const TT_SRC_VVM*>
                                     (src_valid.get())->get_cpu_accessible();
 
                                 const NT_SRC_VVM *psrc_valid = spsrc_valid.get();
@@ -564,13 +564,13 @@ const_p_teca_dataset teca_apply_tempest_remap::execute(
 #if defined(CHAR_VALID_VALUE_MASK)
                 // to improve compile times assume valid value masks are char type
                 using NT_MASK = char;
-                using TT_MASK = const teca_variant_array_impl<NT_MASK>;
+                using TT_MASK = teca_variant_array_impl<NT_MASK>;
 #else
-                NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+                NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
                     tgt_valid.get(),
                     _MASK,
 #endif
-                    auto sptgt_valid = static_cast<TT_MASK*>
+                    auto sptgt_valid = static_cast<const TT_MASK*>
                         (tgt_valid.get())->get_cpu_accessible();
 
                     const NT_MASK *ptgt_valid = sptgt_valid.get();

--- a/alg/teca_bayesian_ar_detect.cxx
+++ b/alg/teca_bayesian_ar_detect.cxx
@@ -199,8 +199,7 @@ public:
 
         unsigned long n_vals = ar_prob->size();
 
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            ar_prob.get(),
+        VARIANT_ARRAY_DISPATCH_FP(ar_prob.get(),
 
             NT num_params = this->parameter_table_size;
 
@@ -260,8 +259,7 @@ public:
                 // their sum
                 unsigned long n_vals = prob_0->size();
                 prob_out = prob_0->new_copy();
-                TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-                    prob_out.get(),
+                VARIANT_ARRAY_DISPATCH_FP(prob_out.get(),
 
                     auto [p_prob_out, p_prob_1] = data<TT>(prob_out, prob_1);
 
@@ -373,7 +371,7 @@ public:
                 unsigned long n_vals = prob->size();
                 prob_out = prob->new_copy();
 
-                NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_I(
                     wvcc.get(), _COMP,
 
                     auto [sp_wvcc, p_wvcc] = get_cpu_accessible<TT_COMP>(wvcc);
@@ -399,7 +397,7 @@ public:
                 NT_PROB *p_prob_out = nullptr;
                 std::tie(prob_out, p_prob_out) = ::New<TT_PROB>(n_vals);
 
-                NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_I(
                     wvcc_0.get(), _COMP,
 
                     auto [sp_wvcc_0, p_wvcc_0] = get_cpu_accessible<TT_COMP>(wvcc_0);
@@ -497,7 +495,7 @@ public:
                 NT_PROB *p_prob_out = nullptr;
                 std::tie(prob_out, p_prob_out) = ::New<TT_PROB>(n_vals);
 
-                NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_I(
                     wvcc.get(), _COMP,
 
                     auto [sp_wvcc, p_wvcc] = get_cpu_accessible<TT_COMP>(wvcc);

--- a/alg/teca_binary_segmentation_internals.cu
+++ b/alg/teca_binary_segmentation_internals.cu
@@ -209,8 +209,7 @@ int cuda_dispatch(int device_id,
     size_t n_elem = input_array->size();
     auto [segmentation, p_seg] = ::New<teca_char_array>(n_elem, allocator::cuda_async);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        input_array.get(),
+    VARIANT_ARRAY_DISPATCH(input_array.get(),
 
         auto [sp_in, p_in] = get_cuda_accessible<CTT>(input_array);
 

--- a/alg/teca_binary_segmentation_internals.cu
+++ b/alg/teca_binary_segmentation_internals.cu
@@ -1,5 +1,7 @@
 #include "teca_binary_segmentation_internals.h"
 #include "teca_variant_array.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_cuda_util.h"
 
 #include <thrust/host_vector.h>
@@ -10,6 +12,9 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 namespace teca_binary_segmentation_internals
 {
@@ -202,18 +207,12 @@ int cuda_dispatch(int device_id,
 
     // do segmentation
     size_t n_elem = input_array->size();
-
-    p_teca_char_array segmentation =
-        teca_char_array::New(n_elem, teca_variant_array::allocator::cuda);
-
-    auto sp_seg = segmentation->get_cuda_accessible();
-    char *p_seg = sp_seg.get();
+    auto [segmentation, p_seg] = ::New<teca_char_array>(n_elem, allocator::cuda_async);
 
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         input_array.get(),
 
-        auto sp_in = static_cast<TT*>(input_array.get())->get_cuda_accessible();
-        const NT *p_in = sp_in.get();
+        auto [sp_in, p_in] = get_cuda_accessible<CTT>(input_array);
 
         if (threshold_mode == teca_binary_segmentation::BY_VALUE)
         {
@@ -232,12 +231,6 @@ int cuda_dispatch(int device_id,
         }
         )
 
-    //segmentation->debug_print();
-
-/*    p_teca_int_array  tmp  = teca_int_array::New();
-    tmp->assign(p_teca_variant_array(segmentation));
-    tmp->print_buffer<int>();
-*/
     output_array = segmentation;
     return 0;
 }

--- a/alg/teca_binary_segmentation_internals.cu
+++ b/alg/teca_binary_segmentation_internals.cu
@@ -209,7 +209,7 @@ int cuda_dispatch(int device_id,
     auto sp_seg = segmentation->get_cuda_accessible();
     char *p_seg = sp_seg.get();
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         input_array.get(),
 
         auto sp_in = static_cast<TT*>(input_array.get())->get_cuda_accessible();

--- a/alg/teca_binary_segmentation_internals.cxx
+++ b/alg/teca_binary_segmentation_internals.cxx
@@ -34,10 +34,10 @@ int cpu_dispatch(
     size_t n_elem = input_array->size();
     p_teca_char_array segmentation = teca_char_array::New(n_elem);
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         input_array.get(),
 
-        auto sp_in = static_cast<TT*>(input_array.get())->get_cpu_accessible();
+        auto sp_in = static_cast<const TT*>(input_array.get())->get_cpu_accessible();
         const NT *p_in = sp_in.get();
 
         auto sp_seg = segmentation->get_cpu_accessible();

--- a/alg/teca_binary_segmentation_internals.cxx
+++ b/alg/teca_binary_segmentation_internals.cxx
@@ -1,5 +1,10 @@
 #include "teca_binary_segmentation_internals.h"
 #include "teca_config.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
+
+using namespace teca_variant_array_util;
+
 
 namespace teca_binary_segmentation_internals
 {
@@ -32,16 +37,12 @@ int cpu_dispatch(
 {
     // do segmentation
     size_t n_elem = input_array->size();
-    p_teca_char_array segmentation = teca_char_array::New(n_elem);
+    auto [segmentation, p_seg] = ::New<teca_char_array>(n_elem);
 
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         input_array.get(),
 
-        auto sp_in = static_cast<const TT*>(input_array.get())->get_cpu_accessible();
-        const NT *p_in = sp_in.get();
-
-        auto sp_seg = segmentation->get_cpu_accessible();
-        char *p_seg = sp_seg.get();
+        auto [sp_in, p_in] = get_cpu_accessible<CTT>(input_array);
 
         if (threshold_mode == teca_binary_segmentation::BY_VALUE)
         {

--- a/alg/teca_binary_segmentation_internals.cxx
+++ b/alg/teca_binary_segmentation_internals.cxx
@@ -39,8 +39,7 @@ int cpu_dispatch(
     size_t n_elem = input_array->size();
     auto [segmentation, p_seg] = ::New<teca_char_array>(n_elem);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        input_array.get(),
+    VARIANT_ARRAY_DISPATCH(input_array.get(),
 
         auto [sp_in, p_in] = get_cpu_accessible<CTT>(input_array);
 

--- a/alg/teca_cartesian_mesh_coordinate_transform.cxx
+++ b/alg/teca_cartesian_mesh_coordinate_transform.cxx
@@ -133,8 +133,7 @@ void teca_cartesian_mesh_coordinate_transform::internals_t::transform_axes(
             size_t ax_size = ax_in->size();
             ax_out = ax_in->new_instance(ax_size);
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                ax_out.get(),
+            VARIANT_ARRAY_DISPATCH(ax_out.get(),
 
                 auto [sp_ax_in, p_ax_in] = get_cpu_accessible<CTT>(ax_in);
                 auto [p_ax_out] = data<TT>(ax_out);
@@ -640,8 +639,7 @@ const_p_teca_dataset teca_cartesian_mesh_coordinate_transform::execute(
     p_teca_variant_array z_out_sub = z_in->new_instance(nz);
 
     // copy the subset
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x_out.get(),
+    VARIANT_ARRAY_DISPATCH(x_out.get(),
 
         auto [p_xo, p_yo, p_zo] = data<TT>(x_out, y_out, z_out);
         auto [p_xos, p_yos, p_zos] = data<TT>(x_out_sub, y_out_sub, z_out_sub);

--- a/alg/teca_cartesian_mesh_coordinate_transform.cxx
+++ b/alg/teca_cartesian_mesh_coordinate_transform.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_coordinate_util.h"
 
@@ -15,6 +16,8 @@
 #endif
 
 //#define TECA_DEBUG
+
+using namespace teca_variant_array_util;
 
 struct teca_cartesian_mesh_coordinate_transform::internals_t
 {
@@ -133,13 +136,10 @@ void teca_cartesian_mesh_coordinate_transform::internals_t::transform_axes(
             TEMPLATE_DISPATCH(teca_variant_array_impl,
                 ax_out.get(),
 
-                auto sp_ax_out = dynamic_cast<TT*>(ax_out.get())->get_cpu_accessible();
-                NT *p_ax_out = sp_ax_out.get();
+                auto [sp_ax_in, p_ax_in] = get_cpu_accessible<CTT>(ax_in);
+                auto [p_ax_out] = data<TT>(ax_out);
 
                 // transform the axis
-                auto sp_ax_in = dynamic_cast<const TT*>(ax_in.get())->get_cpu_accessible();
-                const NT *p_ax_in = sp_ax_in.get();
-
                 teca_cartesian_mesh_coordinate_transform::internals_t::transform_axis(
                     p_ax_out, p_ax_in, ax_size, NT(tgt_bounds[0]), NT(tgt_bounds[1]));
             )
@@ -643,32 +643,17 @@ const_p_teca_dataset teca_cartesian_mesh_coordinate_transform::execute(
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         x_out.get(),
 
-        auto sp_x_out = dynamic_cast<TT*>(x_out.get())->get_cpu_accessible();
-        NT *p_x_out = sp_x_out.get();
-
-        auto sp_x_out_sub = dynamic_cast<TT*>(x_out_sub.get())->get_cpu_accessible();
-        NT *p_x_out_sub = sp_x_out_sub.get();
+        auto [p_xo, p_yo, p_zo] = data<TT>(x_out, y_out, z_out);
+        auto [p_xos, p_yos, p_zos] = data<TT>(x_out_sub, y_out_sub, z_out_sub);
 
         for (unsigned long i = 0; i < nx; ++i)
-            p_x_out_sub[i] = p_x_out[extent[0] +i];
-
-        auto sp_y_out = dynamic_cast<TT*>(y_out.get())->get_cpu_accessible();
-        NT *p_y_out = sp_y_out.get();
-
-        auto sp_y_out_sub = dynamic_cast<TT*>(y_out_sub.get())->get_cpu_accessible();
-        NT *p_y_out_sub = sp_y_out_sub.get();
+            p_xos[i] = p_xo[extent[0] + i];
 
         for (unsigned long i = 0; i < ny; ++i)
-            p_y_out_sub[i] = p_y_out[extent[0] +i];
-
-        auto sp_z_out = dynamic_cast<TT*>(z_out.get())->get_cpu_accessible();
-        NT *p_z_out = sp_z_out.get();
-
-        auto sp_z_out_sub = dynamic_cast<TT*>(z_out_sub.get())->get_cpu_accessible();
-        NT *p_z_out_sub = sp_z_out_sub.get();
+            p_yos[i] = p_yo[extent[2] + i];
 
         for (unsigned long i = 0; i < nz; ++i)
-            p_z_out_sub[i] = p_z_out[extent[0] +i];
+            p_zos[i] = p_zo[extent[4] + i];
         )
 
     // update the mesh

--- a/alg/teca_cartesian_mesh_regrid.cxx
+++ b/alg/teca_cartesian_mesh_regrid.cxx
@@ -593,31 +593,31 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
             }
 
             NESTED_TEMPLATE_DISPATCH_FP(
-                const teca_variant_array_impl,
+                teca_variant_array_impl,
                 target_xc.get(),
                 _TGT,
 
-                auto sp_target_xc = static_cast<TT_TGT*>(target_xc.get())->get_cpu_accessible();
+                auto sp_target_xc = static_cast<const TT_TGT*>(target_xc.get())->get_cpu_accessible();
                 const NT_TGT *p_target_xc = sp_target_xc.get();
 
-                auto sp_target_yc = dynamic_cast<TT_TGT*>(target_yc.get())->get_cpu_accessible();
+                auto sp_target_yc = dynamic_cast<const TT_TGT*>(target_yc.get())->get_cpu_accessible();
                 const NT_TGT *p_target_yc = sp_target_yc.get();
 
-                auto sp_target_zc = dynamic_cast<TT_TGT*>(target_zc.get())->get_cpu_accessible();
+                auto sp_target_zc = dynamic_cast<const TT_TGT*>(target_zc.get())->get_cpu_accessible();
                 const NT_TGT *p_target_zc = sp_target_zc.get();
 
                 NESTED_TEMPLATE_DISPATCH_FP(
-                    const teca_variant_array_impl,
+                    teca_variant_array_impl,
                     source_xc.get(),
                     _SRC,
 
-                    auto sp_source_xc = dynamic_cast<TT_SRC*>(source_xc.get())->get_cpu_accessible();
+                    auto sp_source_xc = dynamic_cast<const TT_SRC*>(source_xc.get())->get_cpu_accessible();
                     const NT_SRC *p_source_xc = sp_source_xc.get();
 
-                    auto sp_source_yc = dynamic_cast<TT_SRC*>(source_yc.get())->get_cpu_accessible();
+                    auto sp_source_yc = dynamic_cast<const TT_SRC*>(source_yc.get())->get_cpu_accessible();
                     const NT_SRC *p_source_yc = sp_source_yc.get();
 
-                    auto sp_source_zc = dynamic_cast<TT_SRC*>(source_zc.get())->get_cpu_accessible();
+                    auto sp_source_zc = dynamic_cast<const TT_SRC*>(source_zc.get())->get_cpu_accessible();
                     const NT_SRC *p_source_zc = sp_source_zc.get();
 
                     const_p_teca_variant_array source_a = source_ac->get(source_arrays[i]);

--- a/alg/teca_cartesian_mesh_regrid.cxx
+++ b/alg/teca_cartesian_mesh_regrid.cxx
@@ -596,7 +596,7 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
                 TECA_STATUS("Interpolating data from \"" << source_arrays[i] << "\"")
             }
 
-            NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH_FP(
                 target_xc.get(), _TGT,
 
                 // get the target cooridnates
@@ -605,7 +605,7 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
                 auto [sp_target_yc, p_target_yc] = get_cpu_accessible<CTT_TGT>(target_yc);
                 auto [sp_target_zc, p_target_zc] = get_cpu_accessible<CTT_TGT>(target_zc);
 
-                NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_FP(
                     source_xc.get(), _SRC,
 
                     // get the target cooridnates
@@ -620,7 +620,7 @@ const_p_teca_dataset teca_cartesian_mesh_regrid::execute(
                     // allocate the target array
                     p_teca_variant_array target_a = source_a->new_instance(target_size);
 
-                    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+                    NESTED_VARIANT_ARRAY_DISPATCH(
                         target_a.get(), _DATA,
 
                         // interpolate

--- a/alg/teca_cartesian_mesh_source.cxx
+++ b/alg/teca_cartesian_mesh_source.cxx
@@ -2,6 +2,8 @@
 #include "teca_dataset.h"
 #include "teca_cartesian_mesh.h"
 #include "teca_coordinate_util.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <string>
 #include <vector>
@@ -10,6 +12,7 @@
 #include <boost/program_options.hpp>
 #endif
 
+using namespace teca_variant_array_util;
 
 struct teca_cartesian_mesh_source::internals_t
 {
@@ -46,12 +49,13 @@ void teca_cartesian_mesh_source::internals_t::initialize_axis(
     p_teca_variant_array_impl<num_t> x, unsigned long i0, unsigned long i1,
     num_t x0, num_t x1)
 {
+    assert(x->cpu_accessible());
+
     // generate an equally spaced coordinate axes
     unsigned long nx = i1 - i0 + 1;
     x->resize(nx);
 
-    auto spx = x->get_cpu_accessible();
-    auto px = spx.get();
+    num_t *px = x->data();
 
     // avoid divide by zero
     if (nx < 2)
@@ -635,6 +639,10 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
         return nullptr;
     }
 
+    // assume coordinate data is on the CPU
+    assert(in_x->cpu_accessible() && in_y->cpu_accessible() &&
+        in_z->cpu_accessible() && in_t->cpu_accessible());
+
     // get the extent of the dataset we could generate
     unsigned long md_whole_extent[6] = {0};
     if (this->internals->metadata.get("whole_extent", md_whole_extent, 6))
@@ -678,10 +686,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
         // translate time to a time step
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             in_t.get(),
-
-            auto spin_t = dynamic_cast<TT*>(in_t.get())->get_cpu_accessible();
-            NT *pin_t = spin_t.get();
-
+            auto [pin_t] = data<CTT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(temporal_bounds[0]), temporal_extent[0]))
             {

--- a/alg/teca_cartesian_mesh_source.cxx
+++ b/alg/teca_cartesian_mesh_source.cxx
@@ -83,8 +83,7 @@ void teca_cartesian_mesh_source::internals_t::initialize_axes(int type_code,
     z_axis = x_axis->new_instance();
     t_axis = x_axis->new_instance();
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x_axis.get(),
+    VARIANT_ARRAY_DISPATCH(x_axis.get(),
 
         internals_t::initialize_axis<NT>(std::static_pointer_cast<TT>(x_axis),
             extent[0], extent[1], bounds[0], bounds[1]);
@@ -110,8 +109,7 @@ void teca_cartesian_mesh_source::internals_t::initialize_axes(int type_code,
     y_axis = x_axis->new_instance();
     z_axis = x_axis->new_instance();
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x_axis.get(),
+    VARIANT_ARRAY_DISPATCH(x_axis.get(),
 
         internals_t::initialize_axis<NT>(std::static_pointer_cast<TT>(x_axis),
             extent[0], extent[1], bounds[0], bounds[1]);
@@ -684,7 +682,7 @@ const_p_teca_dataset teca_cartesian_mesh_source::execute(unsigned int port,
     if (!request.get("time", temporal_bounds[0]))
     {
         // translate time to a time step
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        VARIANT_ARRAY_DISPATCH_FP(
             in_t.get(),
             auto [pin_t] = data<CTT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,

--- a/alg/teca_component_area_filter.cxx
+++ b/alg/teca_component_area_filter.cxx
@@ -2,6 +2,7 @@
 
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_cartesian_mesh.h"
 #include "teca_string_util.h"
@@ -12,6 +13,8 @@
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
 #endif
+
+using namespace teca_variant_array_util;
 
 namespace {
 
@@ -303,31 +306,24 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
     // apply the filter
     NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-        labels_out.get(),
-        _LABEL,
+        labels_out.get(), _LABEL,
 
         // pointer to input/output labels
-        auto sp_labels_in = static_cast<const TT_LABEL*>(labels_in.get())->get_cpu_accessible();
-        const NT_LABEL *p_labels_in = sp_labels_in.get();
-
-        auto sp_labels_out = static_cast<TT_LABEL*>(labels_out.get())->get_cpu_accessible();
-        NT_LABEL *p_labels_out = sp_labels_out.get();
+        auto [sp_labels_in, p_labels_in] = get_cpu_accessible<CTT_LABEL>(labels_in);
+        auto [p_labels_out] = data<TT_LABEL>(labels_out);
 
         // pointer to input ids and a container to hold ids which remain
         // after the filtering operation
-        auto sp_ids_in = static_cast<const TT_LABEL*>(ids_in.get())->get_cpu_accessible();
-        const NT_LABEL *p_ids_in = sp_ids_in.get();
+        auto [sp_ids_in, p_ids_in] = get_cpu_accessible<CTT_LABEL>(ids_in);
 
         std::vector<NT_LABEL> ids_out;
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            areas_in.get(),
-            _AREA,
+            areas_in.get(), _AREA,
 
             // pointer to the areas in and a container to hold areas which
             // remain after the filtering operation
-            auto sp_areas = static_cast<const TT_AREA*>(areas_in.get())->get_cpu_accessible();
-            const NT_AREA *p_areas = sp_areas.get();
+            auto [sp_areas, p_areas] = get_cpu_accessible<CTT_AREA>(areas_in);
 
             std::vector<NT_AREA> areas_out;
 
@@ -356,7 +352,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
             }
             else
             {
-                decltype(std::map<NT_LABEL, NT_LABEL>()) label_map;
+                std::map<NT_LABEL, NT_LABEL> label_map;
 
                 // construct the map from input label to output label.
                 // removing a lable from the output ammounts to applying

--- a/alg/teca_component_area_filter.cxx
+++ b/alg/teca_component_area_filter.cxx
@@ -320,13 +320,13 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
         std::vector<NT_LABEL> ids_out;
 
-        NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             areas_in.get(),
             _AREA,
 
             // pointer to the areas in and a container to hold areas which
             // remain after the filtering operation
-            auto sp_areas = static_cast<TT_AREA*>(areas_in.get())->get_cpu_accessible();
+            auto sp_areas = static_cast<const TT_AREA*>(areas_in.get())->get_cpu_accessible();
             const NT_AREA *p_areas = sp_areas.get();
 
             std::vector<NT_AREA> areas_out;

--- a/alg/teca_component_area_filter.cxx
+++ b/alg/teca_component_area_filter.cxx
@@ -305,7 +305,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
     }
 
     // apply the filter
-    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_I(
         labels_out.get(), _LABEL,
 
         // pointer to input/output labels
@@ -318,7 +318,7 @@ const_p_teca_dataset teca_component_area_filter::execute(
 
         std::vector<NT_LABEL> ids_out;
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             areas_in.get(), _AREA,
 
             // pointer to the areas in and a container to hold areas which

--- a/alg/teca_component_statistics.cxx
+++ b/alg/teca_component_statistics.cxx
@@ -5,6 +5,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 
 #include <algorithm>
@@ -19,6 +20,8 @@
 
 using std::cerr;
 using std::endl;
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -129,39 +132,24 @@ const_p_teca_dataset teca_component_statistics::execute(
     unsigned long n_comps = component_ids->size();
 
     // make a time column
-    p_teca_double_array time = teca_double_array::New();
-    time->resize(n_comps);
-
-    auto spt = time->get_cpu_accessible();
-    double *pt = spt.get();
+    auto [time, pt] = ::New<teca_double_array>(n_comps);
 
     for (unsigned long i = 0; i < n_comps; ++i)
         pt[i] = t;
 
     // make a time step column
-    p_teca_unsigned_long_array step = teca_unsigned_long_array::New();
-    step->resize(n_comps);
-
-    auto sps = step->get_cpu_accessible();
-    unsigned long *ps = sps.get();
+    auto [step, ps] = ::New<teca_unsigned_long_array>(n_comps);
 
     for (unsigned long i = 0; i < n_comps; ++i)
         ps[i] = s;
 
     // compute a glonbal id, from the time step and component id
-    p_teca_unsigned_long_array global_component_ids =
-        teca_unsigned_long_array::New();
-
-    global_component_ids->resize(n_comps);
-
-    auto spgcid = global_component_ids->get_cpu_accessible();
-    unsigned long *pgcid = spgcid.get();
+    auto [global_component_ids, pgcid] = ::New<teca_unsigned_long_array>(n_comps);
 
     TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         component_ids.get(),
 
-        auto spcid = static_cast<TT*>(component_ids.get())->get_cpu_accessible();
-        NT *pcid = spcid.get();
+        auto [spcid, pcid] = get_cpu_accessible<CTT>(component_ids);
 
         unsigned long base = s*1000000;
         for (unsigned long i = 0; i < n_comps; ++i)

--- a/alg/teca_component_statistics.cxx
+++ b/alg/teca_component_statistics.cxx
@@ -146,8 +146,7 @@ const_p_teca_dataset teca_component_statistics::execute(
     // compute a glonbal id, from the time step and component id
     auto [global_component_ids, pgcid] = ::New<teca_unsigned_long_array>(n_comps);
 
-    TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-        component_ids.get(),
+    VARIANT_ARRAY_DISPATCH_I(component_ids.get(),
 
         auto [spcid, pcid] = get_cpu_accessible<CTT>(component_ids);
 

--- a/alg/teca_connected_components.cxx
+++ b/alg/teca_connected_components.cxx
@@ -420,8 +420,7 @@ const_p_teca_dataset teca_connected_components::execute(
     size_t n_elem = input_array->size();
     auto [components, p_components] = ::New<teca_short_array>(n_elem);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        input_array.get(),
+    VARIANT_ARRAY_DISPATCH(input_array.get(),
 
         auto [sp_in, p_in] = get_cpu_accessible<CTT>(input_array);
 

--- a/alg/teca_connected_components.cxx
+++ b/alg/teca_connected_components.cxx
@@ -422,10 +422,10 @@ const_p_teca_dataset teca_connected_components::execute(
 
     short max_component = 0;
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         input_array.get(),
 
-        auto sp_in = static_cast<TT*>(input_array.get())->get_cpu_accessible();
+        auto sp_in = static_cast<const TT*>(input_array.get())->get_cpu_accessible();
         const NT *p_in = sp_in.get();
 
         ::label(extent, periodic_in_x, periodic_in_y,

--- a/alg/teca_derived_quantity_numerics.h
+++ b/alg/teca_derived_quantity_numerics.h
@@ -55,8 +55,7 @@ struct TECA_EXPORT point_wise_average
         p_teca_variant_array avg = v0->new_instance();
         avg->resize(n_pts);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            v0.get(),
+        VARIANT_ARRAY_DISPATCH(v0.get(),
 
             assert_type<CTT>(v1);
             auto [sp_v0, p_v0, sp_v1, p_v1] = get_cpu_accessible<CTT>(v0, v1);
@@ -118,8 +117,7 @@ struct TECA_EXPORT point_wise_difference
         p_teca_variant_array diff = v0->new_instance();
         diff->resize(n_pts);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            v1.get(),
+        VARIANT_ARRAY_DISPATCH(v1.get(),
 
             assert_type<CTT>(v1);
             auto [sp_v0, p_v0, sp_v1, p_v1] = get_cpu_accessible<CTT>(v0, v1);

--- a/alg/teca_derived_quantity_numerics.h
+++ b/alg/teca_derived_quantity_numerics.h
@@ -6,6 +6,10 @@
 #include "teca_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#if !defined(SWIG)
+#include "teca_variant_array_util.h"
+using namespace teca_variant_array_util;
+#endif
 
 #include <string>
 #include <vector>
@@ -52,15 +56,11 @@ struct TECA_EXPORT point_wise_average
         avg->resize(n_pts);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
-            avg.get(),
-            auto sp_v0 = static_cast<const TT*>(v0.get())->get_cpu_accessible();
-            const NT *p_v0 = sp_v0.get();
+            v0.get(),
 
-            auto sp_v1 = dynamic_cast<const TT*>(v1.get())->get_cpu_accessible();
-            const NT *p_v1 = sp_v1.get();
-
-            auto sp_avg = static_cast<TT*>(avg.get())->get_cpu_accessible();
-            NT *p_avg = sp_avg.get();
+            assert_type<CTT>(v1);
+            auto [sp_v0, p_v0, sp_v1, p_v1] = get_cpu_accessible<CTT>(v0, v1);
+            auto [p_avg] = data<TT>(avg);
 
             for (unsigned long i = 0; i < n_pts; ++i)
                 p_avg[i] = (p_v0[i] + p_v1[i])/NT(2);
@@ -119,15 +119,11 @@ struct TECA_EXPORT point_wise_difference
         diff->resize(n_pts);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
-            diff.get(),
-            auto sp_v0 = static_cast<const TT*>(v0.get())->get_cpu_accessible();
-            const NT *p_v0 = sp_v0.get();
+            v1.get(),
 
-            auto sp_v1 = dynamic_cast<const TT*>(v1.get())->get_cpu_accessible();
-            const NT *p_v1 = sp_v1.get();
-
-            auto sp_diff = static_cast<TT*>(diff.get())->get_cpu_accessible();
-            NT *p_diff = sp_diff.get();
+            assert_type<CTT>(v1);
+            auto [sp_v0, p_v0, sp_v1, p_v1] = get_cpu_accessible<CTT>(v0, v1);
+            auto [p_diff] = data<TT>(diff);
 
             for (unsigned long i = 0; i < n_pts; ++i)
                 p_diff[i] = p_v1[i] - p_v0[i];

--- a/alg/teca_descriptive_statistics.cxx
+++ b/alg/teca_descriptive_statistics.cxx
@@ -5,6 +5,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -17,6 +18,8 @@
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
 #endif
+
+using namespace teca_variant_array_util;
 
 using std::string;
 using std::vector;
@@ -327,8 +330,7 @@ const_p_teca_dataset teca_descriptive_statistics::execute(
 
             size_t n = dep_var->size();
 
-            auto spv = static_cast<const TT*>(dep_var.get())->get_cpu_accessible();
-            const NT *pv = spv.get();
+            auto [spv, pv] = get_cpu_accessible<CTT>(dep_var);
 
             // compute stats
             NT mn = internal::min(pv, n);

--- a/alg/teca_descriptive_statistics.cxx
+++ b/alg/teca_descriptive_statistics.cxx
@@ -322,7 +322,7 @@ const_p_teca_dataset teca_descriptive_statistics::execute(
             return nullptr;
         }
 
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             dep_var.get(),
 
             size_t n = dep_var->size();

--- a/alg/teca_descriptive_statistics.cxx
+++ b/alg/teca_descriptive_statistics.cxx
@@ -325,8 +325,7 @@ const_p_teca_dataset teca_descriptive_statistics::execute(
             return nullptr;
         }
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            dep_var.get(),
+        VARIANT_ARRAY_DISPATCH(dep_var.get(),
 
             size_t n = dep_var->size();
 

--- a/alg/teca_elevation_mask.cxx
+++ b/alg/teca_elevation_mask.cxx
@@ -354,12 +354,12 @@ const_p_teca_dataset teca_elevation_mask::execute(
     p_teca_char_array mask = teca_char_array::New(mesh_height->size());
     char *p_mask = mask->data();
 
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         surface_elev.get(), _SURF,
 
         auto [sp_se, p_surface_elev] = get_cpu_accessible<CTT_SURF>(surface_elev);
 
-        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH(
             mesh_height.get(), _MESH,
 
             auto [sp_mh, p_mesh_height] = get_cpu_accessible<CTT_MESH>(mesh_height);

--- a/alg/teca_elevation_mask.cxx
+++ b/alg/teca_elevation_mask.cxx
@@ -351,20 +351,20 @@ const_p_teca_dataset teca_elevation_mask::execute(
     auto sp_mask = mask->get_cpu_accessible();
     char *p_mask = sp_mask.get();
 
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         surface_elev.get(),
         _SURF,
 
-        auto sp_surface_elev = static_cast<TT_SURF*>
+        auto sp_surface_elev = static_cast<const TT_SURF*>
             (surface_elev.get())->get_cpu_accessible();
 
         const NT_SURF *p_surface_elev = sp_surface_elev.get();
 
-        NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             mesh_height.get(),
             _MESH,
 
-            auto sp_mesh_height = static_cast<TT_MESH *>
+            auto sp_mesh_height = static_cast<const TT_MESH *>
                 (mesh_height.get())->get_cpu_accessible();
 
             const NT_MESH *p_mesh_height = sp_mesh_height.get();

--- a/alg/teca_elevation_mask.cxx
+++ b/alg/teca_elevation_mask.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -23,6 +24,9 @@
 #endif
 
 //#define TECA_DEBUG
+
+using namespace teca_variant_array_util;
+
 
 struct teca_elevation_mask::internals_t
 {
@@ -348,26 +352,17 @@ const_p_teca_dataset teca_elevation_mask::execute(
 
     // compute the mask
     p_teca_char_array mask = teca_char_array::New(mesh_height->size());
-    auto sp_mask = mask->get_cpu_accessible();
-    char *p_mask = sp_mask.get();
+    char *p_mask = mask->data();
 
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-        surface_elev.get(),
-        _SURF,
+        surface_elev.get(), _SURF,
 
-        auto sp_surface_elev = static_cast<const TT_SURF*>
-            (surface_elev.get())->get_cpu_accessible();
-
-        const NT_SURF *p_surface_elev = sp_surface_elev.get();
+        auto [sp_se, p_surface_elev] = get_cpu_accessible<CTT_SURF>(surface_elev);
 
         NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-            mesh_height.get(),
-            _MESH,
+            mesh_height.get(), _MESH,
 
-            auto sp_mesh_height = static_cast<const TT_MESH *>
-                (mesh_height.get())->get_cpu_accessible();
-
-            const NT_MESH *p_mesh_height = sp_mesh_height.get();
+            auto [sp_mh, p_mesh_height] = get_cpu_accessible<CTT_MESH>(mesh_height);
 
             internals_t::mask_by_surface_elevation(nx, ny, nz,
                 p_mask, p_surface_elev, p_mesh_height);

--- a/alg/teca_face_to_cell_centering.cxx
+++ b/alg/teca_face_to_cell_centering.cxx
@@ -286,8 +286,7 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         std::string &array_name = x_face_arrays->get_name(i);
         p_teca_variant_array fc = x_face_arrays->get(i);
         p_teca_variant_array cc = fc->new_instance(nxyz);
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            fc.get(),
+        VARIANT_ARRAY_DISPATCH(fc.get(),
 
             auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
             auto [pcc] = data<TT>(cc);
@@ -307,8 +306,7 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         std::string &array_name = y_face_arrays->get_name(i);
         p_teca_variant_array fc = y_face_arrays->get(i);
         p_teca_variant_array cc = fc->new_instance(nxyz);
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            fc.get(),
+        VARIANT_ARRAY_DISPATCH(fc.get(),
 
             auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
             auto [pcc] = data<TT>(cc);
@@ -328,8 +326,7 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         std::string &array_name = z_face_arrays->get_name(i);
         p_teca_variant_array fc = z_face_arrays->get(i);
         p_teca_variant_array cc = fc->new_instance(nxyz);
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            fc.get(),
+        VARIANT_ARRAY_DISPATCH(fc.get(),
 
             auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
             auto [pcc] = data<TT>(cc);

--- a/alg/teca_face_to_cell_centering.cxx
+++ b/alg/teca_face_to_cell_centering.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -21,6 +22,7 @@ using std::vector;
 using std::cerr;
 using std::endl;
 using std::cos;
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -287,11 +289,8 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             fc.get(),
 
-            auto spfc = static_cast<TT*>(fc.get())->get_cpu_accessible();
-            NT *pfc = spfc.get();
-
-            auto spcc = static_cast<TT*>(cc.get())->get_cpu_accessible();
-            NT *pcc = spcc.get();
+            auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
+            auto [pcc] = data<TT>(cc);
 
             ::x_face_to_cell(nx, ny, nz, nxy, pfc, pcc);
             )
@@ -311,11 +310,8 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             fc.get(),
 
-            auto spfc = static_cast<TT*>(fc.get())->get_cpu_accessible();
-            NT *pfc = spfc.get();
-
-            auto spcc = static_cast<TT*>(cc.get())->get_cpu_accessible();
-            NT *pcc = spcc.get();
+            auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
+            auto [pcc] = data<TT>(cc);
 
             ::y_face_to_cell(nx, ny, nz, nxy, pfc, pcc);
             )
@@ -335,11 +331,8 @@ const_p_teca_dataset teca_face_to_cell_centering::execute(
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             fc.get(),
 
-            auto spfc = static_cast<TT*>(fc.get())->get_cpu_accessible();
-            NT *pfc = spfc.get();
-
-            auto spcc = static_cast<TT*>(cc.get())->get_cpu_accessible();
-            NT *pcc = spcc.get();
+            auto [spfc, pfc] = get_cpu_accessible<CTT>(fc);
+            auto [pcc] = data<TT>(cc);
 
             ::z_face_to_cell(nx, ny, nz, nxy, pfc, pcc);
             )

--- a/alg/teca_integrated_vapor_transport.cxx
+++ b/alg/teca_integrated_vapor_transport.cxx
@@ -358,10 +358,10 @@ int dispatch(int device_id, size_t nx, size_t ny, size_t nz,
     ivt_u = wind_u->new_instance(alloc);
     ivt_v = wind_u->new_instance(alloc);
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         p.get(), _COORDS,
 
-        auto sp_p = static_cast<TT_COORDS*>
+        auto sp_p = static_cast<const TT_COORDS*>
             (p.get())->get_cuda_accessible();
 
         const NT_COORDS *p_p = sp_p.get();
@@ -575,14 +575,14 @@ int dispatch(size_t nx, size_t ny, size_t nz,
     ivt_u = wind_u->new_instance();
     ivt_v = wind_u->new_instance();
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         p.get(), _COORDS,
 
-        auto sp_p = static_cast<TT_COORDS*>(p.get())->get_cpu_accessible();
+        auto sp_p = static_cast<const TT_COORDS*>(p.get())->get_cpu_accessible();
         const NT_COORDS *p_p = sp_p.get();
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            ivt_u.get(), _DATA,
+            wind_u.get(), _DATA,
 
             // resize and initialize the ivt output to zero
             TT_DATA *tivt_u = static_cast<TT_DATA*>(ivt_u.get());

--- a/alg/teca_integrated_vapor_transport.cxx
+++ b/alg/teca_integrated_vapor_transport.cxx
@@ -356,12 +356,12 @@ int dispatch(int device_id, size_t nx, size_t ny, size_t nz,
         return -1;
     }
 
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         p.get(), _COORDS,
 
         auto [sp_p, p_p] = get_cuda_accessible<CTT_COORDS>(p);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             wind_u.get(), _DATA,
 
             // allocate and initialize the ivt output to zero
@@ -543,12 +543,12 @@ int dispatch(size_t nx, size_t ny, size_t nz,
     p_teca_variant_array &ivt_u,
     p_teca_variant_array &ivt_v)
 {
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         p.get(), _COORDS,
 
         auto [sp_p, p_p] = get_cpu_accessible<CTT_COORDS>(p);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             wind_u.get(), _DATA,
 
             // allocate and initialize the ivt output to zero

--- a/alg/teca_integrated_water_vapor.cxx
+++ b/alg/teca_integrated_water_vapor.cxx
@@ -314,10 +314,10 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
     out_mesh->get_point_arrays()->set(this->iwv_variable, iwv);
 
     // calculate IWV
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         p.get(), _COORDS,
 
-        auto sp_p = static_cast<TT_COORDS*>(p.get())->get_cpu_accessible();
+        auto sp_p = static_cast<const TT_COORDS*>(p.get())->get_cpu_accessible();
         const NT_COORDS *p_p = sp_p.get();
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,

--- a/alg/teca_integrated_water_vapor.cxx
+++ b/alg/teca_integrated_water_vapor.cxx
@@ -318,12 +318,12 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
     out_mesh->get_point_arrays()->set(this->iwv_variable, iwv);
 
     // calculate IWV
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         p.get(), _COORDS,
 
         auto [sp_p, p_p] = get_cpu_accessible<CTT_COORDS>(p);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             iwv.get(), _DATA,
 
             auto [sp_q, p_q] = get_cpu_accessible<CTT_DATA>(q);

--- a/alg/teca_integrated_water_vapor.cxx
+++ b/alg/teca_integrated_water_vapor.cxx
@@ -4,8 +4,10 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_coordinate_util.h"
+#include "teca_valid_value_mask.h"
 
 #include <algorithm>
 #include <iostream>
@@ -21,6 +23,8 @@ using std::vector;
 using std::cerr;
 using std::endl;
 using std::cos;
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -317,24 +321,17 @@ const_p_teca_dataset teca_integrated_water_vapor::execute(
     NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         p.get(), _COORDS,
 
-        auto sp_p = static_cast<const TT_COORDS*>(p.get())->get_cpu_accessible();
-        const NT_COORDS *p_p = sp_p.get();
+        auto [sp_p, p_p] = get_cpu_accessible<CTT_COORDS>(p);
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             iwv.get(), _DATA,
 
-            auto sp_iwv = static_cast<TT_DATA*>(iwv.get())->get_cpu_accessible();
-            NT_DATA *p_iwv = sp_iwv.get();
-
-            auto sp_q = static_cast<const TT_DATA*>(q.get())->get_cpu_accessible();
-            const NT_DATA *p_q = sp_q.get();
+            auto [sp_q, p_q] = get_cpu_accessible<CTT_DATA>(q);
+            auto [p_iwv] = data<TT_DATA>(iwv);
 
             if (q_valid)
             {
-                using TT_MASK = teca_char_array;
-                auto sp_q_valid = dynamic_cast<const TT_MASK*>(q_valid.get())->get_cpu_accessible();
-                const char *p_q_valid = sp_q_valid.get();
-
+                auto [spqv, p_q_valid] = get_cpu_accessible<CTT_MASK>(q_valid);
                 ::cartesian_iwv(nx, ny, nz, p_p, p_q, p_q_valid, p_iwv);
             }
             else

--- a/alg/teca_l2_norm.cxx
+++ b/alg/teca_l2_norm.cxx
@@ -78,8 +78,7 @@ int dispatch(p_teca_variant_array &l2_norm,
     p_teca_variant_array tmp = c0->new_instance(n_elem);
 
     // compute l2 norm
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        l2_norm.get(),
+    VARIANT_ARRAY_DISPATCH_FP(l2_norm.get(),
 
         auto [ptmp, pl2n] = data<TT>(tmp, l2_norm);
         auto [spc0, pc0] = get_cpu_accessible<CTT>(c0);
@@ -190,8 +189,7 @@ int dispatch(int device_id, p_teca_variant_array &l2_norm,
     l2_norm = c0->new_instance(n_elem, allocator::cuda_async);
 
     // compute l2 norm
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        l2_norm.get(),
+    VARIANT_ARRAY_DISPATCH_FP(l2_norm.get(),
 
         auto [pl2n] = data<TT>(l2_norm);
         auto [spc0, pc0] = get_cuda_accessible<CTT>(c0);

--- a/alg/teca_laplacian.cxx
+++ b/alg/teca_laplacian.cxx
@@ -381,15 +381,13 @@ const_p_teca_dataset teca_laplacian::execute(
     p_teca_variant_array lapl = comp_0->new_instance(comp_0->size());
 
     // compute laplacian
-    NESTED_TEMPLATE_DISPATCH_FP(
-        teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         lon.get(), 1,
 
         assert_type<CTT1>(lat);
         auto [splo, p_lon, spla, p_lat] = get_cpu_accessible<CTT1>(lon, lat);
 
-        NESTED_TEMPLATE_DISPATCH_FP(
-            teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             lapl.get(), 2,
 
             auto [sp_comp_0, p_comp_0] = get_cpu_accessible<CTT2>(comp_0);

--- a/alg/teca_laplacian.cxx
+++ b/alg/teca_laplacian.cxx
@@ -375,20 +375,19 @@ const_p_teca_dataset teca_laplacian::execute(
     }
 
     // allocate the output array
-    p_teca_variant_array lapl = comp_0->new_instance();
-    lapl->resize(comp_0->size());
+    p_teca_variant_array lapl = comp_0->new_instance(comp_0->size());
 
     // compute laplacian
     NESTED_TEMPLATE_DISPATCH_FP(
-        const teca_variant_array_impl,
+        teca_variant_array_impl,
         lon.get(), 1,
 
-        auto sp_lon = dynamic_cast<TT1*>
+        auto sp_lon = dynamic_cast<const TT1*>
             (lon.get())->get_cpu_accessible();
 
         const NT1 *p_lon = sp_lon.get();
 
-        auto sp_lat = dynamic_cast<TT1*>
+        auto sp_lat = dynamic_cast<const TT1*>
             (lat.get())->get_cpu_accessible();
 
         const NT1 *p_lat = sp_lat.get();
@@ -397,7 +396,7 @@ const_p_teca_dataset teca_laplacian::execute(
             teca_variant_array_impl,
             lapl.get(), 2,
 
-            auto sp_comp_0 = dynamic_cast<const TT2*>
+            auto sp_comp_0 = static_cast<const TT2*>
                 (comp_0.get())->get_cpu_accessible();
 
             const NT2 *p_comp_0 = sp_comp_0.get();

--- a/alg/teca_laplacian.cxx
+++ b/alg/teca_laplacian.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 
 #include <algorithm>
@@ -21,6 +22,8 @@ using std::cerr;
 using std::endl;
 using std::cos;
 using std::tan;
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -382,29 +385,15 @@ const_p_teca_dataset teca_laplacian::execute(
         teca_variant_array_impl,
         lon.get(), 1,
 
-        auto sp_lon = dynamic_cast<const TT1*>
-            (lon.get())->get_cpu_accessible();
-
-        const NT1 *p_lon = sp_lon.get();
-
-        auto sp_lat = dynamic_cast<const TT1*>
-            (lat.get())->get_cpu_accessible();
-
-        const NT1 *p_lat = sp_lat.get();
+        assert_type<CTT1>(lat);
+        auto [splo, p_lon, spla, p_lat] = get_cpu_accessible<CTT1>(lon, lat);
 
         NESTED_TEMPLATE_DISPATCH_FP(
             teca_variant_array_impl,
             lapl.get(), 2,
 
-            auto sp_comp_0 = static_cast<const TT2*>
-                (comp_0.get())->get_cpu_accessible();
-
-            const NT2 *p_comp_0 = sp_comp_0.get();
-
-            auto sp_lapl = dynamic_cast<TT2*>
-                (lapl.get())->get_cpu_accessible();
-
-            NT2 *p_lapl = sp_lapl.get();
+            auto [sp_comp_0, p_comp_0] = get_cpu_accessible<CTT2>(comp_0);
+            auto [p_lapl] = data<TT2>(lapl);
 
             ::laplacian(p_lapl, p_lon, p_lat,
                 p_comp_0, lon->size(), lat->size());

--- a/alg/teca_latitude_damper.cxx
+++ b/alg/teca_latitude_damper.cxx
@@ -293,7 +293,7 @@ const_p_teca_dataset teca_latitude_damper::execute(
     p_teca_variant_array filter_array = lat->new_instance(n_lat);
 
     // Get the gaussian filter
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         lat.get(), _COORD,
 
         auto [sp_lat, p_lat] = get_cpu_accessible<TT_COORD>(lat);
@@ -318,7 +318,7 @@ const_p_teca_dataset teca_latitude_damper::execute(
             size_t n_elem = input_array->size();
             p_teca_variant_array damped_array = input_array->new_instance(n_elem);
 
-            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH(
                 input_array.get(), _DATA,
 
                 auto [sp_in, p_in] = get_cpu_accessible<CTT_DATA>(input_array);

--- a/alg/teca_mask.cxx
+++ b/alg/teca_mask.cxx
@@ -3,6 +3,7 @@
 #include "teca_mesh.h"
 #include "teca_array_collection.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_cartesian_mesh.h"
 
@@ -17,6 +18,8 @@ using std::vector;
 using std::set;
 using std::cerr;
 using std::endl;
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 namespace {
@@ -185,13 +188,10 @@ const_p_teca_dataset teca_mask::execute(
         p_teca_variant_array mask = input_array->new_instance(n_elem);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
-            mask.get(),
+            input_array.get(),
 
-            auto sp_in = static_cast<const TT*>(input_array.get())->get_cpu_accessible();
-            auto p_in = sp_in.get();
-
-            auto sp_mask = static_cast<TT*>(mask.get())->get_cpu_accessible();
-            auto p_mask = sp_mask.get();
+            auto [p_mask] = data<TT>(mask);
+            auto [sp_in, p_in] = get_cpu_accessible<CTT>(input_array);
 
             ::apply_mask(p_mask, p_in,  n_elem,
                 static_cast<NT>(low_val), static_cast<NT>(high_val),

--- a/alg/teca_mask.cxx
+++ b/alg/teca_mask.cxx
@@ -187,8 +187,7 @@ const_p_teca_dataset teca_mask::execute(
         size_t n_elem = input_array->size();
         p_teca_variant_array mask = input_array->new_instance(n_elem);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            input_array.get(),
+        VARIANT_ARRAY_DISPATCH(input_array.get(),
 
             auto [p_mask] = data<TT>(mask);
             auto [sp_in, p_in] = get_cpu_accessible<CTT>(input_array);

--- a/alg/teca_normalize_coordinates.cxx
+++ b/alg/teca_normalize_coordinates.cxx
@@ -99,7 +99,7 @@ int internals::reorder(p_teca_variant_array &x_out,
     unsigned long nx = x->size();
     unsigned long x1 = nx - 1;
 
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         x.get(), _C,
 
         auto [spx, px] = get_cpu_accessible<CTT_C>(x);
@@ -206,7 +206,7 @@ int internals::inv_periodic_shift_x(p_teca_unsigned_long_array &map,
 {
     unsigned long nx = x->size();
 
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         x.get(), _C,
 
         auto [spx, px] = get_cpu_accessible<CTT_C>(x);
@@ -238,7 +238,7 @@ int internals::periodic_shift_x(p_teca_variant_array &x_out,
     unsigned long nx = x->size();
     unsigned long x1 = nx - 1;
 
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         x.get(), _C,
 
         auto [spx, px] = get_cpu_accessible<CTT_C>(x);
@@ -354,7 +354,7 @@ int internals::periodic_shift_x(p_teca_array_collection arrays,
         p_teca_variant_array a = arrays->get(l);
 
         p_teca_variant_array ao = a->new_instance(nxyzo);
-        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH(
             a.get(), _A,
 
             auto [spa, pa] = get_cpu_accessible<CTT_A>(a);
@@ -423,7 +423,7 @@ int internals::ascending_order_y(p_teca_array_collection arrays,
         // apply the transform
         p_teca_variant_array a = arrays->get(l);
         p_teca_variant_array ao = a->new_instance(nxyz);
-        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH(
             a.get(), _A,
 
             auto [spa, pa] = get_cpu_accessible<CTT_A>(a);

--- a/alg/teca_normalize_coordinates.cxx
+++ b/alg/teca_normalize_coordinates.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_coordinate_util.h"
 #include "teca_metadata_util.h"
@@ -17,6 +18,8 @@
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
 #endif
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -99,8 +102,7 @@ int internals::reorder(p_teca_variant_array &x_out,
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
-        const NT_C *px = spx.get();
+        auto [spx, px] = get_cpu_accessible<CTT_C>(x);
 
         // if comp(x0, x1) reverse the axis.
         // when comp is less than the output will be ascending
@@ -113,9 +115,7 @@ int internals::reorder(p_teca_variant_array &x_out,
 
         using TT_C_OUT = teca_variant_array_impl<NT_C>;
         std::shared_ptr<TT_C_OUT> xo = TT_C_OUT::New(nx);
-
-        auto spxo = xo->get_cpu_accessible();
-        NT_C *pxo = spxo.get();
+        NT_C *pxo = xo->data();
 
         pxo += x1;
         for (unsigned long i = 0; i < nx; ++i)
@@ -209,12 +209,10 @@ int internals::inv_periodic_shift_x(p_teca_unsigned_long_array &map,
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
-        const NT_C *px = spx.get();
+        auto [spx, px] = get_cpu_accessible<CTT_C>(x);
 
         map = teca_unsigned_long_array::New(nx);
-        auto spmap = map->get_cpu_accessible();
-        unsigned long *pmap = spmap.get();
+        unsigned long *pmap = map->data();
 
         inv_periodic_shift_x(pmap, px, nx);
 
@@ -243,8 +241,7 @@ int internals::periodic_shift_x(p_teca_variant_array &x_out,
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
-        const NT_C *px = spx.get();
+        auto [spx, px] = get_cpu_accessible<CTT_C>(x);
 
         // check that the shift is needed.
         shifted_x = (px[0] < NT_C(0));
@@ -280,15 +277,10 @@ int internals::periodic_shift_x(p_teca_variant_array &x_out,
         }
 
         p_teca_variant_array xo = x->new_instance(nx);
-
-        using TT_C_OUT = teca_variant_array_impl<NT_C>;
-        auto spxo = static_cast<TT_C_OUT*>(xo.get())->get_cpu_accessible();
-        NT_C *pxo = spxo.get();
+        auto [pxo] = data<TT_C>(xo);
 
         map = teca_unsigned_long_array::New(nx);
-
-        auto spmap = map->get_cpu_accessible();
-        unsigned long *pmap = spmap.get();
+        unsigned long *pmap = map->data();
 
         periodic_shift_x(pxo, pmap, px, nx);
 
@@ -317,21 +309,20 @@ int internals::ascending_order_y(
 }
 
 // --------------------------------------------------------------------------
-int internals::periodic_shift_x(p_teca_array_collection data,
+int internals::periodic_shift_x(p_teca_array_collection arrays,
     const teca_metadata &attributes,
     const const_p_teca_unsigned_long_array &shift_map,
     const unsigned long *extent_in,
     const unsigned long *extent_out)
 {
     // apply periodic shift in the x-direction
-    auto spmap = shift_map->get_cpu_accessible();
-    const unsigned long *pmap = spmap.get();
+    const unsigned long *pmap = shift_map->data();
 
-    unsigned int n_arrays = data->size();
+    unsigned int n_arrays = arrays->size();
     for (unsigned int l = 0; l < n_arrays; ++l)
     {
         // get the extent of the input/output array
-        const std::string &array_name = data->get_name(l);
+        const std::string &array_name = arrays->get_name(l);
         teca_metadata array_attributes;
         if (attributes.get(array_name, array_attributes))
         {
@@ -360,17 +351,14 @@ int internals::periodic_shift_x(p_teca_array_collection data,
         unsigned long nxyo = nxo*nyo;
         unsigned long nxyzo = nxyo*nzo;
 
-        p_teca_variant_array a = data->get(l);
+        p_teca_variant_array a = arrays->get(l);
 
         p_teca_variant_array ao = a->new_instance(nxyzo);
         NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             a.get(), _A,
 
-            auto spa = static_cast<TT_A*>(a.get())->get_cpu_accessible();
-            NT_A *pa = spa.get();
-
-            auto spao = static_cast<TT_A*>(ao.get())->get_cpu_accessible();
-            NT_A *pao = spao.get();
+            auto [spa, pa] = get_cpu_accessible<CTT_A>(a);
+            auto [pao] = data<TT_A>(ao);
 
             for (unsigned long k = 0; k < nzo; ++k)
             {
@@ -381,7 +369,7 @@ int internals::periodic_shift_x(p_teca_array_collection data,
                     unsigned long jji = kki + j*nxi;
                     unsigned long jjo = kko + j*nxo;
 
-                    NT_A *par = pa + jji;
+                    const NT_A *par = pa + jji;
                     NT_A *paor = pao + jjo;
 
                     for (unsigned long i = 0; i < nxo; ++i)
@@ -392,22 +380,22 @@ int internals::periodic_shift_x(p_teca_array_collection data,
             }
             )
 
-        data->set(l, ao);
+        arrays->set(l, ao);
     }
 
     return 0;
 }
 
 // --------------------------------------------------------------------------
-int internals::ascending_order_y(p_teca_array_collection data,
+int internals::ascending_order_y(p_teca_array_collection arrays,
     const teca_metadata &attributes, const unsigned long *mesh_extent)
 {
     // for any coodinate axes that have been transformed from descending order
     // into ascending order, apply the same transform to the scalar data arrays
-    unsigned int n_arrays = data->size();
+    unsigned int n_arrays = arrays->size();
     for (unsigned int l = 0; l < n_arrays; ++l)
     {
-        const std::string &array_name = data->get_name(l);
+        const std::string &array_name = arrays->get_name(l);
 
         // get the extent of the array
         unsigned long array_extent[8] = {0ul};
@@ -433,16 +421,13 @@ int internals::ascending_order_y(p_teca_array_collection data,
         unsigned long y1 = ny - 1;
 
         // apply the transform
-        p_teca_variant_array a = data->get(l);
+        p_teca_variant_array a = arrays->get(l);
         p_teca_variant_array ao = a->new_instance(nxyz);
         NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             a.get(), _A,
 
-            auto spa = static_cast<TT_A*>(a.get())->get_cpu_accessible();
-            NT_A *pa = spa.get();
-
-            auto spao = static_cast<TT_A*>(ao.get())->get_cpu_accessible();
-            NT_A *pao = spao.get();
+            auto [spa, pa] = get_cpu_accessible<CTT_A>(a);
+            auto [pao] = ::data<TT_A>(ao);
 
             for (unsigned long k = 0; k < nz; ++k)
             {
@@ -451,14 +436,14 @@ int internals::ascending_order_y(p_teca_array_collection data,
                 {
                     unsigned long jj = kk + j*nx;
                     unsigned long jjo = kk + (y1 - j)*nx;
-                    NT_A *par = pa + jj;
+                    const NT_A *par = pa + jj;
                     NT_A *paor = pao + jjo;
                     for (unsigned long i = 0; i < nx; ++i)
                         paor[i] = par[i];
                 }
             }
             )
-        data->set(l, ao);
+        arrays->set(l, ao);
     }
 
     return 0;

--- a/alg/teca_normalize_coordinates.cxx
+++ b/alg/teca_normalize_coordinates.cxx
@@ -96,10 +96,10 @@ int internals::reorder(p_teca_variant_array &x_out,
     unsigned long nx = x->size();
     unsigned long x1 = nx - 1;
 
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<TT_C*>(x.get())->get_cpu_accessible();
+        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
         const NT_C *px = spx.get();
 
         // if comp(x0, x1) reverse the axis.
@@ -206,10 +206,10 @@ int internals::inv_periodic_shift_x(p_teca_unsigned_long_array &map,
 {
     unsigned long nx = x->size();
 
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<TT_C*>(x.get())->get_cpu_accessible();
+        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
         const NT_C *px = spx.get();
 
         map = teca_unsigned_long_array::New(nx);
@@ -240,10 +240,10 @@ int internals::periodic_shift_x(p_teca_variant_array &x_out,
     unsigned long nx = x->size();
     unsigned long x1 = nx - 1;
 
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         x.get(), _C,
 
-        auto spx = dynamic_cast<TT_C*>(x.get())->get_cpu_accessible();
+        auto spx = dynamic_cast<const TT_C*>(x.get())->get_cpu_accessible();
         const NT_C *px = spx.get();
 
         // check that the shift is needed.

--- a/alg/teca_simple_moving_average.cxx
+++ b/alg/teca_simple_moving_average.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_metadata_util.h"
 
@@ -19,6 +20,9 @@ using std::string;
 using std::vector;
 using std::cerr;
 using std::endl;
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 //#define TECA_DEBUG
 
@@ -200,7 +204,8 @@ const_p_teca_dataset teca_simple_moving_average::execute(
     p_teca_array_collection out_arrays = out_mesh->get_point_arrays();
 
     // initialize with a copy of the first dataset
-    out_arrays->copy(in_mesh->get_point_arrays());
+    out_arrays->copy(in_mesh->get_point_arrays(), allocator::malloc);
+
     size_t n_arrays = out_arrays->size();
     size_t n_elem = n_arrays ? out_arrays->get(0)->size() : 0;
 
@@ -216,15 +221,11 @@ const_p_teca_dataset teca_simple_moving_average::execute(
             const_p_teca_variant_array in_a = in_arrays->get(j);
             p_teca_variant_array out_a = out_arrays->get(j);
 
-            TEMPLATE_DISPATCH(
-                teca_variant_array_impl,
-                out_a.get(),
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
+                in_a.get(),
 
-                auto sp_in_a = dynamic_cast<const TT*>(in_a.get())->get_cpu_accessible();
-                const NT *p_in_a = sp_in_a.get();
-
-                auto sp_out_a = dynamic_cast<TT*>(out_a.get())->get_cpu_accessible();
-                NT *p_out_a = sp_out_a.get();
+                auto [sp_in_a, p_in_a] = get_cpu_accessible<CTT>(in_a);
+                auto [p_out_a] = data<TT>(out_a);
 
                 for (size_t q = 0; q < n_elem; ++q)
                     p_out_a[q] += p_in_a[q];
@@ -237,12 +238,10 @@ const_p_teca_dataset teca_simple_moving_average::execute(
     {
         p_teca_variant_array out_a = out_arrays->get(j);
 
-        TEMPLATE_DISPATCH(
-            teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             out_a.get(),
 
-            auto sp_out_a = dynamic_cast<TT*>(out_a.get())->get_cpu_accessible();
-            NT *p_out_a = sp_out_a.get();
+            auto [p_out_a] = data<TT>(out_a);
 
             NT fac = static_cast<NT>(n_meshes);
 

--- a/alg/teca_simple_moving_average.cxx
+++ b/alg/teca_simple_moving_average.cxx
@@ -221,8 +221,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
             const_p_teca_variant_array in_a = in_arrays->get(j);
             p_teca_variant_array out_a = out_arrays->get(j);
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                in_a.get(),
+            VARIANT_ARRAY_DISPATCH(in_a.get(),
 
                 auto [sp_in_a, p_in_a] = get_cpu_accessible<CTT>(in_a);
                 auto [p_out_a] = data<TT>(out_a);
@@ -238,8 +237,7 @@ const_p_teca_dataset teca_simple_moving_average::execute(
     {
         p_teca_variant_array out_a = out_arrays->get(j);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_a.get(),
+        VARIANT_ARRAY_DISPATCH(out_a.get(),
 
             auto [p_out_a] = data<TT>(out_a);
 

--- a/alg/teca_table_calendar.cxx
+++ b/alg/teca_table_calendar.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -28,6 +29,8 @@ using std::vector;
 using std::set;
 using std::cerr;
 using std::endl;
+
+using namespace teca_variant_array_util;
 
 // --------------------------------------------------------------------------
 teca_table_calendar::teca_table_calendar() :
@@ -263,8 +266,7 @@ const_p_teca_dataset teca_table_calendar::execute(
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         time.get(),
 
-        auto scurr_time = static_cast<const TT*>(time.get())->get_cpu_accessible();
-        const NT *curr_time = scurr_time.get();
+        auto [spct, curr_time] = get_cpu_accessible<CTT>(time);
 
         for (unsigned long i = 0; i < n_rows; ++i)
         {

--- a/alg/teca_table_calendar.cxx
+++ b/alg/teca_table_calendar.cxx
@@ -260,10 +260,10 @@ const_p_teca_dataset teca_table_calendar::execute(
     out_table->get_metadata().set("attributes", atrs);
 
     // make the date computations
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         time.get(),
 
-        auto scurr_time = static_cast<TT*>(time.get())->get_cpu_accessible();
+        auto scurr_time = static_cast<const TT*>(time.get())->get_cpu_accessible();
         const NT *curr_time = scurr_time.get();
 
         for (unsigned long i = 0; i < n_rows; ++i)

--- a/alg/teca_table_calendar.cxx
+++ b/alg/teca_table_calendar.cxx
@@ -263,8 +263,7 @@ const_p_teca_dataset teca_table_calendar::execute(
     out_table->get_metadata().set("attributes", atrs);
 
     // make the date computations
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH(time.get(),
 
         auto [spct, curr_time] = get_cpu_accessible<CTT>(time);
 

--- a/alg/teca_table_region_mask.cxx
+++ b/alg/teca_table_region_mask.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_distance_function.h"
 #include "teca_geometry.h"
@@ -26,6 +27,7 @@
 
 using std::cerr;
 using std::endl;
+using namespace teca_variant_array_util;
 
 // --------------------------------------------------------------------------
 teca_table_region_mask::teca_table_region_mask() :
@@ -181,19 +183,14 @@ const_p_teca_dataset teca_table_region_mask::execute(
     short T = this->invert ? 0 : 1;
     short F = this->invert ? 1 : 0;
 
-    p_teca_short_array mask = teca_short_array::New(n_rows, F);
-    auto spmask = mask->get_cpu_accessible();
-    short *pmask = spmask.get();
+    auto [mask, pmask] = ::New<teca_short_array>(n_rows, F);
     unsigned int nhit = 0;
 
     TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(),
 
-        auto spx = static_cast<const TT*>(x.get())->get_cpu_accessible();
-        auto px = spx.get();
-
-        auto spy = static_cast<const TT*>(y.get())->get_cpu_accessible();
-        auto py = spy.get();
+        assert_type<CTT>(y);
+        auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
 
         for (unsigned long i = 0; i < n_rows; ++i)
         {

--- a/alg/teca_table_region_mask.cxx
+++ b/alg/teca_table_region_mask.cxx
@@ -186,7 +186,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
     short *pmask = spmask.get();
     unsigned int nhit = 0;
 
-    TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(),
 
         auto spx = static_cast<const TT*>(x.get())->get_cpu_accessible();

--- a/alg/teca_table_region_mask.cxx
+++ b/alg/teca_table_region_mask.cxx
@@ -186,8 +186,7 @@ const_p_teca_dataset teca_table_region_mask::execute(
     auto [mask, pmask] = ::New<teca_short_array>(n_rows, F);
     unsigned int nhit = 0;
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);

--- a/alg/teca_table_remove_rows.cxx
+++ b/alg/teca_table_remove_rows.cxx
@@ -171,8 +171,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
     std::vector<unsigned long> valid_rows;
     valid_rows.reserve(n_rows);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        mask.get(),
+    VARIANT_ARRAY_DISPATCH(mask.get(),
 
         auto [spmask, pmask] = get_cpu_accessible<CTT>(mask);
 
@@ -192,8 +191,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
         p_teca_variant_array out_col = out_table->get_column(j);
         out_col->resize(n_valid);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_col.get(),
+        VARIANT_ARRAY_DISPATCH(out_col.get(),
 
             auto [pout] = data<TT>(out_col);
             auto [spin, pin] = get_cpu_accessible<CTT>(in_col);

--- a/alg/teca_table_remove_rows.cxx
+++ b/alg/teca_table_remove_rows.cxx
@@ -168,10 +168,10 @@ const_p_teca_dataset teca_table_remove_rows::execute(
     std::vector<unsigned long> valid_rows;
     valid_rows.reserve(n_rows);
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         mask.get(),
 
-        auto spmask = static_cast<TT*>(mask.get())->get_cpu_accessible();
+        auto spmask = static_cast<const TT*>(mask.get())->get_cpu_accessible();
         auto pmask = spmask.get();
 
         for (unsigned long i = 0; i < n_rows; ++i)

--- a/alg/teca_table_remove_rows.cxx
+++ b/alg/teca_table_remove_rows.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_parser.h"
 #include "teca_variant_array_operator.h"
@@ -29,6 +30,8 @@ using std::endl;
 
 using operator_resolver_t = teca_variant_array_operator::resolver;
 using operand_resolver_t = teca_variant_array_operand::resolver;
+
+using namespace teca_variant_array_util;
 
 // --------------------------------------------------------------------------
 teca_table_remove_rows::teca_table_remove_rows() :
@@ -171,8 +174,7 @@ const_p_teca_dataset teca_table_remove_rows::execute(
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         mask.get(),
 
-        auto spmask = static_cast<const TT*>(mask.get())->get_cpu_accessible();
-        auto pmask = spmask.get();
+        auto [spmask, pmask] = get_cpu_accessible<CTT>(mask);
 
         for (unsigned long i = 0; i < n_rows; ++i)
         {
@@ -193,11 +195,8 @@ const_p_teca_dataset teca_table_remove_rows::execute(
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             out_col.get(),
 
-            auto spin = static_cast<const TT*>(in_col.get())->get_cpu_accessible();
-            auto pin = spin.get();
-
-            auto spout = static_cast<TT*>(out_col.get())->get_cpu_accessible();
-            auto pout = spout.get();
+            auto [pout] = data<TT>(out_col);
+            auto [spin, pin] = get_cpu_accessible<CTT>(in_col);
 
             for (unsigned long i = 0; i < n_valid; ++i)
             {

--- a/alg/teca_table_sort.cxx
+++ b/alg/teca_table_sort.cxx
@@ -149,8 +149,7 @@ const_p_teca_dataset teca_table_sort::execute(
     for (unsigned long i = 0; i < n_rows; ++i)
         index[i] = i;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        index_col.get(),
+    VARIANT_ARRAY_DISPATCH(index_col.get(),
 
         auto [scol, col] = get_cpu_accessible<CTT>(index_col);
 
@@ -170,8 +169,7 @@ const_p_teca_dataset teca_table_sort::execute(
         const_p_teca_variant_array in_col = in_table->get_column(j);
         p_teca_variant_array out_col = out_table->get_column(j);
         out_col->resize(n_rows);
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_col.get(),
+        VARIANT_ARRAY_DISPATCH(out_col.get(),
 
             auto [sp_in_col, p_in_col] = get_cpu_accessible<CTT>(in_col);
             auto [p_out_col] = data<TT>(out_col);

--- a/alg/teca_table_sort.cxx
+++ b/alg/teca_table_sort.cxx
@@ -146,10 +146,10 @@ const_p_teca_dataset teca_table_sort::execute(
         malloc(n_rows*sizeof(unsigned long)));
     for (unsigned long i = 0; i < n_rows; ++i)
         index[i] = i;
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         index_col.get(),
 
-        auto scol = static_cast<TT*>(index_col.get())->get_cpu_accessible();
+        auto scol = static_cast<const TT*>(index_col.get())->get_cpu_accessible();
         const NT *col = scol.get();
 
         if (this->stable_sort)

--- a/alg/teca_table_sort.cxx
+++ b/alg/teca_table_sort.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 
 #include <algorithm>
@@ -25,6 +26,7 @@ using std::vector;
 using std::set;
 using std::cerr;
 using std::endl;
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -146,11 +148,11 @@ const_p_teca_dataset teca_table_sort::execute(
         malloc(n_rows*sizeof(unsigned long)));
     for (unsigned long i = 0; i < n_rows; ++i)
         index[i] = i;
+
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         index_col.get(),
 
-        auto scol = static_cast<const TT*>(index_col.get())->get_cpu_accessible();
-        const NT *col = scol.get();
+        auto [scol, col] = get_cpu_accessible<CTT>(index_col);
 
         if (this->stable_sort)
             std::stable_sort(index, index+n_rows, internal::less<NT>(col));
@@ -171,11 +173,8 @@ const_p_teca_dataset teca_table_sort::execute(
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             out_col.get(),
 
-            auto sp_in_col = static_cast<const TT*>(in_col.get())->get_cpu_accessible();
-            const NT *p_in_col = sp_in_col.get();
-
-            auto sp_out_col = static_cast<TT*>(out_col.get())->get_cpu_accessible();
-            NT *p_out_col = sp_out_col.get();
+            auto [sp_in_col, p_in_col] = get_cpu_accessible<CTT>(in_col);
+            auto [p_out_col] = data<TT>(out_col);
 
             for (unsigned long i = 0; i < n_rows; ++i)
                 p_out_col[i] = p_in_col[index[i]];

--- a/alg/teca_tc_candidates.cxx
+++ b/alg/teca_tc_candidates.cxx
@@ -3,6 +3,7 @@
 #include "teca_cartesian_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_table.h"
 #include "teca_database.h"
 #include "teca_coordinate_util.h"
@@ -26,6 +27,7 @@
 using std::cerr;
 using std::endl;
 using seconds_t = std::chrono::duration<double, std::chrono::seconds::period>;
+using namespace teca_variant_array_util;
 
 // --------------------------------------------------------------------------
 teca_tc_candidates::teca_tc_candidates() :
@@ -161,8 +163,7 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             lon.get(),
 
-            auto sp_lon = static_cast<const TT*>(lon.get())->get_cpu_accessible();
-            const NT *p_lon = sp_lon.get();
+            auto [sp_lon, p_lon] = get_cpu_accessible<CTT>(lon);
 
             if (teca_coordinate_util::index_of(p_lon, 0, high_i, static_cast<NT>(this->search_lon_low), false, extent[0])
                 || teca_coordinate_util::index_of(p_lon, 0, high_i, static_cast<NT>(this->search_lon_high), true, extent[1]))
@@ -194,8 +195,7 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             lat.get(),
 
-            auto sp_lat = static_cast<const TT*>(lat.get())->get_cpu_accessible();
-            const NT *p_lat = sp_lat.get();
+            auto [sp_lat, p_lat] = get_cpu_accessible<CTT>(lat);
 
             if (teca_coordinate_util::index_of(p_lat, 0, high_j, static_cast<NT>(this->search_lat_low), false, extent[2])
                 || teca_coordinate_util::index_of(p_lat, 0, high_j, static_cast<NT>(this->search_lat_high), true, extent[3]))
@@ -404,11 +404,8 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
     NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(), _COORD,
 
-        auto slon = static_cast<const TT_COORD*>(x.get())->get_cpu_accessible();
-        const NT_COORD *lon = slon.get();
-
-        auto slat = static_cast<const TT_COORD*>(y.get())->get_cpu_accessible();
-        const NT_COORD *lat = slat.get();
+        assert_type<CTT_COORD>(y);
+        auto [slon, lon, slat, lat] = get_cpu_accessible<CTT_COORD>(x, y);
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             surface_wind_speed.get(), _VAR,
@@ -420,22 +417,18 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
                 "have_core_temp", int(), "have_thickness", int(),
                 "core_temp", NT_VAR(), "thickness", NT_VAR());
 
-            auto sv = dynamic_cast<const TT_VAR*>(surface_wind_speed.get())->get_cpu_accessible();
-            const NT_VAR *v = sv.get();
+            // get the inputs
+            assert_type<CTT_VAR>(vorticity_850mb,
+                sea_level_pressure, core_temperature, thickness);
 
-            auto sw = dynamic_cast<const TT_VAR*>(vorticity_850mb.get())->get_cpu_accessible();
-            const NT_VAR *w = sw.get();
-
-            auto sP = dynamic_cast<const TT_VAR*>(sea_level_pressure.get())->get_cpu_accessible();
-            const NT_VAR *P = sP.get();
-
-            auto sT = dynamic_cast<const TT_VAR*>(core_temperature.get())->get_cpu_accessible();
-            const NT_VAR *T = sT.get();
-
-            auto sth = dynamic_cast<const TT_VAR*>(thickness.get())->get_cpu_accessible();
-            const NT_VAR *th = sth.get();
+            auto [sv, v] = get_cpu_accessible<CTT_VAR>(surface_wind_speed);
+            auto [sw, w] = get_cpu_accessible<CTT_VAR>(vorticity_850mb);
+            auto [sP, P] = get_cpu_accessible<CTT_VAR>(sea_level_pressure);
+            auto [sT, T] = get_cpu_accessible<CTT_VAR>(core_temperature);
+            auto [sth, th] = get_cpu_accessible<CTT_VAR>(thickness);
 
             t0 = std::chrono::high_resolution_clock::now();
+
             // invoke the detector
             if (teca_gfdl::tc_candidates(this->max_core_radius,
                 this->min_vorticity_850mb, this->vorticity_850mb_window,
@@ -448,6 +441,7 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
                 TECA_FATAL_ERROR("GFDL TC detector encountered an error")
                 return nullptr;
             }
+
             t1 = std::chrono::high_resolution_clock::now();
             )
         )

--- a/alg/teca_tc_candidates.cxx
+++ b/alg/teca_tc_candidates.cxx
@@ -158,10 +158,10 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
     }
     else
     {
-        TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             lon.get(),
 
-            auto sp_lon = static_cast<TT*>(lon.get())->get_cpu_accessible();
+            auto sp_lon = static_cast<const TT*>(lon.get())->get_cpu_accessible();
             const NT *p_lon = sp_lon.get();
 
             if (teca_coordinate_util::index_of(p_lon, 0, high_i, static_cast<NT>(this->search_lon_low), false, extent[0])
@@ -191,10 +191,10 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
     }
     else
     {
-        TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             lat.get(),
 
-            auto sp_lat = static_cast<TT*>(lat.get())->get_cpu_accessible();
+            auto sp_lat = static_cast<const TT*>(lat.get())->get_cpu_accessible();
             const NT *p_lat = sp_lat.get();
 
             if (teca_coordinate_util::index_of(p_lat, 0, high_j, static_cast<NT>(this->search_lat_low), false, extent[2])
@@ -401,16 +401,16 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     std::chrono::high_resolution_clock::time_point t0, t1;
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(), _COORD,
 
-        auto slon = static_cast<TT_COORD*>(x.get())->get_cpu_accessible();
+        auto slon = static_cast<const TT_COORD*>(x.get())->get_cpu_accessible();
         const NT_COORD *lon = slon.get();
 
-        auto slat = static_cast<TT_COORD*>(y.get())->get_cpu_accessible();
+        auto slat = static_cast<const TT_COORD*>(y.get())->get_cpu_accessible();
         const NT_COORD *lat = slat.get();
 
-        NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             surface_wind_speed.get(), _VAR,
 
             // configure the candidate table
@@ -420,19 +420,19 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
                 "have_core_temp", int(), "have_thickness", int(),
                 "core_temp", NT_VAR(), "thickness", NT_VAR());
 
-            auto sv = dynamic_cast<TT_VAR*>(surface_wind_speed.get())->get_cpu_accessible();
+            auto sv = dynamic_cast<const TT_VAR*>(surface_wind_speed.get())->get_cpu_accessible();
             const NT_VAR *v = sv.get();
 
-            auto sw = dynamic_cast<TT_VAR*>(vorticity_850mb.get())->get_cpu_accessible();
+            auto sw = dynamic_cast<const TT_VAR*>(vorticity_850mb.get())->get_cpu_accessible();
             const NT_VAR *w = sw.get();
 
-            auto sP = dynamic_cast<TT_VAR*>(sea_level_pressure.get())->get_cpu_accessible();
+            auto sP = dynamic_cast<const TT_VAR*>(sea_level_pressure.get())->get_cpu_accessible();
             const NT_VAR *P = sP.get();
 
-            auto sT = dynamic_cast<TT_VAR*>(core_temperature.get())->get_cpu_accessible();
+            auto sT = dynamic_cast<const TT_VAR*>(core_temperature.get())->get_cpu_accessible();
             const NT_VAR *T = sT.get();
 
-            auto sth = dynamic_cast<TT_VAR*>(thickness.get())->get_cpu_accessible();
+            auto sth = dynamic_cast<const TT_VAR*>(thickness.get())->get_cpu_accessible();
             const NT_VAR *th = sth.get();
 
             t0 = std::chrono::high_resolution_clock::now();

--- a/alg/teca_tc_candidates.cxx
+++ b/alg/teca_tc_candidates.cxx
@@ -160,8 +160,7 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
     }
     else
     {
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            lon.get(),
+        VARIANT_ARRAY_DISPATCH_FP(lon.get(),
 
             auto [sp_lon, p_lon] = get_cpu_accessible<CTT>(lon);
 
@@ -192,8 +191,7 @@ int teca_tc_candidates::get_active_extent(const const_p_teca_variant_array &lat,
     }
     else
     {
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            lat.get(),
+        VARIANT_ARRAY_DISPATCH_FP(lat.get(),
 
             auto [sp_lat, p_lat] = get_cpu_accessible<CTT>(lat);
 
@@ -401,13 +399,13 @@ const_p_teca_dataset teca_tc_candidates::execute(unsigned int port,
 
     std::chrono::high_resolution_clock::time_point t0, t1;
 
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         x.get(), _COORD,
 
         assert_type<CTT_COORD>(y);
         auto [slon, lon, slat, lat] = get_cpu_accessible<CTT_COORD>(x, y);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             surface_wind_speed.get(), _VAR,
 
             // configure the candidate table

--- a/alg/teca_tc_classify.cxx
+++ b/alg/teca_tc_classify.cxx
@@ -555,10 +555,10 @@ const_p_teca_dataset teca_tc_classify::execute(
     // sustained wind speed in knots.
     p_teca_variant_array ACE = surface_wind->new_instance(n_tracks);
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         time.get(), _T,
 
-        auto sptime = static_cast<TT_T*>(time.get())->get_cpu_accessible();
+        auto sptime = static_cast<const TT_T*>(time.get())->get_cpu_accessible();
         const NT_T *ptime = sptime.get();
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
@@ -606,10 +606,10 @@ const_p_teca_dataset teca_tc_classify::execute(
     // KERRY EMANUEL, 15 NOVEMBER 2007, JOURNAL OF CLIMATE
     p_teca_variant_array PDI = surface_wind->new_instance(n_tracks);
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         time.get(), _T,
 
-        auto sptime = static_cast<TT_T*>(time.get())->get_cpu_accessible();
+        auto sptime = static_cast<const TT_T*>(time.get())->get_cpu_accessible();
         const NT_T *ptime = sptime.get();
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
@@ -711,7 +711,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     auto spregion_long_name = region_long_name->get_cpu_accessible();
     std::string *pregion_long_name = spregion_long_name.get();
 
-    TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(),
 
         auto spx = static_cast<const TT*>(x.get())->get_cpu_accessible();

--- a/alg/teca_tc_classify.cxx
+++ b/alg/teca_tc_classify.cxx
@@ -251,8 +251,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     // record track start time
     p_teca_variant_array start_time = time->new_instance(n_tracks);
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH(time.get(),
 
         auto [pstart_time] = data<TT>(start_time);
         auto [sptime, ptime] = get_cpu_accessible<CTT>(time);
@@ -265,8 +264,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     p_teca_variant_array start_x = x->new_instance(n_tracks);
     p_teca_variant_array start_y = x->new_instance(n_tracks);
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
@@ -283,8 +281,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     // compute the storm duration
     p_teca_variant_array duration = time->new_instance(n_tracks);
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH(time.get(),
 
         auto [sptime, ptime] = get_cpu_accessible<CTT>(time);
         auto [pduration] = data<TT>(duration);
@@ -300,8 +297,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     // compute the distance traveled
     p_teca_variant_array length = x->new_instance(n_tracks);
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
@@ -333,8 +329,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     p_teca_variant_array max_surface_wind;
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        surface_wind.get(),
+    VARIANT_ARRAY_DISPATCH_FP(surface_wind.get(),
 
         NT *pmax_surface_wind = nullptr;
         std::tie(max_surface_wind, pmax_surface_wind) = ::New<TT>(n_tracks);
@@ -367,8 +362,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     // location of the max surface wind
     p_teca_variant_array max_surface_wind_x = x->new_instance(n_tracks);
     p_teca_variant_array max_surface_wind_y = x->new_instance(n_tracks);
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
@@ -387,8 +381,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     // time of max surface wind
     p_teca_variant_array max_surface_wind_t = time->new_instance(n_tracks);
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH(time.get(),
 
         auto [sptime, ptime] = get_cpu_accessible<CTT>(time);
         auto [pmax_surface_wind_t] = data<TT>(max_surface_wind_t);
@@ -406,8 +399,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     auto [min_sea_level_pressure_id,
           pmin_sea_level_pressure_id] = ::New<teca_unsigned_long_array>(n_tracks);
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        sea_level_pressure.get(),
+    VARIANT_ARRAY_DISPATCH_FP(sea_level_pressure.get(),
 
         auto [spsea_level_pressure,
               psea_level_pressure] = get_cpu_accessible<CTT>(sea_level_pressure);
@@ -439,8 +431,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     // location of the min sea level pressure
     p_teca_variant_array min_sea_level_pressure_x = x->new_instance(n_tracks);
     p_teca_variant_array min_sea_level_pressure_y = x->new_instance(n_tracks);
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
@@ -459,8 +450,7 @@ const_p_teca_dataset teca_tc_classify::execute(
 
     // time of min sea level pressure
     p_teca_variant_array min_sea_level_pressure_t = time->new_instance(n_tracks);
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH(time.get(),
 
         auto [sptime, ptime] = get_cpu_accessible<CTT>(time);
         auto [pmin_sea_level_pressure_t] = data<TT>(min_sea_level_pressure_t);
@@ -487,12 +477,12 @@ const_p_teca_dataset teca_tc_classify::execute(
     // sustained wind speed in knots.
     p_teca_variant_array ACE = surface_wind->new_instance(n_tracks);
 
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         time.get(), _T,
 
         auto [sptime, ptime] = get_cpu_accessible<CTT_T>(time);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             ACE.get(), _W,
 
             auto [spsw, psurface_wind] = get_cpu_accessible<CTT_W>(surface_wind);
@@ -532,12 +522,12 @@ const_p_teca_dataset teca_tc_classify::execute(
     // KERRY EMANUEL, 15 NOVEMBER 2007, JOURNAL OF CLIMATE
     p_teca_variant_array PDI = surface_wind->new_instance(n_tracks);
 
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         time.get(), _T,
 
         auto [sptime, ptime] = get_cpu_accessible<CTT_T>(time);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             PDI.get(), _W,
 
             auto [spsw, psurface_wind] = get_cpu_accessible<CTT_W>(surface_wind);
@@ -623,8 +613,7 @@ const_p_teca_dataset teca_tc_classify::execute(
     auto [region_name, pregion_name] = ::New<teca_string_array>(n_tracks);
     auto [region_long_name, pregion_long_name] = ::New<teca_string_array>(n_tracks);
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<CTT>(y);
         auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);

--- a/alg/teca_tc_trajectory.cxx
+++ b/alg/teca_tc_trajectory.cxx
@@ -416,13 +416,13 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     std::chrono::high_resolution_clock::time_point t0, t1;
     t0 = std::chrono::high_resolution_clock::now();
 
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         lon.get(), _COORD,
 
         assert_type<CTT_COORD>(lat);
         auto [sp_lon, p_lon, sp_lat, p_lat] = get_cpu_accessible<CTT_COORD>(lon, lat);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             wind_max.get(), _VAR,
 
             // configure the output

--- a/alg/teca_tc_trajectory.cxx
+++ b/alg/teca_tc_trajectory.cxx
@@ -432,16 +432,16 @@ const_p_teca_dataset teca_tc_trajectory::execute(
     std::chrono::high_resolution_clock::time_point t0, t1;
     t0 = std::chrono::high_resolution_clock::now();
 
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         lon.get(), _COORD,
 
-        auto sp_lon = static_cast<TT_COORD*>(lon.get())->get_cpu_accessible();
+        auto sp_lon = static_cast<const TT_COORD*>(lon.get())->get_cpu_accessible();
         const NT_COORD *p_lon = sp_lon.get();
 
-        auto sp_lat = static_cast<TT_COORD*>(lat.get())->get_cpu_accessible();
+        auto sp_lat = static_cast<const TT_COORD*>(lat.get())->get_cpu_accessible();
         const NT_COORD *p_lat = sp_lat.get();
 
-        NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             wind_max.get(), _VAR,
 
             // configure the output
@@ -454,19 +454,19 @@ const_p_teca_dataset teca_tc_trajectory::execute(
                 "core_temp", NT_VAR(), "thickness", NT_VAR(),
                 "storm_speed", NT_COORD());
 
-            auto sp_wind_max = dynamic_cast<TT_VAR*>(wind_max.get())->get_cpu_accessible();
+            auto sp_wind_max = dynamic_cast<const TT_VAR*>(wind_max.get())->get_cpu_accessible();
             const NT_VAR *p_wind_max = sp_wind_max.get();
 
-            auto sp_vort_max = dynamic_cast<TT_VAR*>(vort_max.get())->get_cpu_accessible();
+            auto sp_vort_max = dynamic_cast<const TT_VAR*>(vort_max.get())->get_cpu_accessible();
             const NT_VAR *p_vort_max = sp_vort_max.get();
 
-            auto sp_psl_min = dynamic_cast<TT_VAR*>(psl_min.get())->get_cpu_accessible();
+            auto sp_psl_min = dynamic_cast<const TT_VAR*>(psl_min.get())->get_cpu_accessible();
             const NT_VAR *p_psl_min = sp_psl_min.get();
 
-            auto sp_twc_max = dynamic_cast<TT_VAR*>(twc_max.get())->get_cpu_accessible();
+            auto sp_twc_max = dynamic_cast<const TT_VAR*>(twc_max.get())->get_cpu_accessible();
             const NT_VAR *p_twc_max = sp_twc_max.get();
 
-            auto sp_thick_max = dynamic_cast<TT_VAR*>(thick_max.get())->get_cpu_accessible();
+            auto sp_thick_max = dynamic_cast<const TT_VAR*>(thick_max.get())->get_cpu_accessible();
             const NT_VAR *p_thick_max = sp_thick_max.get();
 
             // invoke the track finder

--- a/alg/teca_tc_wind_radii.cxx
+++ b/alg/teca_tc_wind_radii.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_coordinate_util.h"
 #include "teca_table.h"
@@ -26,6 +27,7 @@
 using std::cout;
 using std::cerr;
 using std::endl;
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -158,33 +160,33 @@ public:
     bin_average(int nbins) : m_nbins(nbins)
     {
         m_vals = teca_variant_array_impl<NT>::New(nbins, NT());
-        m_pvals = m_vals->get_cpu_accessible();
+        m_pvals = m_vals->data();
 
         m_count = teca_int_array::New(nbins, 0);
-        m_pcount = m_count->get_cpu_accessible();
+        m_pcount = m_count->data();
     }
 
     void operator()(int bin, NT val)
     {
-        m_pvals.get()[bin] += val;
-        m_pcount.get()[bin] += 1;
+        m_pvals[bin] += val;
+        m_pcount[bin] += 1;
     }
 
     p_teca_variant_array_impl<NT> get_bin_values()
     {
         for (int i = 0; i < m_nbins; ++i)
         {
-            m_pvals.get()[i] = m_pcount.get()[i] ?
-                m_pvals.get()[i]/m_pcount.get()[i] : m_pvals.get()[i];
+            m_pvals[i] = m_pcount[i] ?
+                m_pvals[i]/m_pcount[i] : m_pvals[i];
         }
         return m_vals;
     }
 
 private:
     p_teca_variant_array_impl<NT> m_vals;
-    std::shared_ptr<NT> m_pvals;
+    NT *m_pvals;
     p_teca_int_array m_count;
-    std::shared_ptr<int> m_pcount;
+    int *m_pcount;
     int m_nbins;
 };
 
@@ -197,18 +199,18 @@ public:
     bin_max(int nbins)
     {
         m_vals = teca_variant_array_impl<NT>::New(nbins, NT());
-        m_pvals = m_vals->get_cpu_accessible();
+        m_pvals = m_vals->data();
     }
 
     void operator()(int bin, NT val)
-    { m_pvals.get()[bin] = std::max(m_pvals.get()[bin], val); }
+    { m_pvals[bin] = std::max(m_pvals[bin], val); }
 
     p_teca_variant_array_impl<NT> get_bin_values()
     { return m_vals; }
 
 private:
     p_teca_variant_array_impl<NT> m_vals;
-    std::shared_ptr<NT> m_pvals;
+    NT *m_pvals;
 };
 
 
@@ -762,8 +764,7 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
     TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         storm_ids.get(),
 
-        auto spstorm_ids = dynamic_cast<const TT*>(storm_ids.get())->get_cpu_accessible();
-        auto pstorm_ids = spstorm_ids.get();
+        auto [spstorm_ids, pstorm_ids] = get_cpu_accessible<CTT>(storm_ids);
 
         teca_coordinate_util::get_table_offsets(pstorm_ids,
             this->internals->storm_table->get_number_of_rows(),
@@ -854,13 +855,12 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     unsigned long n_incomplete = 0;
     TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x_coordinates.get(),
+
+        assert_type<CTT>(y_coordinates);
+
         // for each point in track compute the bounding box needed
         // for the wind profile
-        auto spx = static_cast<const TT*>(x_coordinates.get())->get_cpu_accessible();
-        auto px = spx.get();
-
-        auto spy = static_cast<const TT*>(y_coordinates.get())->get_cpu_accessible();
-        auto py = spy.get();
+        auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x_coordinates, y_coordinates);
 
         for (unsigned long i = 0; i < n_ids; ++i)
         {
@@ -905,8 +905,7 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     // request the specific time needed
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         times.get(),
-        auto spt = static_cast<const TT*>(times.get())->get_cpu_accessible();
-        auto pt = spt.get();
+        auto [spt, pt] = get_cpu_accessible<CTT>(times);
         for (unsigned long i = 0; i < n_ids; ++i)
             up_reqs[i].set("time", pt[i+id_ofs]);
         )
@@ -958,23 +957,21 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
     // allocate output columns
     unsigned int n_crit_vals = this->critical_wind_speeds.size();
     std::vector<p_teca_double_array> crit_radii(n_crit_vals);
+    std::vector<double*> pcrit_radii(n_crit_vals);
 
     for (unsigned int i = 0; i < n_crit_vals; ++i)
-        crit_radii[i] = teca_double_array::New(npts, 0.0);
+        std::tie(crit_radii[i], pcrit_radii[i]) = ::New<teca_double_array>(npts, 0.0);
 
-    p_teca_double_array peak_radius = teca_double_array::New(npts, 0.0);
-    p_teca_double_array peak_wind = teca_double_array::New(npts, 0.0);
+    auto [peak_radius, ppeak_radius] = ::New<teca_double_array>(npts, 0.0);
+    auto [peak_wind, ppeak_wind] = ::New<teca_double_array>(npts, 0.0);
 
     // compute radius at each point in time along the storm track
     NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         storm_x.get(), _STORM,
 
         // get the storm centers
-        auto spstorm_x = static_cast<const TT_STORM*>(storm_x.get())->get_cpu_accessible();
-        auto pstorm_x = spstorm_x.get();
-
-        auto spstorm_y = static_cast<const TT_STORM*>(storm_y.get())->get_cpu_accessible();
-        auto pstorm_y = spstorm_y.get();
+        assert_type<CTT_STORM>(storm_y);
+        auto [spsx, pstorm_x, spsy, pstorm_y] = get_cpu_accessible<CTT_STORM>(storm_x, storm_y);
 
         // for each time instance in the storm compute the storm radius
         for (unsigned long k = 0; k < npts; ++k)
@@ -999,21 +996,14 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
             NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
                 mesh_x.get(), _MESH,
 
-                auto spmesh_x = static_cast<const TT_MESH*>(mesh_x.get())->get_cpu_accessible();
-                auto pmesh_x = spmesh_x.get();
-
-                auto spmesh_y = static_cast<const TT_MESH*>(mesh_y.get())->get_cpu_accessible();
-                auto pmesh_y = spmesh_y.get();
+                assert_type<CTT_MESH>(mesh_y);
+                auto [spmx, pmesh_x, spmy, pmesh_y] = get_cpu_accessible<CTT_MESH>(mesh_x, mesh_y);
 
                 unsigned long nx = mesh_x->size();
                 unsigned long ny = mesh_y->size();
 
                 // construct radial discretization
-                p_teca_variant_array_impl<NT_MESH> radius =
-                    teca_variant_array_impl<NT_MESH>::New(this->number_of_radial_bins);
-
-                auto spr = radius->get_cpu_accessible();
-                auto pr = spr.get();
+                auto [radius, pr] = ::New<TT_MESH>(this->number_of_radial_bins);
 
                 NT_MESH max_radius = static_cast<NT_MESH>(this->search_radius);
 
@@ -1033,11 +1023,8 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                 NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
                     wind_u.get(), _WIND,
 
-                    auto spwu = static_cast<const TT_WIND*>(wind_u.get())->get_cpu_accessible();
-                    auto pwu = spwu.get();
-
-                    auto spwv = static_cast<const TT_WIND*>(wind_v.get())->get_cpu_accessible();
-                    auto pwv = spwv.get();
+                    assert_type<CTT_WIND>(wind_v);
+                    auto [spwu, pwu, spwv, pwv] = get_cpu_accessible<TT_WIND>(wind_u, wind_v);
 
                     // get the kth storm center
                     NT_MESH sx = static_cast<NT_MESH>(pstorm_x[k+ofs]);
@@ -1075,8 +1062,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                         this->critical_wind_speeds.end());
 
                     // compute the offsets of the critical radii
-                    auto spw = wind->get_cpu_accessible();
-                    auto pw = spw.get();
+                    NT_WIND *pw = wind->data();
 
                     teca_tc_wind_radii::internals_t::locate_critical_ids(
                         pr, pw, this->number_of_radial_bins,
@@ -1085,26 +1071,22 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                         peak_id);
 
                     // compute the intercepts with the critical wind speeds
-                    p_teca_variant_array_impl<NT_MESH> rcross =
-                        teca_variant_array_impl<NT_MESH>::New(n_crit_vals, NT_MESH());
-
-                    auto sprcross = rcross->get_cpu_accessible();
-                    auto prcross = sprcross.get();
+                    auto [rcross, prcross] = ::New<TT_MESH>(n_crit_vals, NT_MESH());
 
                     teca_tc_wind_radii::internals_t::compute_crossings(pr, pw,
                         crit_wind.data(), n_crit_vals, crit_ids.data(), prcross);
 
                     // record critical radii
                     for (unsigned int i = 0; i < n_crit_vals; ++i)
-                        crit_radii[i]->set(k, prcross[i]);
+                        pcrit_radii[i][k] = prcross[i];
 
                     // record peak radius and peak wind speed
-                    peak_radius->set(k,
-                        peak_id == std::numeric_limits<unsigned int>::max() ?
+                    ppeak_radius[k] =
+                        (peak_id == std::numeric_limits<unsigned int>::max() ?
                         0 : pr[peak_id]);
 
-                    peak_wind->set(k,
-                        peak_id == std::numeric_limits<unsigned int>::max() ?
+                    ppeak_wind[k] =
+                        (peak_id == std::numeric_limits<unsigned int>::max() ?
                         0 : pw[peak_id]);
 
 #if defined(TECA_DEBUG)

--- a/alg/teca_tc_wind_radii.cxx
+++ b/alg/teca_tc_wind_radii.cxx
@@ -759,10 +759,10 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
     const_p_teca_variant_array storm_ids =
         this->internals->storm_table->get_column(this->storm_id_column);
 
-    TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         storm_ids.get(),
 
-        auto spstorm_ids = dynamic_cast<TT*>(storm_ids.get())->get_cpu_accessible();
+        auto spstorm_ids = dynamic_cast<const TT*>(storm_ids.get())->get_cpu_accessible();
         auto pstorm_ids = spstorm_ids.get();
 
         teca_coordinate_util::get_table_offsets(pstorm_ids,
@@ -852,14 +852,14 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     // request the tile of dimension search radius centered on the
     // storm at this instant
     unsigned long n_incomplete = 0;
-    TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x_coordinates.get(),
         // for each point in track compute the bounding box needed
         // for the wind profile
-        auto spx = static_cast<TT*>(x_coordinates.get())->get_cpu_accessible();
+        auto spx = static_cast<const TT*>(x_coordinates.get())->get_cpu_accessible();
         auto px = spx.get();
 
-        auto spy = static_cast<TT*>(y_coordinates.get())->get_cpu_accessible();
+        auto spy = static_cast<const TT*>(y_coordinates.get())->get_cpu_accessible();
         auto py = spy.get();
 
         for (unsigned long i = 0; i < n_ids; ++i)
@@ -903,9 +903,9 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     }
 
     // request the specific time needed
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         times.get(),
-        auto spt = static_cast<TT*>(times.get())->get_cpu_accessible();
+        auto spt = static_cast<const TT*>(times.get())->get_cpu_accessible();
         auto pt = spt.get();
         for (unsigned long i = 0; i < n_ids; ++i)
             up_reqs[i].set("time", pt[i+id_ofs]);
@@ -966,14 +966,14 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
     p_teca_double_array peak_wind = teca_double_array::New(npts, 0.0);
 
     // compute radius at each point in time along the storm track
-    NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         storm_x.get(), _STORM,
 
         // get the storm centers
-        auto spstorm_x = static_cast<TT_STORM*>(storm_x.get())->get_cpu_accessible();
+        auto spstorm_x = static_cast<const TT_STORM*>(storm_x.get())->get_cpu_accessible();
         auto pstorm_x = spstorm_x.get();
 
-        auto spstorm_y = static_cast<TT_STORM*>(storm_y.get())->get_cpu_accessible();
+        auto spstorm_y = static_cast<const TT_STORM*>(storm_y.get())->get_cpu_accessible();
         auto pstorm_y = spstorm_y.get();
 
         // for each time instance in the storm compute the storm radius
@@ -996,13 +996,13 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
             double t = 0.0;
             mesh->get_time(t);
 
-            NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+            NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
                 mesh_x.get(), _MESH,
 
-                auto spmesh_x = static_cast<TT_MESH*>(mesh_x.get())->get_cpu_accessible();
+                auto spmesh_x = static_cast<const TT_MESH*>(mesh_x.get())->get_cpu_accessible();
                 auto pmesh_x = spmesh_x.get();
 
-                auto spmesh_y = static_cast<TT_MESH*>(mesh_y.get())->get_cpu_accessible();
+                auto spmesh_y = static_cast<const TT_MESH*>(mesh_y.get())->get_cpu_accessible();
                 auto pmesh_y = spmesh_y.get();
 
                 unsigned long nx = mesh_x->size();
@@ -1030,13 +1030,13 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                 const_p_teca_variant_array wind_v =
                     mesh->get_point_arrays()->get(this->wind_v_variable);
 
-                NESTED_TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+                NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
                     wind_u.get(), _WIND,
 
-                    auto spwu = static_cast<TT_WIND*>(wind_u.get())->get_cpu_accessible();
+                    auto spwu = static_cast<const TT_WIND*>(wind_u.get())->get_cpu_accessible();
                     auto pwu = spwu.get();
 
-                    auto spwv = static_cast<TT_WIND*>(wind_v.get())->get_cpu_accessible();
+                    auto spwv = static_cast<const TT_WIND*>(wind_v.get())->get_cpu_accessible();
                     auto pwv = spwv.get();
 
                     // get the kth storm center

--- a/alg/teca_tc_wind_radii.cxx
+++ b/alg/teca_tc_wind_radii.cxx
@@ -761,8 +761,7 @@ teca_metadata teca_tc_wind_radii::teca_tc_wind_radii::get_output_metadata(
     const_p_teca_variant_array storm_ids =
         this->internals->storm_table->get_column(this->storm_id_column);
 
-    TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-        storm_ids.get(),
+    VARIANT_ARRAY_DISPATCH_I(storm_ids.get(),
 
         auto [spstorm_ids, pstorm_ids] = get_cpu_accessible<CTT>(storm_ids);
 
@@ -853,8 +852,7 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     // request the tile of dimension search radius centered on the
     // storm at this instant
     unsigned long n_incomplete = 0;
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x_coordinates.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x_coordinates.get(),
 
         assert_type<CTT>(y_coordinates);
 
@@ -903,7 +901,7 @@ std::vector<teca_metadata> teca_tc_wind_radii::get_upstream_request(
     }
 
     // request the specific time needed
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
+    VARIANT_ARRAY_DISPATCH(
         times.get(),
         auto [spt, pt] = get_cpu_accessible<CTT>(times);
         for (unsigned long i = 0; i < n_ids; ++i)
@@ -966,7 +964,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
     auto [peak_wind, ppeak_wind] = ::New<teca_double_array>(npts, 0.0);
 
     // compute radius at each point in time along the storm track
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         storm_x.get(), _STORM,
 
         // get the storm centers
@@ -993,7 +991,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
             double t = 0.0;
             mesh->get_time(t);
 
-            NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH_FP(
                 mesh_x.get(), _MESH,
 
                 assert_type<CTT_MESH>(mesh_y);
@@ -1020,7 +1018,7 @@ const_p_teca_dataset teca_tc_wind_radii::execute(unsigned int port,
                 const_p_teca_variant_array wind_v =
                     mesh->get_point_arrays()->get(this->wind_v_variable);
 
-                NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_FP(
                     wind_u.get(), _WIND,
 
                     assert_type<CTT_WIND>(wind_v);

--- a/alg/teca_temporal_index_select.cxx
+++ b/alg/teca_temporal_index_select.cxx
@@ -100,8 +100,7 @@ teca_metadata teca_temporal_index_select::get_output_metadata(unsigned int port,
 
         // create the output times by selecting times at the given indices
         p_teca_variant_array t_out;
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            t_in.get(),
+        VARIANT_ARRAY_DISPATCH_FP(t_in.get(),
 
             auto [tmp, p_tmp] = ::New<TT>(n_elem);
             auto [sp_t_in, p_t_in] = get_cpu_accessible<CTT>(t_in);

--- a/alg/teca_temporal_index_select.cxx
+++ b/alg/teca_temporal_index_select.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -23,6 +24,9 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 //#define TECA_DEBUG
 
@@ -80,8 +84,10 @@ teca_metadata teca_temporal_index_select::get_output_metadata(unsigned int port,
     // copy the incoming metadata
     teca_metadata md_out = teca_metadata(md_in[0]);
 
+    size_t n_elem = this->indices.size();
+
     // skip modifying the coordinates if no indices have been requested
-    if (! (this->indices.size() == 0) )
+    if (n_elem)
     {
         // revise the time coordinate to be the subset that was requested
         teca_metadata coords;
@@ -91,26 +97,22 @@ teca_metadata teca_temporal_index_select::get_output_metadata(unsigned int port,
             TECA_FATAL_ERROR("failed to locate target mesh coordinates")
             return md_out;
         }
-        // get the incoming time values
-        p_teca_variant_array t_out = t_in->new_instance();
+
         // create the output times by selecting times at the given indices
-        t_out->resize(this->indices.size());
-        NESTED_TEMPLATE_DISPATCH_FP(
-            teca_variant_array_impl,
-            t_in.get(), 1,
-            auto sp_t_in = dynamic_cast<TT1*>
-                (t_in.get())->get_cpu_accessible();
-            auto sp_t_out = dynamic_cast<TT1*>
-                (t_out.get())->get_cpu_accessible();
+        p_teca_variant_array t_out;
+        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+            t_in.get(),
 
-            const NT1 *p_t_in = sp_t_in.get();
-            NT1 *p_t_out = sp_t_out.get();
+            auto [tmp, p_tmp] = ::New<TT>(n_elem);
+            auto [sp_t_in, p_t_in] = get_cpu_accessible<CTT>(t_in);
 
-            for ( size_t i = 0; i < this->indices.size(); ++i )
+            for ( size_t i = 0; i < n_elem; ++i )
             {
                 // set this time value
-                p_t_out[i] = p_t_in[this->indices[i]];
+                p_tmp[i] = p_t_in[this->indices[i]];
             }
+
+            t_out = tmp;
         )
 
         // overwrite the coordinates
@@ -126,8 +128,7 @@ teca_metadata teca_temporal_index_select::get_output_metadata(unsigned int port,
         }
 
         // reset the length of the time coordinate
-        md_out.set(init_key, this->indices.size());
-
+        md_out.set(init_key, n_elem);
     }
 
     // return the output metadata
@@ -165,10 +166,10 @@ std::vector<teca_metadata> teca_temporal_index_select::get_upstream_request(
             if ( i >= this->indices.size() )
             {
                 TECA_FATAL_ERROR(
-                    << "index_request_key: " << 
+                    << "index_request_key: " <<
                     index_extent[0] << ":" << index_extent[1]
                     << std::endl
-                    << "Bad request: list index " << i 
+                    << "Bad request: list index " << i
                     << " is out of bounds of the index list of size "
                     << this->indices.size())
             }
@@ -208,7 +209,6 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
 
     std::ostringstream oss;
 
-
     // check for valid incoming data
     if (input_data.size() == 0)
     {
@@ -228,25 +228,16 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
 
     // default to CPU operations
     int device_id = -1;
-    teca_variant_array::allocator allocator = 
-        teca_variant_array::allocator::malloc;
+    allocator alloc = allocator::malloc;
 #if defined(TECA_HAS_CUDA)
+    // if we are assigned a gpu, put the output on that device
     request.get("device_id",device_id);
-
-    // set the allocator to CUDA if that's the device the data are already on
     if ( device_id >= 0 )
     {
-        // set the CUDA device to run on
-        cudaError_t ierr = cudaSuccess;
-        if (( ierr = cudaSetDevice(device_id)) != cudaSuccess )
-        {
-            TECA_ERROR("Failed to set the CUDA device to " << device_id
-                << ". " << cudaGetErrorString(ierr))
-            return nullptr;   
-        }
+        if (teca_cuda_util::set_device(device_id))
+            return nullptr;
 
-        // set the allocator
-        allocator = teca_variant_array::allocator::cuda;
+        alloc = allocator::cuda_async;
     }
 #endif
 
@@ -270,9 +261,8 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
         oss << "(device_id=" << device_id << "): "
             << "Mapping request " << index_extent[0] << ":" << index_extent[1]
             << " to indices " << ind_request;
-        
-        TECA_STATUS(<< oss.str())
 
+        TECA_STATUS(<< oss.str())
     }
 
     // create the output mesh
@@ -283,18 +273,17 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
     // proceed if there are indices to remap; otherwise pass data along
     if ( this->indices.size() > 0 )
     {
-
         // get the arrays and their names
         p_teca_array_collection arrays = out_mesh->get_point_arrays();
         std::vector<std::string> array_names = arrays->get_names();
-        // pass the output mesh through if there are no arrays
-        if ( array_names.size() == 0 ) return out_mesh;
 
+        // pass the output mesh through if there are no arrays
+        if ( array_names.size() == 0 )
+            return out_mesh;
 
         // loop over the point arrays
         for ( auto& array_name : array_names)
         {
-
             // get the shape of one timestep of this array
             const_p_teca_variant_array array_in = arrays->get(array_name);
             size_t nxyz = array_in->size();
@@ -302,15 +291,13 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
             // set the shape of the output array
             size_t nxyzt = nxyz * input_data.size();
 
-            // pre-allocate the output array on the specified device
-            p_teca_variant_array array_out = 
-                array_in->new_instance(allocator);
+            // pre-allocate the output array on the specified device sized so
+            // it can accommodate all timesteps.
+            p_teca_variant_array array_out = array_in->new_instance(nxyzt, alloc);
 
-            // resize the output array so it can accommodate all timesteps
-            array_out->resize(nxyzt);
-            
             // loop over the requests
-            for ( size_t i = 0; i < input_data.size(); ++i )
+            size_t n_steps = input_data.size();
+            for ( size_t i = 0; i < n_steps; ++i )
             {
                 // get the current timestep's data
                 p_teca_mesh tmp_data = std::static_pointer_cast<teca_mesh>
@@ -318,7 +305,7 @@ const_p_teca_dataset teca_temporal_index_select::execute(unsigned int port,
                     std::dynamic_pointer_cast<const teca_mesh>(input_data[i])));
 
                 // get the current timestep's array
-                p_teca_variant_array tmp_array = 
+                p_teca_variant_array tmp_array =
                     tmp_data->get_point_arrays()->get(array_name);
 
                 // insert data into the output array

--- a/alg/teca_temporal_index_select.h
+++ b/alg/teca_temporal_index_select.h
@@ -31,10 +31,6 @@ public:
     TECA_ALGORITHM_VECTOR_PROPERTY(long long, indice)
     ///@}
 
-    // set indices from a file
-    
-
-
 protected:
     teca_temporal_index_select();
 

--- a/alg/teca_temporal_reduction.cxx
+++ b/alg/teca_temporal_reduction.cxx
@@ -755,8 +755,8 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_cpu(
     if (!count)
     {
         // allocate and initialize the count
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_array.get(),
+        VARIANT_ARRAY_DISPATCH(out_array.get(),
+
             auto [tmp, p_tmp] = ::New<TT>(n_elem_count);
             if (out_valid)
             {
@@ -778,8 +778,7 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_cpu(
     p_teca_variant_array red_valid;
     p_teca_variant_array red_count;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem);
         auto [res_count, p_res_count] = ::New<TT>(n_elem_count);
@@ -896,8 +895,8 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_gpu(
     if (!count)
     {
         // allocate and initialize the count
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_array.get(),
+        VARIANT_ARRAY_DISPATCH(out_array.get(),
+
             auto [tmp, p_tmp] = ::New<TT>(n_elem_count, alloc_count);
             if (out_valid)
             {
@@ -917,22 +916,18 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_gpu(
     p_teca_variant_array red_count;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
         auto [res_count, p_res_count] = ::New<TT>(n_elem_count, alloc_count);
-
         auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
         auto [sp_out_array, p_out_array] = get_cuda_accessible<CTT>(out_array);
-
         auto [p_count] = data<TT>(count);
 
         if (out_valid)
         {
             // update while respecting invalid/missing data
             auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
-
             auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
             auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
@@ -1000,19 +995,16 @@ int teca_cpp_temporal_reduction::internals_t::summation_operator::update_cpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [sp_in_array, p_in_array] = get_cpu_accessible<CTT>(in_array);
         auto [sp_out_array, p_out_array] = get_cpu_accessible<CTT>(out_array);
-
         auto [res_array, p_res_array] = ::New<TT>(n_elem);
 
         if (out_valid)
         {
             // update, respect missing values
             auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
-
             auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
             auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
@@ -1084,11 +1076,9 @@ int teca_cpp_temporal_reduction::internals_t::summation_operator::update_gpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
-
         auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
         auto [sp_out_array, p_out_array] = get_cuda_accessible<CTT>(out_array);
 
@@ -1096,7 +1086,6 @@ int teca_cpp_temporal_reduction::internals_t::summation_operator::update_gpu(
         {
             // update, respect missing values
             auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
-
             auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
             auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
@@ -1157,11 +1146,9 @@ int teca_cpp_temporal_reduction::internals_t::minimum_operator::update_cpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem);
-
         auto [sp_in_array, p_in_array] = get_cpu_accessible<TT>(in_array);
         auto [sp_out_array, p_out_array] = get_cpu_accessible<TT>(out_array);
 
@@ -1169,7 +1156,6 @@ int teca_cpp_temporal_reduction::internals_t::minimum_operator::update_cpu(
         {
             // update, respect missing values
             auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
-
             auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
             auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
@@ -1243,8 +1229,7 @@ int teca_cpp_temporal_reduction::internals_t::minimum_operator::update_gpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
         auto [sp_in_array, p_in_array] = get_cuda_accessible<TT>(in_array);
@@ -1313,11 +1298,9 @@ int teca_cpp_temporal_reduction::internals_t::maximum_operator::update_cpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem);
-
         auto [sp_in_array, p_in_array] = get_cpu_accessible<CTT>(in_array);
         auto [sp_out_array, p_out_array] = get_cpu_accessible<CTT>(out_array);
 
@@ -1325,7 +1308,6 @@ int teca_cpp_temporal_reduction::internals_t::maximum_operator::update_cpu(
         {
             // update, respect missing values
             auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
-
             auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
             auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
@@ -1399,8 +1381,7 @@ int teca_cpp_temporal_reduction::internals_t::maximum_operator::update_gpu(
     p_teca_variant_array red_array;
     p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
         auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
@@ -1464,8 +1445,7 @@ int teca_cpp_temporal_reduction::internals_t::reduction_operator::finalize(
 
     if (out_valid)
     {
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_array.get(),
+        VARIANT_ARRAY_DISPATCH(out_array.get(),
 
             NT fill_value = NT(this->fill_value);
             unsigned long n_elem = out_array->size();
@@ -1525,8 +1505,7 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::finalize(
 
     p_teca_variant_array red_array;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        out_array.get(),
+    VARIANT_ARRAY_DISPATCH(out_array.get(),
 
         NT fill_val = NT(this->fill_value);
 
@@ -2184,9 +2163,7 @@ const_p_teca_dataset teca_cpp_temporal_reduction::execute(
 
             bool have_vv_mask = arrays_in->has(array + "_valid");
 
-            TEMPLATE_DISPATCH(
-                teca_variant_array_impl,
-                in_array.get(),
+            VARIANT_ARRAY_DISPATCH(in_array.get(),
 
                 if (this->op == average)
                 {

--- a/alg/teca_temporal_reduction.cxx
+++ b/alg/teca_temporal_reduction.cxx
@@ -2331,7 +2331,7 @@ const_p_teca_dataset teca_cpp_temporal_reduction::execute(
             bool have_vv_mask = arrays_in->has(array + "_valid");
 
             TEMPLATE_DISPATCH(
-                const teca_variant_array_impl,
+                teca_variant_array_impl,
                 in_array.get(),
 
                 if (this->op == average)

--- a/alg/teca_temporal_reduction.cxx
+++ b/alg/teca_temporal_reduction.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_calendar_util.h"
 #include "teca_valid_value_mask.h"
@@ -23,6 +24,7 @@
 
 //#define TECA_DEBUG
 
+using namespace teca_variant_array_util;
 using allocator = teca_variant_array::allocator;
 
 
@@ -746,137 +748,110 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_cpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    // allocate space for the calculation
-    p_teca_variant_array red_array = out_array->new_instance(n_elem);
-
-    // allocate space for the output mask which is a function of the current
-    // input and previous state
-    size_t n_elem_count = 1;
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid)
-    {
-        red_valid = out_valid->new_instance(n_elem);
-        n_elem_count = n_elem;
-    }
-
-    // allocate space for the output count
-    p_teca_variant_array red_count = out_array->new_instance(n_elem_count);
-
     // get the current count
-    p_teca_variant_array count;
-    if (arrays_out->has(array + "_count"))
+    size_t n_elem_count = out_valid ? n_elem : 1;
+    std::string count_name = array + "_count";
+    p_teca_variant_array count = arrays_out->get(count_name);
+    if (!count)
     {
-        count = arrays_out->get(array + "_count");
-    }
-    else
-    {
-        count = out_array->new_instance(n_elem_count);
-
-        TEMPLATE_DISPATCH(
-            teca_variant_array_impl,
-            count.get(),
-
-            NT *p_count = static_cast<TT*>(count.get())->data();
-
+        // allocate and initialize the count
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
+            out_array.get(),
+            auto [tmp, p_tmp] = ::New<TT>(n_elem_count);
             if (out_valid)
             {
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
+                auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
                 for (unsigned int i = 0; i < n_elem; ++i)
-                    p_count[i] = (p_out_valid[i]) ? NT(1) : NT(0);
+                    p_tmp[i] = (p_out_valid[i]) ? NT(1) : NT(0);
             }
             else
             {
-                p_count[0] = 1.;
+                p_tmp[0] = 1.;
             }
+            count = tmp;
         )
     }
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    // the result of this pass
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
+    p_teca_variant_array red_count;
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cpu_accessible();
-        const NT *p_in_array = sp_in_array.get();
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cpu_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem);
+        auto [res_count, p_res_count] = ::New<TT>(n_elem_count);
 
-        NT *p_red_array = static_cast<TT*>(red_array.get())->data();
+        auto [sp_in_array, p_in_array] = get_cpu_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cpu_accessible<CTT>(out_array);
 
-        NT *p_count = static_cast<TT*>(count.get())->data();
+        auto [p_count] = data<TT>(count);
 
-        NT *p_red_count = static_cast<TT*>(red_count.get())->data();
-
-        if (out_valid != nullptr)
+        if (out_valid)
         {
             // update, respecting missing data
 
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
 
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            NT_MASK *p_red_valid = static_cast<TT_MASK*>(red_valid.get())->data();
+            auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
             for (unsigned int i = 0; i < n_elem; ++i)
             {
                 // count where there is valid data, otherwise pass the current count through
                 if (p_in_valid[i])
                 {
-                    p_red_count[i] = p_count[i] + NT(1);
+                    p_res_count[i] = p_count[i] + NT(1);
                 }
                 else
                 {
-                    p_red_count[i] = p_count[i];
+                    p_res_count[i] = p_count[i];
                 }
 
                 // update, respecting missing data
-                p_red_valid[i] = NT_MASK(1);
+                p_res_valid[i] = NT_MASK(1);
                 if (p_in_valid[i] && p_out_valid[i])
                 {
-                    p_red_array[i] = p_out_array[i] + p_in_array[i];
+                    p_res_array[i] = p_out_array[i] + p_in_array[i];
                 }
                 else if (p_in_valid[i] && !p_out_valid[i])
                 {
-                    p_red_array[i] = p_in_array[i];
+                    p_res_array[i] = p_in_array[i];
                 }
                 else if (!p_in_valid[i] && p_out_valid[i])
                 {
-                    p_red_array[i] = p_out_array[i];
+                    p_res_array[i] = p_out_array[i];
                 }
                 else
                 {
-                    p_red_array[i] = NT(this->fill_value);
-                    p_red_valid[i] = NT_MASK(0);
+                    p_res_array[i] = NT(this->fill_value);
+                    p_res_valid[i] = NT_MASK(0);
                 }
             }
+
+            red_valid = res_valid;
         }
         else
         {
             // update , no misisng data
-
-            // update count
-            p_red_count[0] = p_count[0] + NT(1);
+            p_res_count[0] = p_count[0] + NT(1);
 
             for (unsigned int i = 0; i < n_elem; ++i)
-            {
-                // accumulate
-                p_red_array[i] = p_out_array[i] + p_in_array[i];
-            }
+                p_res_array[i] = p_out_array[i] + p_in_array[i];
         }
+
+        red_array = res_array;
+        red_count = res_count;
     )
 
     // update the output
     arrays_out->set(array, red_array);
+    arrays_out->set(count_name, red_count);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
-
-    if (red_count != nullptr)
-        arrays_out->set(array + "_count", red_count);
 
     return 0;
 }
@@ -896,114 +871,97 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::update_gpu(
     unsigned long n_elem = out_array->size();
 
     // don't use integer types for this calculation
-    internals_t::ensure_floating_point(allocator::cuda, in_array);
-    internals_t::ensure_floating_point(allocator::cuda, out_array);
+    internals_t::ensure_floating_point(allocator::cuda_async, in_array);
+    internals_t::ensure_floating_point(allocator::cuda_async, out_array);
 
     // get the valid value masks
     std::string valid = array + "_valid";
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    // allocate space for the calculation
-    p_teca_variant_array red_array = out_array->new_instance(n_elem, allocator::cuda);
-
     // allocate space for the output mask which is a function of the current
     // input and previous state and size and place the count array
     size_t n_elem_count = 1;
     allocator alloc_count = allocator::malloc;
-    p_teca_variant_array red_valid = nullptr;
     if (out_valid)
     {
-        red_valid = out_valid->new_instance(n_elem, allocator::cuda);
-
         // when we have the valid value mask we need a per-mesh element count
         n_elem_count = n_elem;
-        alloc_count = allocator::cuda;
+        alloc_count = allocator::cuda_async;
     }
-
-    // allocate space for the output count
-    p_teca_variant_array red_count = out_array->new_instance(n_elem_count, alloc_count);
 
     // get the current count
-    p_teca_variant_array count;
-    if (arrays_out->has(array + "_count"))
+    std::string count_name = array + "_count";
+    p_teca_variant_array count = arrays_out->get(count_name);
+    if (!count)
     {
-        count = arrays_out->get(array + "_count");
-    }
-    else
-    {
-        count = out_array->new_instance(n_elem_count, alloc_count);
-
-        TEMPLATE_DISPATCH(
-            teca_variant_array_impl,
-            count.get(),
-
-            NT *p_count = static_cast<TT*>(count.get())->data();
-
+        // allocate and initialize the count
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
+            out_array.get(),
+            auto [tmp, p_tmp] = ::New<TT>(n_elem_count, alloc_count);
             if (out_valid)
             {
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
-
-                cuda::count_init(device_id, p_out_valid, p_count, n_elem_count);
+                auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
+                cuda::count_init(device_id, p_out_valid, p_tmp, n_elem_count);
             }
             else
             {
-                p_count[0] = NT(1);
+                p_tmp[0] = NT(1);
             }
+            count = tmp;
         )
     }
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    // results of the calc
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_count;
+    p_teca_variant_array red_valid;
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cuda_accessible();
-        const NT *p_in_array = sp_in_array.get();
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cuda_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
+        auto [res_count, p_res_count] = ::New<TT>(n_elem_count, alloc_count);
 
-        NT *p_red_array = static_cast<TT*>(red_array.get())->data();
+        auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cuda_accessible<CTT>(out_array);
 
-        NT *p_count = static_cast<TT*>(count.get())->data();
+        auto [p_count] = data<TT>(count);
 
-        NT *p_red_count = static_cast<TT*>(red_count.get())->data();
-
-        if (out_valid != nullptr)
+        if (out_valid)
         {
             // update while respecting invalid/missing data
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
 
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            NT_MASK *p_red_valid = static_cast<TT_MASK*>(red_valid.get())->data();
+            auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
             cuda::average(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_count, p_red_count,
-                p_red_array, p_red_valid, n_elem);
+                p_in_array, p_in_valid, p_count, p_res_count,
+                p_res_array, p_res_valid, n_elem);
+
+            red_valid = res_valid;
         }
         else
         {
             // update, no missing data
-            p_red_count[0] = p_count[0] + 1.;
+            p_res_count[0] = p_count[0] + 1.;
 
             cuda::summation(device_id, p_out_array, nullptr,
-                p_in_array, nullptr, p_red_array, nullptr,
+                p_in_array, nullptr, p_res_array, nullptr,
                 n_elem);
         }
+
+        red_array = res_array;
+        red_count = res_count;
     )
 
     // update the output
     arrays_out->set(array, red_array);
+    arrays_out->set(count_name, red_count);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
-
-    if (red_count != nullptr)
-        arrays_out->set(array + "_count", red_count);
 
     return 0;
 #else
@@ -1038,73 +996,65 @@ int teca_cpp_temporal_reduction::internals_t::summation_operator::update_cpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem);
-    }
+    // update reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cpu_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [sp_in_array, p_in_array] = get_cpu_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cpu_accessible<CTT>(out_array);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cpu_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem);
 
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cpu_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT*>(in_valid.get())->get_cpu_accessible();
-            const NT *p_in_valid = sp_in_valid.get();
+            // update, respect missing values
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
 
-            auto sp_out_valid = static_cast<const TT*>(out_valid.get())->get_cpu_accessible();
-            const NT *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cpu_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                p_red_valid[i] = char(1);
+                p_res_valid[i] = NT_MASK(1);
                 if (p_in_valid[i] && p_out_valid[i])
                 {
-                    // accumulate
-                    p_red_array[i] = p_out_array[i] + p_in_array[i];
+                    p_res_array[i] = p_out_array[i] + p_in_array[i];
                 }
                 else if (p_in_valid[i] && !p_out_valid[i])
                 {
-                    p_red_array[i] = p_in_array[i];
+                    p_res_array[i] = p_in_array[i];
                 }
                 else if (!p_in_valid[i] && p_out_valid[i])
                 {
-                    p_red_array[i] = p_out_array[i];
+                    p_res_array[i] = p_out_array[i];
                 }
                 else
                 {
-                    p_red_valid[i] = char(0);
+                    p_res_valid[i] = NT_MASK(0);
                 }
             }
+
+            red_valid = res_valid;
         }
         else
         {
+            // update, no misisng values
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                p_red_array[i] = p_out_array[i] + p_in_array[i];
+                p_res_array[i] = p_out_array[i] + p_in_array[i];
             }
         }
+
+        red_array = res_array;
     )
 
     // update the output
     arrays_out->set(array, red_array);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
 
     return 0;
@@ -1130,56 +1080,44 @@ int teca_cpp_temporal_reduction::internals_t::summation_operator::update_gpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    }
+    // partial update the reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cuda_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cuda_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cuda_accessible<CTT>(out_array);
 
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cuda_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
+            // update, respect missing values
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
 
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cuda_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
             cuda::summation(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+                p_in_array, p_in_valid, p_res_array, p_res_valid, n_elem);
+
+            red_valid = res_valid;
         }
         else
         {
-            const NT_MASK *p_in_valid = nullptr;
-            const NT_MASK *p_out_valid = nullptr;
-            NT_MASK *p_red_valid = nullptr;
-
-            cuda::summation(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+            cuda::summation(device_id, p_out_array, nullptr,
+                p_in_array, nullptr, p_res_array, nullptr, n_elem);
         }
+
+        red_array = res_array;
     )
 
     // update the output
     arrays_out->set(array, red_array);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
 
     return 0;
@@ -1215,75 +1153,67 @@ int teca_cpp_temporal_reduction::internals_t::minimum_operator::update_cpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem);
-    }
+    // partial update the reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cpu_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cpu_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [sp_in_array, p_in_array] = get_cpu_accessible<TT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cpu_accessible<TT>(out_array);
 
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cpu_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
+            // update, respect missing values
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
 
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cpu_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                // update the valid value mask
-                p_red_valid[i] = char(1);
+                p_res_valid[i] = NT_MASK(1);
                 if (p_in_valid[i] && p_out_valid[i])
-                    // reduce
-                    p_red_array[i] = (p_in_array[i] < p_out_array[i]) ?
+                {
+                    p_res_array[i] = (p_in_array[i] < p_out_array[i]) ?
                                                     p_in_array[i] : p_out_array[i];
+                }
                 else if (p_in_valid[i] && !p_out_valid[i])
                 {
-                    p_red_array[i] = p_in_array[i];
+                    p_res_array[i] = p_in_array[i];
                 }
                 else if (!p_in_valid[i] && p_out_valid[i])
                 {
-                    p_red_array[i] = p_out_array[i];
+                    p_res_array[i] = p_out_array[i];
                 }
                 else
                 {
-                    p_red_valid[i] = char(0);
+                    p_res_valid[i] = NT_MASK(0);
                 }
             }
+
+            red_valid = res_valid;
         }
         else
         {
+            // update, no missing values
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                // reduce
-                p_red_array[i] = p_in_array[i] < p_out_array[i] ?
+                p_res_array[i] = p_in_array[i] < p_out_array[i] ?
                                                p_in_array[i] : p_out_array[i];
             }
         }
+
+        red_array = res_array;
     )
 
     // update the output
     arrays_out->set(array, red_array);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
 
     return 0;
@@ -1309,50 +1239,35 @@ int teca_cpp_temporal_reduction::internals_t::minimum_operator::update_gpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    }
+    // partial update of the reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cuda_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
+        auto [sp_in_array, p_in_array] = get_cuda_accessible<TT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cuda_accessible<TT>(out_array);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cuda_accessible();
-        const NT *p_out_array = sp_out_array.get();
-
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cuda_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
-
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cuda_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
+            auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
             cuda::minimum(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+                p_in_array, p_in_valid, p_res_array, p_res_valid, n_elem);
+
+            red_valid = res_valid;
         }
         else
         {
-            const NT_MASK *p_in_valid = nullptr;
-            const NT_MASK *p_out_valid = nullptr;
-            NT_MASK *p_red_valid = nullptr;
-
-            cuda::minimum(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+            cuda::minimum(device_id, p_out_array, nullptr,
+                p_in_array, nullptr, p_res_array, nullptr, n_elem);
         }
+
+        red_array = res_array;
     )
 
     // update the output
@@ -1394,75 +1309,67 @@ int teca_cpp_temporal_reduction::internals_t::maximum_operator::update_cpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem);
-    }
+    // partial update of the reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cpu_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cpu_accessible();
-        const NT *p_out_array = sp_out_array.get();
+        auto [sp_in_array, p_in_array] = get_cpu_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cpu_accessible<CTT>(out_array);
 
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cpu_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
+            // update, respect missing values
+            auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem);
 
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cpu_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            auto [sp_in_valid, p_in_valid] = get_cpu_accessible<CTT_MASK>(in_valid);
+            auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
 
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                // update the valid value mask
-                p_red_valid[i] = char(1);
+                p_res_valid[i] = NT_MASK(1);
                 if (p_in_valid[i] && p_out_valid[i])
-                    // reduce
-                    p_red_array[i] = (p_in_array[i] > p_out_array[i]) ?
+                {
+                    p_res_array[i] = (p_in_array[i] > p_out_array[i]) ?
                                                     p_in_array[i] : p_out_array[i];
+                }
                 else if (p_in_valid[i] && !p_out_valid[i])
                 {
-                    p_red_array[i] = p_in_array[i];
+                    p_res_array[i] = p_in_array[i];
                 }
                 else if (!p_in_valid[i] && p_out_valid[i])
                 {
-                    p_red_array[i] = p_out_array[i];
+                    p_res_array[i] = p_out_array[i];
                 }
                 else
                 {
-                    p_red_valid[i] = char(0);
+                    p_res_valid[i] = NT_MASK(0);
                 }
             }
+
+            red_valid = res_valid;
         }
         else
         {
+            // update, no missing values
             for (unsigned int i = 0; i < n_elem; ++i)
             {
-                // reduce
-                p_red_array[i] = p_in_array[i] > p_out_array[i] ?
+                p_res_array[i] = p_in_array[i] > p_out_array[i] ?
                                                p_in_array[i] : p_out_array[i];
             }
         }
+
+        red_array = res_array;
     )
 
     // update the output
     arrays_out->set(array, red_array);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
 
     return 0;
@@ -1488,56 +1395,43 @@ int teca_cpp_temporal_reduction::internals_t::maximum_operator::update_gpu(
     const_p_teca_variant_array in_valid = arrays_in->get(valid);
     const_p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    p_teca_variant_array red_array = out_array->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    p_teca_variant_array red_valid = nullptr;
-    if (out_valid != nullptr)
-    {
-        red_valid = out_valid->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    }
+    // partial update of the reduction
+    p_teca_variant_array red_array;
+    p_teca_variant_array red_valid;
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-        auto sp_in_array = static_cast<const TT*>(in_array.get())->get_cuda_accessible();
-        const NT *p_in_array = sp_in_array.get();
+        auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
+        auto [sp_in_array, p_in_array] = get_cuda_accessible<CTT>(in_array);
+        auto [sp_out_array, p_out_array] = get_cuda_accessible<CTT>(out_array);
 
-        auto sp_out_array = static_cast<const TT*>(out_array.get())->get_cuda_accessible();
-        const NT *p_out_array = sp_out_array.get();
-
-        auto sp_red_array = static_cast<TT*>(red_array.get())->get_cuda_accessible();
-        NT *p_red_array = sp_red_array.get();
-
-        // fix invalid values
-        if (out_valid != nullptr)
+        if (out_valid)
         {
-            auto sp_in_valid = static_cast<const TT_MASK*>(in_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_in_valid = sp_in_valid.get();
-
-            auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-            const NT_MASK *p_out_valid = sp_out_valid.get();
-
-            auto sp_red_valid = static_cast<TT_MASK*>(red_valid.get())->get_cuda_accessible();
-            NT_MASK *p_red_valid = sp_red_valid.get();
+            // update, respect missing values
+           auto [res_valid, p_res_valid] = ::New<TT_MASK>(n_elem, allocator::cuda_async);
+           auto [sp_in_valid, p_in_valid] = get_cuda_accessible<CTT_MASK>(in_valid);
+           auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
             cuda::maximum(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+                p_in_array, p_in_valid, p_res_array, p_res_valid, n_elem);
+
+            red_valid = res_valid;
         }
         else
         {
-            const NT_MASK *p_in_valid = nullptr;
-            const NT_MASK *p_out_valid = nullptr;
-            NT_MASK *p_red_valid = nullptr;
-
-            cuda::maximum(device_id, p_out_array, p_out_valid,
-                p_in_array, p_in_valid, p_red_array, p_red_valid, n_elem);
+            // update, no misisng values
+            cuda::maximum(device_id, p_out_array, nullptr,
+                p_in_array, nullptr, p_res_array, nullptr, n_elem);
         }
+
+        red_array = res_array;
     )
 
     // update the output
     arrays_out->set(array, red_array);
 
-    if (red_valid != nullptr)
+    if (out_valid)
         arrays_out->set(valid, red_valid);
 
     return 0;
@@ -1565,59 +1459,41 @@ int teca_cpp_temporal_reduction::internals_t::reduction_operator::finalize(
     p_teca_variant_array out_array = arrays_out->get(array);
 
     // the valid value masks
-    // returns a nullptr if the array is not in the collection
     std::string valid = array + "_valid";
     p_teca_variant_array out_valid = arrays_out->get(valid);
 
-    if (out_valid != nullptr)
+    if (out_valid)
     {
-        TEMPLATE_DISPATCH(
-            teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             out_array.get(),
 
+            NT fill_value = NT(this->fill_value);
             unsigned long n_elem = out_array->size();
+
+            auto [p_out_array] = data<TT>(out_array);
 
 #if defined(TECA_HAS_CUDA)
             if (device_id >= 0)
             {
-                auto sp_out_array = static_cast<TT*>(out_array.get())->get_cuda_accessible();
-                NT *p_out_array = sp_out_array.get();
-
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
-
-                cuda::finalize(device_id, p_out_array, p_out_valid,
-                    this->fill_value, n_elem);
+                auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
+                cuda::finalize(device_id, p_out_array, p_out_valid, fill_value, n_elem);
             }
             else
             {
 #endif
-                auto sp_out_array = static_cast<TT*>(out_array.get())->get_cpu_accessible();
-                NT *p_out_array = sp_out_array.get();
-
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
-
-                NT fill_value = NT(this->fill_value);
-
+                auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
                 for (unsigned int i = 0; i < n_elem; ++i)
                 {
-                    if (!p_out_valid[i])
-                    {
-                        p_out_array[i] = fill_value;
-                    }
+                    p_out_array[i] = p_out_valid[i] ? p_out_array[i] : fill_value;
                 }
 #if defined(TECA_HAS_CUDA)
             }
 #endif
-        )
-
         // update the output
         arrays_out->set(array, out_array);
-
-        if (out_valid != nullptr)
-           arrays_out->set(valid, out_valid);
+        )
     }
+
     return 0;
 }
 
@@ -1633,91 +1509,72 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::finalize(
 
     p_teca_variant_array out_array = arrays_out->get(array);
 
-    // the valid value masks
-    // returns a nullptr if the array is not in the collection
+    // get the valid value masks
     std::string valid = array + "_valid";
     p_teca_variant_array out_valid = arrays_out->get(valid);
 
+    // get the count, always have it, but it will be per point when dealing
+    // with valid value masks
+    p_teca_variant_array count = arrays_out->get(array + "_count");
+
+    // finalize the reduciton by scaling by 1 / count
+                // finish the average. We keep track of the invalid
+                // values (these will have a zero count) set them to
+                // the fill value
     unsigned long n_elem = out_array->size();
 
     p_teca_variant_array red_array;
-#if defined(TECA_HAS_CUDA)
-    if (device_id >= 0)
-    {
-        red_array = out_array->new_instance(n_elem, teca_variant_array::allocator::cuda);
-    }
-    else
-    {
-#endif
-        red_array = out_array->new_instance(n_elem);
-#if defined(TECA_HAS_CUDA)
-    }
-#endif
 
-    p_teca_variant_array count = arrays_out->get(array + "_count");
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
+        out_array.get(),
 
-    TEMPLATE_DISPATCH(
-        teca_variant_array_impl,
-        red_array.get(),
+        NT fill_val = NT(this->fill_value);
+
+        auto [p_out_array] = data<TT>(out_array);
+        auto [p_count] = data<TT>(count);
 
 #if defined(TECA_HAS_CUDA)
         if (device_id >= 0)
         {
-            auto sp_out_array = static_cast<TT*>(out_array.get())->get_cuda_accessible();
-            NT *p_out_array = sp_out_array.get();
-
-            NT *p_red_array = static_cast<TT*>(red_array.get())->data();
-
-            const NT *p_count = static_cast<const TT*>(count.get())->data();
-
+            // GPU
+            auto [res_array, p_res_array] = ::New<TT>(n_elem, allocator::cuda_async);
             if (out_valid)
             {
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cuda_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
+                auto [sp_out_valid, p_out_valid] = get_cuda_accessible<CTT_MASK>(out_valid);
 
                 cuda::average_finalize(device_id, p_out_array, p_out_valid,
-                    p_red_array, p_count, this->fill_value, n_elem);
+                    p_res_array, p_count, fill_val, n_elem);
             }
             else
             {
                 cuda::average_finalize(device_id, p_out_array, nullptr,
-                    p_red_array, p_count, this->fill_value, n_elem);
+                    p_res_array, p_count, fill_val, n_elem);
             }
+            red_array = res_array;
         }
         else
         {
 #endif
-            auto sp_out_array = static_cast<TT*>(out_array.get())->get_cpu_accessible();
-            NT *p_out_array = sp_out_array.get();
-
-            NT *p_red_array = static_cast<TT*>(red_array.get())->data();
-
-            const NT *p_count = static_cast<const TT*>(count.get())->data();
-
+            // CPU
+            auto [res_array, p_res_array] = ::New<TT>(n_elem);
             if (out_valid)
             {
-                // finish the average. We keep track of the invalid
-                // values (these will have a zero count) set them to
-                // the fill value
-
-                auto sp_out_valid = static_cast<const TT_MASK*>(out_valid.get())->get_cpu_accessible();
-                const NT_MASK *p_out_valid = sp_out_valid.get();
-
-                NT fill_value = NT(this->fill_value);
-
+                auto [sp_out_valid, p_out_valid] = get_cpu_accessible<CTT_MASK>(out_valid);
                 for (unsigned int i = 0; i < n_elem; ++i)
                 {
-                    p_red_array[i] = (!p_out_valid[i]) ?
-                                      fill_value : p_out_array[i]/p_count[i];
+                    p_res_array[i] = (!p_out_valid[i]) ?
+                                      fill_val : p_out_array[i]/p_count[i];
                 }
             }
             else
             {
                 for (unsigned int i = 0; i < n_elem; ++i)
                 {
-                    p_red_array[i] = p_out_array[i]/p_count[0];
+                    p_res_array[i] = p_out_array[i]/p_count[0];
                 }
             }
+
+            red_array = res_array;
 #if defined(TECA_HAS_CUDA)
         }
 #endif
@@ -1725,9 +1582,6 @@ int teca_cpp_temporal_reduction::internals_t::average_operator::finalize(
 
     // update the output
     arrays_out->set(array, red_array);
-
-    if (out_valid != nullptr)
-       arrays_out->set(valid, out_valid);
 
     return 0;
 }
@@ -2274,7 +2128,7 @@ const_p_teca_dataset teca_cpp_temporal_reduction::execute(
 #if defined(TECA_HAS_CUDA)
     if (device_id >= 0)
     {
-       alloc = allocator::cuda;
+       alloc = allocator::cuda_async;
 
        if (teca_cuda_util::set_device(device_id))
            return nullptr;
@@ -2347,7 +2201,7 @@ const_p_teca_dataset teca_cpp_temporal_reduction::execute(
                     if (have_vv_mask)
                     {
                         n_elem_count = n_elem;
-                        alloc_count = (device_id >= 0 ? allocator::cuda : allocator::malloc);
+                        alloc_count = (device_id >= 0 ? allocator::cuda_async : allocator::malloc);
                     }
 
                     p_teca_variant_array_impl<NT> count =

--- a/alg/teca_time_axis_convolution.cxx
+++ b/alg/teca_time_axis_convolution.cxx
@@ -523,8 +523,7 @@ const_p_teca_dataset teca_time_axis_convolution::execute(
             const_p_teca_array_collection in_arrays = in_mesh->get_point_arrays();
             const_p_teca_variant_array in_array = in_arrays->get(j);
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                in_array.get(),
+            VARIANT_ARRAY_DISPATCH(in_array.get(),
 
                 // allocate and initialize the output
                 if (i == 0)

--- a/alg/teca_time_axis_convolution.cxx
+++ b/alg/teca_time_axis_convolution.cxx
@@ -519,7 +519,7 @@ const_p_teca_dataset teca_time_axis_convolution::execute(
             const_p_teca_array_collection in_arrays = in_mesh->get_point_arrays();
             const_p_teca_variant_array in_array = in_arrays->get(j);
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 in_array.get(),
 
                 using TT_OUT = teca_variant_array_impl<NT>;
@@ -542,7 +542,7 @@ const_p_teca_dataset teca_time_axis_convolution::execute(
                 auto sp_out = dynamic_cast<TT_OUT*>(out_array.get())->get_cpu_accessible();
                 NT *p_out = sp_out.get();
 
-                auto sp_in = dynamic_cast<TT*>(in_array.get())->get_cpu_accessible();
+                auto sp_in = dynamic_cast<const TT*>(in_array.get())->get_cpu_accessible();
                 const NT *p_in = sp_in.get();
 
                 // apply the kernel weight for this time step

--- a/alg/teca_time_axis_convolution.cxx
+++ b/alg/teca_time_axis_convolution.cxx
@@ -3,6 +3,8 @@
 #include "teca_mesh.h"
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 #include "teca_string_util.h"
@@ -17,6 +19,8 @@
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
 #endif
+
+using namespace teca_variant_array_util;
 
 //#define TECA_DEBUG
 
@@ -522,14 +526,12 @@ const_p_teca_dataset teca_time_axis_convolution::execute(
             TEMPLATE_DISPATCH(teca_variant_array_impl,
                 in_array.get(),
 
-                using TT_OUT = teca_variant_array_impl<NT>;
-
                 // allocate and initialize the output
                 if (i == 0)
                 {
                     // allocate the output array
                     n_elem = in_array->size();
-                    out_array = TT_OUT::New(n_elem, NT(0));
+                    out_array = TT::New(n_elem, NT(0));
 
                     // store it in the output mesh
                     std::string array_name =
@@ -539,11 +541,8 @@ const_p_teca_dataset teca_time_axis_convolution::execute(
                 }
 
                 // get the typed instances
-                auto sp_out = dynamic_cast<TT_OUT*>(out_array.get())->get_cpu_accessible();
-                NT *p_out = sp_out.get();
-
-                auto sp_in = dynamic_cast<const TT*>(in_array.get())->get_cpu_accessible();
-                const NT *p_in = sp_in.get();
+                auto [sp_in, p_in] = get_cpu_accessible<CTT>(in_array);
+                auto [p_out] = data<TT>(out_array);
 
                 // apply the kernel weight for this time step
                 NT weight = NT(this->kernel_weights[i]);

--- a/alg/teca_unpack_data.cxx
+++ b/alg/teca_unpack_data.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -20,6 +21,9 @@
 #if defined(TECA_HAS_CUDA)
 #include "teca_cuda_util.h"
 #endif
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 //#define TECA_DEBUG
 
@@ -66,27 +70,21 @@ int dispatch(const p_teca_variant_array &in_array,
 
     // transform arrays
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-        in_array.get(),
-        _IN,
+        in_array.get(), _IN,
 
-        auto sp_in = dynamic_cast<TT_IN*>(in_array.get())->get_cpu_accessible();
-        NT_IN *p_in = sp_in.get();
+        auto [sp_in, p_in] = get_cpu_accessible<TT_IN>(in_array);
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            out_array.get(),
-            _OUT,
+            out_array.get(), _OUT,
 
-            auto sp_out = dynamic_cast<TT_OUT*>(out_array.get())->get_cpu_accessible();
-            NT_OUT *p_out = sp_out.get();
+            auto [p_out] = data<TT_OUT>(out_array);
 
             if (mask)
             {
                 NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-                    mask.get(),
-                    _MASK,
+                    mask.get(), _MASK,
 
-                    auto sp_mask = dynamic_cast<TT_MASK*>(mask.get())->get_cpu_accessible();
-                    NT_MASK *p_mask = sp_mask.get();
+                    auto [sp_mask, p_mask] = get_cpu_accessible<TT_MASK>(mask);
 
                     cpu::transform(p_out, p_in, p_mask,
                         n_elem, NT_OUT(scale), NT_OUT(offset), NT_OUT(1e20));
@@ -208,8 +206,8 @@ int dispatch(int device_id, const p_teca_variant_array &in_array,
     teca_cuda_util::set_device(device_id);
 
     // allocate the output
-    out_array = teca_variant_array_factory::New(output_data_type,
-        teca_variant_array::allocator::cuda);
+    out_array = teca_variant_array_factory::New
+        (output_data_type, allocator::cuda_async);
 
     if (!out_array)
     {
@@ -222,33 +220,21 @@ int dispatch(int device_id, const p_teca_variant_array &in_array,
 
     // transform arrays
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
-        in_array.get(),
-        _IN,
+        in_array.get(), _IN,
 
-        auto sp_in = dynamic_cast<TT_IN*>
-            (in_array.get())->get_cuda_accessible();
-
-        NT_IN *p_in = sp_in.get();
+        auto [sp_in, p_in] = get_cuda_accessible<TT_IN>(in_array);
 
         NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            out_array.get(),
-            _OUT,
+            out_array.get(), _OUT,
 
-            auto sp_out = dynamic_cast<TT_OUT*>
-                (out_array.get())->get_cuda_accessible();
-
-            NT_OUT *p_out = sp_out.get();
+            auto [p_out] = data<TT_OUT>(out_array);
 
             if (mask)
             {
                 NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-                    mask.get(),
-                    _MASK,
+                    mask.get(), _MASK,
 
-                    auto sp_mask = dynamic_cast<TT_MASK*>
-                        (mask.get())->get_cuda_accessible();
-
-                    NT_MASK *p_mask = sp_mask.get();
+                    auto [sp_mask, p_mask] = get_cuda_accessible<TT_MASK>(mask);
 
                     // unpack the data
                     if (cuda::transform(device_id, p_out, p_in, p_mask,

--- a/alg/teca_unpack_data.cxx
+++ b/alg/teca_unpack_data.cxx
@@ -69,19 +69,19 @@ int dispatch(const p_teca_variant_array &in_array,
     out_array->resize(n_elem);
 
     // transform arrays
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         in_array.get(), _IN,
 
         auto [sp_in, p_in] = get_cpu_accessible<TT_IN>(in_array);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             out_array.get(), _OUT,
 
             auto [p_out] = data<TT_OUT>(out_array);
 
             if (mask)
             {
-                NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_I(
                     mask.get(), _MASK,
 
                     auto [sp_mask, p_mask] = get_cpu_accessible<TT_MASK>(mask);
@@ -219,19 +219,19 @@ int dispatch(int device_id, const p_teca_variant_array &in_array,
     out_array->resize(n_elem);
 
     // transform arrays
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         in_array.get(), _IN,
 
         auto [sp_in, p_in] = get_cuda_accessible<TT_IN>(in_array);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             out_array.get(), _OUT,
 
             auto [p_out] = data<TT_OUT>(out_array);
 
             if (mask)
             {
-                NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+                NESTED_VARIANT_ARRAY_DISPATCH_I(
                     mask.get(), _MASK,
 
                     auto [sp_mask, p_mask] = get_cuda_accessible<TT_MASK>(mask);

--- a/alg/teca_valid_value_mask.cxx
+++ b/alg/teca_valid_value_mask.cxx
@@ -495,8 +495,7 @@ const_p_teca_dataset teca_valid_value_mask::execute(
             return nullptr;
         }
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            array.get(),
+        VARIANT_ARRAY_DISPATCH(array.get(),
 
             // look for a _FillValue
             bool have_fill_value = false;

--- a/alg/teca_valid_value_mask.h
+++ b/alg/teca_valid_value_mask.h
@@ -9,11 +9,16 @@
 #include <string>
 #include <vector>
 
-/// The valid value mask array elements will be of this type
+/// @name mask type aliases
+///@{
 using NT_MASK = char;
-
-/// The valid value mask array will be of this type
 using TT_MASK = teca_variant_array_impl<NT_MASK>;
+using CTT_MASK = teca_variant_array_impl<NT_MASK>;
+using PT_MASK = p_teca_variant_array_impl<NT_MASK>;
+using CPT_MASK = const_p_teca_variant_array_impl<NT_MASK>;
+using SP_MASK = std::shared_ptr<NT_MASK>;
+using CSP_MASK = std::shared_ptr<const NT_MASK>;
+///@}
 
 TECA_SHARED_OBJECT_FORWARD_DECL(teca_valid_value_mask)
 

--- a/alg/teca_variant_array_operator.h
+++ b/alg/teca_variant_array_operator.h
@@ -79,17 +79,17 @@ p_teca_variant_array apply(const const_p_teca_variant_array &arg1,
     const const_p_teca_variant_array &arg2, const const_p_teca_variant_array &arg3,
     const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         arg1.get(), _1,
-        auto sparg1 = static_cast<TT_1*>(arg1.get())->get_cpu_accessible();
+        auto sparg1 = static_cast<const TT_1*>(arg1.get())->get_cpu_accessible();
         auto parg1 = sparg1.get();
-        NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             arg2.get(), _2,
-            auto sparg2 = static_cast<TT_2*>(arg2.get())->get_cpu_accessible();
+            auto sparg2 = static_cast<const TT_2*>(arg2.get())->get_cpu_accessible();
             auto parg2 = sparg2.get();
-            NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
                 arg2.get(), _3,
-                auto sparg3 = static_cast<TT_3*>(arg3.get())->get_cpu_accessible();
+                auto sparg3 = static_cast<const TT_3*>(arg3.get())->get_cpu_accessible();
                 auto parg3 = sparg3.get();
                 return internal::apply(arg1->size(), parg1, parg2, parg3, op);
                 )
@@ -104,13 +104,13 @@ template <typename operator_t>
 p_teca_variant_array apply_i(const const_p_teca_variant_array &larg,
     const const_p_teca_variant_array &rarg, const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         larg.get(), _LEFT,
-        auto splarg = static_cast<TT_LEFT*>(larg.get())->get_cpu_accessible();
+        auto splarg = static_cast<const TT_LEFT*>(larg.get())->get_cpu_accessible();
         auto plarg = splarg.get();
-        NESTED_TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
             rarg.get(), _RIGHT,
-            auto sprarg = static_cast<TT_RIGHT*>(rarg.get())->get_cpu_accessible();
+            auto sprarg = static_cast<const TT_RIGHT*>(rarg.get())->get_cpu_accessible();
             auto prarg = sprarg.get();
             return internal::apply(larg->size(), plarg, prarg, op);
             )
@@ -124,13 +124,13 @@ template <typename operator_t>
 p_teca_variant_array apply(const const_p_teca_variant_array &larg,
     const const_p_teca_variant_array &rarg, const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         larg.get(), _LEFT,
-        auto splarg = static_cast<TT_LEFT*>(larg.get())->get_cpu_accessible();
+        auto splarg = static_cast<const TT_LEFT*>(larg.get())->get_cpu_accessible();
         auto plarg = splarg.get();
-        NESTED_TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             rarg.get(), _RIGHT,
-            auto sprarg = static_cast<TT_RIGHT*>(rarg.get())->get_cpu_accessible();
+            auto sprarg = static_cast<const TT_RIGHT*>(rarg.get())->get_cpu_accessible();
             auto prarg = sprarg.get();
             return internal::apply(larg->size(), plarg, prarg, op);
             )
@@ -144,9 +144,9 @@ template <typename operator_t>
 p_teca_variant_array apply(const const_p_teca_variant_array &arg,
     const operator_t &op)
 {
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         arg.get(),
-        auto sparg = static_cast<TT*>(arg.get())->get_cpu_accessible();
+        auto sparg = static_cast<const TT*>(arg.get())->get_cpu_accessible();
         auto parg = sparg.get();
         return internal::apply(arg->size(), parg, op);
         )

--- a/alg/teca_variant_array_operator.h
+++ b/alg/teca_variant_array_operator.h
@@ -80,13 +80,13 @@ p_teca_variant_array apply(const const_p_teca_variant_array &arg1,
     const const_p_teca_variant_array &arg2, const const_p_teca_variant_array &arg3,
     const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         arg1.get(), _1,
         auto [sparg1, parg1] = get_cpu_accessible<CTT_1>(arg1);
-        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH(
             arg2.get(), _2,
             auto [sparg2, parg2] = get_cpu_accessible<CTT_2>(arg2);
-            NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+            NESTED_VARIANT_ARRAY_DISPATCH(
                 arg2.get(), _3,
                 auto [sparg3, parg3] = get_cpu_accessible<CTT_3>(arg3);
                 return internal::apply(arg1->size(), parg1, parg2, parg3, op);
@@ -102,10 +102,10 @@ template <typename operator_t>
 p_teca_variant_array apply_i(const const_p_teca_variant_array &larg,
     const const_p_teca_variant_array &rarg, const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_I(
         larg.get(), _LEFT,
         auto [splarg, plarg] = get_cpu_accessible<CTT_LEFT>(larg);
-        NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_I(
             rarg.get(), _RIGHT,
             auto [sprarg, prarg] = get_cpu_accessible<CTT_RIGHT>(rarg);
             return internal::apply(larg->size(), plarg, prarg, op);
@@ -120,10 +120,10 @@ template <typename operator_t>
 p_teca_variant_array apply(const const_p_teca_variant_array &larg,
     const const_p_teca_variant_array &rarg, const operator_t &op)
 {
-    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH(
         larg.get(), _LEFT,
         auto [splarg, plarg] = get_cpu_accessible<CTT_LEFT>(larg);
-        NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH(
             rarg.get(), _RIGHT,
             auto [sprarg, prarg] = get_cpu_accessible<CTT_RIGHT>(rarg);
             return internal::apply(larg->size(), plarg, prarg, op);
@@ -138,7 +138,7 @@ template <typename operator_t>
 p_teca_variant_array apply(const const_p_teca_variant_array &arg,
     const operator_t &op)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
+    VARIANT_ARRAY_DISPATCH(
         arg.get(),
         auto [sparg, parg] = get_cpu_accessible<CTT>(arg);
         return internal::apply(arg->size(), parg, op);

--- a/alg/teca_variant_array_operator.h
+++ b/alg/teca_variant_array_operator.h
@@ -4,7 +4,11 @@
 /// @file
 
 #include "teca_variant_array.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_type_select.h"
+
+using namespace teca_variant_array_util;
 
 /// Codes dealing with run time specified operations on teca_variant_arrays
 namespace teca_variant_array_operator
@@ -25,8 +29,7 @@ p_teca_variant_array apply(unsigned long n,
     p_teca_variant_array_impl<nt_out> out =
         teca_variant_array_impl<nt_out>::New(n);
 
-    auto spout = out->get_cpu_accessible();
-    nt_out *pout = spout.get();
+    nt_out *pout = out->data();
 
     for (unsigned long i = 0; i < n; ++i)
         pout[i] = static_cast<nt_out>(op(parg1[i], parg2[i], parg3[i]));
@@ -45,8 +48,7 @@ p_teca_variant_array apply(unsigned long n,
     p_teca_variant_array_impl<nt_out> out =
         teca_variant_array_impl<nt_out>::New(n);
 
-    auto spout = out->get_cpu_accessible();
-    nt_out *pout = spout.get();
+    nt_out *pout = out->data();
 
     for (unsigned long i = 0; i < n; ++i)
         pout[i] = static_cast<nt_out>(op(plarg[i], prarg[i]));
@@ -62,8 +64,7 @@ p_teca_variant_array apply(unsigned long n,
     p_teca_variant_array_impl<nt_arg> out =
         teca_variant_array_impl<nt_arg>::New(n);
 
-    auto spout = out->get_cpu_accessible();
-    nt_arg *pout = spout.get();
+    nt_arg *pout = out->data();
 
     for (unsigned long i = 0; i < n; ++i)
         pout[i] = static_cast<nt_arg>(op(parg[i]));
@@ -81,16 +82,13 @@ p_teca_variant_array apply(const const_p_teca_variant_array &arg1,
 {
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         arg1.get(), _1,
-        auto sparg1 = static_cast<const TT_1*>(arg1.get())->get_cpu_accessible();
-        auto parg1 = sparg1.get();
+        auto [sparg1, parg1] = get_cpu_accessible<CTT_1>(arg1);
         NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             arg2.get(), _2,
-            auto sparg2 = static_cast<const TT_2*>(arg2.get())->get_cpu_accessible();
-            auto parg2 = sparg2.get();
+            auto [sparg2, parg2] = get_cpu_accessible<CTT_2>(arg2);
             NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
                 arg2.get(), _3,
-                auto sparg3 = static_cast<const TT_3*>(arg3.get())->get_cpu_accessible();
-                auto parg3 = sparg3.get();
+                auto [sparg3, parg3] = get_cpu_accessible<CTT_3>(arg3);
                 return internal::apply(arg1->size(), parg1, parg2, parg3, op);
                 )
             )
@@ -106,12 +104,10 @@ p_teca_variant_array apply_i(const const_p_teca_variant_array &larg,
 {
     NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         larg.get(), _LEFT,
-        auto splarg = static_cast<const TT_LEFT*>(larg.get())->get_cpu_accessible();
-        auto plarg = splarg.get();
+        auto [splarg, plarg] = get_cpu_accessible<CTT_LEFT>(larg);
         NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
             rarg.get(), _RIGHT,
-            auto sprarg = static_cast<const TT_RIGHT*>(rarg.get())->get_cpu_accessible();
-            auto prarg = sprarg.get();
+            auto [sprarg, prarg] = get_cpu_accessible<CTT_RIGHT>(rarg);
             return internal::apply(larg->size(), plarg, prarg, op);
             )
         )
@@ -126,12 +122,10 @@ p_teca_variant_array apply(const const_p_teca_variant_array &larg,
 {
     NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
         larg.get(), _LEFT,
-        auto splarg = static_cast<const TT_LEFT*>(larg.get())->get_cpu_accessible();
-        auto plarg = splarg.get();
+        auto [splarg, plarg] = get_cpu_accessible<CTT_LEFT>(larg);
         NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl,
             rarg.get(), _RIGHT,
-            auto sprarg = static_cast<const TT_RIGHT*>(rarg.get())->get_cpu_accessible();
-            auto prarg = sprarg.get();
+            auto [sprarg, prarg] = get_cpu_accessible<CTT_RIGHT>(rarg);
             return internal::apply(larg->size(), plarg, prarg, op);
             )
         )
@@ -146,8 +140,7 @@ p_teca_variant_array apply(const const_p_teca_variant_array &arg,
 {
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         arg.get(),
-        auto sparg = static_cast<const TT*>(arg.get())->get_cpu_accessible();
-        auto parg = sparg.get();
+        auto [sparg, parg] = get_cpu_accessible<CTT>(arg);
         return internal::apply(arg->size(), parg, op);
         )
     TECA_ERROR("failed to apply " << operator_t::name() << ". unsupported type.")

--- a/alg/teca_vertical_coordinate_transform.cxx
+++ b/alg/teca_vertical_coordinate_transform.cxx
@@ -296,8 +296,7 @@ const_p_teca_dataset teca_vertical_coordinate_transform::execute(
             p_teca_variant_array yo;
             p_teca_variant_array ph;
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                xi.get(),
+            VARIANT_ARRAY_DISPATCH(xi.get(),
 
                 auto [tmp_xo, pxo] = ::New<TT>(nxyz);
                 auto [tmp_yo, pyo] = ::New<TT>(nxyz);

--- a/alg/teca_vorticity.cxx
+++ b/alg/teca_vorticity.cxx
@@ -362,13 +362,13 @@ const_p_teca_dataset teca_vorticity::execute(
 
     // compute vorticity
     NESTED_TEMPLATE_DISPATCH_FP(
-        const teca_variant_array_impl,
+        teca_variant_array_impl,
         lon.get(), 1,
 
-        auto sp_lon = dynamic_cast<TT1*>(lon.get())->get_cpu_accessible();
+        auto sp_lon = dynamic_cast<const TT1*>(lon.get())->get_cpu_accessible();
         const NT1 *p_lon = sp_lon.get();
 
-        auto sp_lat = dynamic_cast<TT1*>(lat.get())->get_cpu_accessible();
+        auto sp_lat = dynamic_cast<const TT1*>(lat.get())->get_cpu_accessible();
         const NT1 *p_lat = sp_lat.get();
 
         NESTED_TEMPLATE_DISPATCH_FP(

--- a/alg/teca_vorticity.cxx
+++ b/alg/teca_vorticity.cxx
@@ -365,13 +365,13 @@ const_p_teca_dataset teca_vorticity::execute(
     vort->resize(comp_0->size());
 
     // compute vorticity
-    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_FP(
         lon.get(), 1,
 
         assert_type<TT1>(lat);
         auto [sp_lon, p_lon, sp_lat, p_lat] = get_cpu_accessible<CTT1>(lon, lat);
 
-        NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
+        NESTED_VARIANT_ARRAY_DISPATCH_FP(
             comp_0.get(), 2,
 
             assert_type<TT2>(comp_1);

--- a/apps/teca_metadata_probe.cpp
+++ b/apps/teca_metadata_probe.cpp
@@ -270,8 +270,7 @@ int main(int argc, char **argv)
             size_t n = t->size();
             double *p_time = nullptr;
             std::tie(time, p_time) = ::New<teca_double_array>(n);
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                t.get(),
+            VARIANT_ARRAY_DISPATCH(t.get(),
                 auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
                 for (size_t i = 0; i < n; ++i)
                     p_time[i] = static_cast<double>(p_t[i]);

--- a/apps/teca_metadata_probe.cpp
+++ b/apps/teca_metadata_probe.cpp
@@ -7,6 +7,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_coordinate_util.h"
 #include "teca_mpi_manager.h"
 #include "teca_system_interface.h"
@@ -33,6 +34,7 @@ using teca_calendar_util::year_iterator;
 
 using namespace std;
 using boost::program_options::value;
+using namespace teca_variant_array_util;
 
 #if defined(TECA_HAS_UDUNITS)
 // --------------------------------------------------------------------------
@@ -266,13 +268,11 @@ int main(int argc, char **argv)
         {
             // convert to double precision
             size_t n = t->size();
-            time = teca_double_array::New(n);
-            auto sp_time = time->get_cpu_accessible();
-            double *p_time = sp_time.get();
+            double *p_time = nullptr;
+            std::tie(time, p_time) = ::New<teca_double_array>(n);
             TEMPLATE_DISPATCH(teca_variant_array_impl,
                 t.get(),
-                auto sp_t = std::dynamic_pointer_cast<TT>(t)->get_cpu_accessible();
-                NT *p_t = sp_t.get();
+                auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
                 for (size_t i = 0; i < n; ++i)
                     p_time[i] = static_cast<double>(p_t[i]);
                 )
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
 
             // type
             NC_DISPATCH(type,
-                at.push_back(teca_netcdf_util::netcdf_tt<NC_T>::name());
+                at.push_back(teca_netcdf_util::netcdf_tt<NC_NT>::name());
                 )
             atw = std::max<int>(atw, at.back().size() + 4);
 

--- a/core/teca_metadata.cxx
+++ b/core/teca_metadata.cxx
@@ -275,22 +275,19 @@ int teca_metadata::to_stream(ostream &os) const
     for (; it != end; ++it)
     {
         os << it->first << " = " << "{";
-        TEMPLATE_DISPATCH_CASE(
-            teca_variant_array_impl, std::string, it->second.get(),
+        VARIANT_ARRAY_DISPATCH_CASE(std::string, it->second.get(),
             const TT *val = static_cast<const TT*>(it->second.get());
             val->to_stream(os);
             )
-        TEMPLATE_DISPATCH_CASE(
-            teca_variant_array_impl, teca_metadata, it->second.get(),
+        VARIANT_ARRAY_DISPATCH_CASE(teca_metadata, it->second.get(),
             const TT *val = static_cast<const TT*>(it->second.get());
             val->to_stream(os);
             )
-        TEMPLATE_DISPATCH_CASE(
-            teca_variant_array_impl, p_teca_variant_array, it->second.get(),
+        VARIANT_ARRAY_DISPATCH_CASE(p_teca_variant_array, it->second.get(),
             const TT *val = static_cast<const TT*>(it->second.get());
             val->to_stream(os);
             )
-        TEMPLATE_DISPATCH(teca_variant_array_impl, it->second.get(),
+        VARIANT_ARRAY_DISPATCH(it->second.get(),
             const TT *val = static_cast<const TT*>(it->second.get());
             val->to_stream(os);
             )

--- a/core/teca_variant_array.h
+++ b/core/teca_variant_array.h
@@ -372,6 +372,12 @@ public:
     /// a code for the contained data type used for serialization
     virtual unsigned int type_code() const noexcept = 0;
 
+    /// @returns true if the contents are accesisble from the CPU
+    virtual int cpu_accessible() const noexcept = 0;
+
+    /// @returns true if the contents are accesisble from CUDA
+    virtual int cuda_accessible() const noexcept = 0;
+
 private:
     template<typename T>
     void get_dispatch(unsigned long i, T &val,

--- a/core/teca_variant_array.h
+++ b/core/teca_variant_array.h
@@ -36,8 +36,8 @@ TECA_SHARED_OBJECT_FORWARD_DECL(teca_variant_array)
  * public API.  Use the concrete implementation (::teca_variant_array_impl) for
  * direct access to the typed data.
  *
- * See #TEMPLATE_DISPATCH and #NESTED_TEMPLATE_DISPATCH for details on how to
- * apply type specific code to an instance of teca_variant_array.
+ * See #VARIANT_ARRAY_DISPATCH and #NESTED_VARIANT_ARRAY_DISPATCH for details
+ * on how to apply type specific code to an instance of teca_variant_array.
  */
 class TECA_EXPORT teca_variant_array : public std::enable_shared_from_this<teca_variant_array>
 {

--- a/core/teca_variant_array_impl.h
+++ b/core/teca_variant_array_impl.h
@@ -39,6 +39,12 @@ class teca_metadata;
 TECA_SHARED_OBJECT_TEMPLATE_FORWARD_DECL(teca_variant_array_impl)
 
 #ifndef SWIG
+template<typename T>
+using p_teca_variant_array_impl = std::shared_ptr<teca_variant_array_impl<T>>;
+
+template<typename T>
+using const_p_teca_variant_array_impl = std::shared_ptr<const teca_variant_array_impl<T>>;
+
 using teca_string_array = teca_variant_array_impl<std::string>;
 using p_teca_string_array = std::shared_ptr<teca_variant_array_impl<std::string>>;
 using const_p_teca_string_array = std::shared_ptr<const teca_variant_array_impl<std::string>>;
@@ -134,10 +140,11 @@ struct object_dispatch :
  *
  *      using NT = nt;
  *      using TT = tt<nt>;
+ *      using CTT = const tt<nt>;
  *      using PT = std::shared_ptr<tt<nt>>;
  *      using CPT = std::shared_ptr<const tt<nt>>;
- *      using SPT = std::shared_ptr<nt>;
- *      using CSPT = std::shared_ptr<const nt>;
+ *      using SP = std::shared_ptr<nt>;
+ *      using CSP = std::shared_ptr<const nt>;
  *
  */
 #define TEMPLATE_DISPATCH_CASE(tt, nt, p, ...)      \
@@ -145,10 +152,11 @@ struct object_dispatch :
     {                                               \
         using NT = nt;                              \
         using TT = tt<nt>;                          \
+        using CTT = const tt<nt>;                   \
         using PT = std::shared_ptr<tt<nt>>;         \
         using CPT = std::shared_ptr<const tt<nt>>;  \
-        using SPT = std::shared_ptr<nt>;            \
-        using CSPT = std::shared_ptr<const nt>;     \
+        using SP = std::shared_ptr<nt>;             \
+        using CSP = std::shared_ptr<const nt>;      \
         __VA_ARGS__                                 \
     }
 
@@ -165,10 +173,11 @@ struct object_dispatch :
  *
  *      using NT##i = nt;
  *      using TT##i = tt<nt>;
+ *      using CTT##i = const tt<nt>;
  *      using PT##i = std::shared_ptr<tt<nt>>;
  *      using CPT##i = std::shared_ptr<const tt<nt>>;
- *      using SPT##i = std::shared_ptr<nt>;
- *      using CSPT##i = std::shared_ptr<const nt>;
+ *      using SP##i = std::shared_ptr<nt>;
+ *      using CSP##i = std::shared_ptr<const nt>;
  *
  */
 #define NESTED_TEMPLATE_DISPATCH_CASE(tt, nt, p, i, ...)    \
@@ -176,10 +185,11 @@ struct object_dispatch :
     {                                                       \
         using NT##i = nt;                                   \
         using TT##i = tt<nt>;                               \
+        using CTT##i = const tt<nt>;                        \
         using PT##i = std::shared_ptr<tt<nt>>;              \
         using CPT##i = std::shared_ptr<const tt<nt>>;       \
-        using SPT##i = std::shared_ptr<nt>;                 \
-        using CSPT##i = std::shared_ptr<const nt>;          \
+        using SP##i = std::shared_ptr<nt>;                  \
+        using CSP##i = std::shared_ptr<const nt>;           \
         __VA_ARGS__                                         \
     }
 

--- a/core/teca_variant_array_impl.h
+++ b/core/teca_variant_array_impl.h
@@ -303,6 +303,35 @@ struct object_dispatch :
     NESTED_TEMPLATE_DISPATCH_FP(t, p, i, __VA_ARGS__)      \
     else NESTED_TEMPLATE_DISPATCH_I(t, p, i, __VA_ARGS__)
 
+/** shortcuts for NESTED_TEMPLATE_DISPATCH macros */
+#define NESTED_VARIANT_ARRAY_DISPATCH(p, i, ...) \
+    NESTED_TEMPLATE_DISPATCH(teca_variant_array_impl, p, i, __VA_ARGS__)
+
+#define NESTED_VARIANT_ARRAY_DISPATCH_FP(p, i, ...) \
+    NESTED_TEMPLATE_DISPATCH_FP(teca_variant_array_impl, p, i, __VA_ARGS__)
+
+#define NESTED_VARIANT_ARRAY_DISPATCH_I(p, i, ...) \
+    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl, p, i, __VA_ARGS__)
+
+#define NESTED_VARIANT_ARRAY_DISPATCH_CASE(nt, p, i, ...) \
+    TEMPLATE_DISPATCH_CASE(teca_variant_array_impl, nt, p, i, __VA_ARGS__)
+
+/** shortcuts for TEMPLATE_DISPATCH macros */
+#define VARIANT_ARRAY_DISPATCH(p, ...) \
+    TEMPLATE_DISPATCH(teca_variant_array_impl, p, __VA_ARGS__)
+
+#define VARIANT_ARRAY_DISPATCH_FP(p, ...) \
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl, p, __VA_ARGS__)
+
+#define VARIANT_ARRAY_DISPATCH_I(p, ...) \
+    TEMPLATE_DISPATCH_I(teca_variant_array_impl, p, __VA_ARGS__)
+
+#define VARIANT_ARRAY_DISPATCH_FP_SI(p, ...) \
+    TEMPLATE_DISPATCH_FP_SI(teca_variant_array_impl, p, __VA_ARGS__)
+
+#define VARIANT_ARRAY_DISPATCH_CASE(nt, p, ...) \
+    TEMPLATE_DISPATCH_CASE(teca_variant_array_impl, nt, p, __VA_ARGS__)
+
 /// @cond
 // tag for contiguous arrays, and objects that have
 // overrides in teca_binary_stream

--- a/core/teca_variant_array_impl.h
+++ b/core/teca_variant_array_impl.h
@@ -132,16 +132,24 @@ struct object_dispatch :
  *
  * The following aliases are provided to know the type within the code to execute.
  *
- *     using TT = tt<nt>;
- *     using NT = nt;
+ *      using NT = nt;
+ *      using TT = tt<nt>;
+ *      using PT = std::shared_ptr<tt<nt>>;
+ *      using CPT = std::shared_ptr<const tt<nt>>;
+ *      using SPT = std::shared_ptr<nt>;
+ *      using CSPT = std::shared_ptr<const nt>;
  *
  */
-#define TEMPLATE_DISPATCH_CASE(tt, nt, p, body) \
-    if (dynamic_cast<tt<nt>*>(p))               \
-    {                                           \
-        using TT = tt<nt>;                      \
-        using NT = nt;                          \
-        body                                    \
+#define TEMPLATE_DISPATCH_CASE(tt, nt, p, ...)      \
+    if (dynamic_cast<const tt<nt>*>(p))             \
+    {                                               \
+        using NT = nt;                              \
+        using TT = tt<nt>;                          \
+        using PT = std::shared_ptr<tt<nt>>;         \
+        using CPT = std::shared_ptr<const tt<nt>>;  \
+        using SPT = std::shared_ptr<nt>;            \
+        using CSPT = std::shared_ptr<const nt>;     \
+        __VA_ARGS__                                 \
     }
 
 /** Executes the code in body if p is a tt<nt> an idnetifier disambiguates type
@@ -155,49 +163,57 @@ struct object_dispatch :
  *
  * The following aliases are provided to know the type within the code to execute.
  *
- *     using TT##i = tt<nt>;
- *     using NT##i = nt;
+ *      using NT##i = nt;
+ *      using TT##i = tt<nt>;
+ *      using PT##i = std::shared_ptr<tt<nt>>;
+ *      using CPT##i = std::shared_ptr<const tt<nt>>;
+ *      using SPT##i = std::shared_ptr<nt>;
+ *      using CSPT##i = std::shared_ptr<const nt>;
  *
  */
-#define NESTED_TEMPLATE_DISPATCH_CASE(tt, nt, p, i, body)   \
-    if (dynamic_cast<tt<nt>*>(p))                           \
+#define NESTED_TEMPLATE_DISPATCH_CASE(tt, nt, p, i, ...)    \
+    if (dynamic_cast<const tt<nt>*>(p))                     \
     {                                                       \
-        using TT##i = tt<nt>;                               \
         using NT##i = nt;                                   \
-        body                                                \
+        using TT##i = tt<nt>;                               \
+        using PT##i = std::shared_ptr<tt<nt>>;              \
+        using CPT##i = std::shared_ptr<const tt<nt>>;       \
+        using SPT##i = std::shared_ptr<nt>;                 \
+        using CSPT##i = std::shared_ptr<const nt>;          \
+        __VA_ARGS__                                         \
     }
 
 /// Executes the code in body if p is a t<nt> where nt is a floating point type
-#define TEMPLATE_DISPATCH_FP(t, p, body)        \
-    TEMPLATE_DISPATCH_CASE(t, float, p, body)   \
-    else TEMPLATE_DISPATCH_CASE(t, double, p, body)
+#define TEMPLATE_DISPATCH_FP(t, p, ...)                 \
+    TEMPLATE_DISPATCH_CASE(t, float, p, __VA_ARGS__)    \
+    else TEMPLATE_DISPATCH_CASE(t, double, p, __VA_ARGS__)
 
 /// Executes the code in body if p is a t<nt> where nt is a signed inetegral type
-#define TEMPLATE_DISPATCH_SI(t, p, body)                        \
-    TEMPLATE_DISPATCH_CASE(t, long long, p, body)               \
-    else TEMPLATE_DISPATCH_CASE(t, long, p, body)               \
-    else TEMPLATE_DISPATCH_CASE(t, int, p, body)                \
-    else TEMPLATE_DISPATCH_CASE(t, short int, p, body)          \
-    else TEMPLATE_DISPATCH_CASE(t, char, p, body)
+#define TEMPLATE_DISPATCH_SI(t, p, ...)                         \
+    TEMPLATE_DISPATCH_CASE(t, long long, p, __VA_ARGS__)        \
+    else TEMPLATE_DISPATCH_CASE(t, long, p, __VA_ARGS__)        \
+    else TEMPLATE_DISPATCH_CASE(t, int, p, __VA_ARGS__)         \
+    else TEMPLATE_DISPATCH_CASE(t, short int, p, __VA_ARGS__)   \
+    else TEMPLATE_DISPATCH_CASE(t, char, p, __VA_ARGS__)
 
 /// Executes the code in body if p is a t<nt> where nt is either a signed integral or floating point type
-#define TEMPLATE_DISPATCH_FP_SI(t, p, body)             \
-    TEMPLATE_DISPATCH_CASE(t, float, p, body)           \
-    else TEMPLATE_DISPATCH_CASE(t, double, p, body)     \
-    else TEMPLATE_DISPATCH_SI(t, p, body)
+#define TEMPLATE_DISPATCH_FP_SI(t, p, ...)                  \
+    TEMPLATE_DISPATCH_CASE(t, float, p, __VA_ARGS__)        \
+    else TEMPLATE_DISPATCH_CASE(t, double, p, __VA_ARGS__)  \
+    else TEMPLATE_DISPATCH_SI(t, p, __VA_ARGS__)
 
 /// Executes the code in body if p is a t<nt> where nt is an integral type
-#define TEMPLATE_DISPATCH_I(t, p, body)                         \
-    TEMPLATE_DISPATCH_CASE(t, long long, p, body)               \
-    else TEMPLATE_DISPATCH_CASE(t, unsigned long long, p, body) \
-    else TEMPLATE_DISPATCH_CASE(t, long, p, body)               \
-    else TEMPLATE_DISPATCH_CASE(t, int, p, body)                \
-    else TEMPLATE_DISPATCH_CASE(t, unsigned int, p, body)       \
-    else TEMPLATE_DISPATCH_CASE(t, unsigned long, p, body)      \
-    else TEMPLATE_DISPATCH_CASE(t, short int, p, body)          \
-    else TEMPLATE_DISPATCH_CASE(t, short unsigned int, p, body) \
-    else TEMPLATE_DISPATCH_CASE(t, char, p, body)               \
-    else TEMPLATE_DISPATCH_CASE(t, unsigned char, p, body)
+#define TEMPLATE_DISPATCH_I(t, p, ...)                                 \
+    TEMPLATE_DISPATCH_CASE(t, long long, p, __VA_ARGS__)               \
+    else TEMPLATE_DISPATCH_CASE(t, unsigned long long, p, __VA_ARGS__) \
+    else TEMPLATE_DISPATCH_CASE(t, long, p, __VA_ARGS__)               \
+    else TEMPLATE_DISPATCH_CASE(t, int, p, __VA_ARGS__)                \
+    else TEMPLATE_DISPATCH_CASE(t, unsigned int, p, __VA_ARGS__)       \
+    else TEMPLATE_DISPATCH_CASE(t, unsigned long, p, __VA_ARGS__)      \
+    else TEMPLATE_DISPATCH_CASE(t, short int, p, __VA_ARGS__)          \
+    else TEMPLATE_DISPATCH_CASE(t, short unsigned int, p, __VA_ARGS__) \
+    else TEMPLATE_DISPATCH_CASE(t, char, p, __VA_ARGS__)               \
+    else TEMPLATE_DISPATCH_CASE(t, unsigned char, p, __VA_ARGS__)
 
 /** A macro for accessing the typed contents of a teca_variant_array
  * @param t    container type
@@ -206,9 +222,9 @@ struct object_dispatch :
  *
  * See #TEMPLATE_DISPATCH_CASE for details.
  */
-#define TEMPLATE_DISPATCH(t, p, body)       \
-    TEMPLATE_DISPATCH_FP(t, p, body)        \
-    else TEMPLATE_DISPATCH_I(t, p, body)
+#define TEMPLATE_DISPATCH(t, p, ...)            \
+    TEMPLATE_DISPATCH_FP(t, p, __VA_ARGS__)     \
+    else TEMPLATE_DISPATCH_I(t, p, __VA_ARGS__)
 
 /** A macro for accessing the typed contents of a teca_variant_array
  * @param t    container type
@@ -217,9 +233,9 @@ struct object_dispatch :
  *
  * See #TEMPLATE_DISPATCH_CASE for details.
  */
-#define TEMPLATE_DISPATCH_OBJ(t, p, body)                               \
-    TEMPLATE_DISPATCH_CASE(t, std::string, p, body)                     \
-    else TEMPLATE_DISPATCH_CASE(t, teca_metadata, p, body)
+#define TEMPLATE_DISPATCH_OBJ(t, p, ...)                            \
+    TEMPLATE_DISPATCH_CASE(t, std::string, p, __VA_ARGS__)          \
+    else TEMPLATE_DISPATCH_CASE(t, teca_metadata, p, __VA_ARGS__)
 
 /** A macro for accessing the typed contents of a teca_variant_array
  * @param t    container type
@@ -228,9 +244,9 @@ struct object_dispatch :
  *
  * See #TEMPLATE_DISPATCH_CASE for details.
  */
-#define TEMPLATE_DISPATCH_PTR(t, p, body)                           \
-    TEMPLATE_DISPATCH_CASE(t, const_p_teca_variant_array, p, body)  \
-    else TEMPLATE_DISPATCH_CASE(t, p_teca_variant_array, p, body)
+#define TEMPLATE_DISPATCH_PTR(t, p, ...)                                    \
+    TEMPLATE_DISPATCH_CASE(t, const_p_teca_variant_array, p, __VA_ARGS__)   \
+    else TEMPLATE_DISPATCH_CASE(t, p_teca_variant_array, p, __VA_ARGS__)
 
 /** A macro for accessing the floating point typed contents of a teca_variant_array
  * @param t    container type
@@ -240,9 +256,9 @@ struct object_dispatch :
  *
  * See #NESTED_TEMPLATE_DISPATCH_CASE for details.
  */
-#define NESTED_TEMPLATE_DISPATCH_FP(t, p, i, body)              \
-    NESTED_TEMPLATE_DISPATCH_CASE(t, float, p, i, body)         \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, double, p, i, body)
+#define NESTED_TEMPLATE_DISPATCH_FP(t, p, i, ...)                       \
+    NESTED_TEMPLATE_DISPATCH_CASE(t, float, p, i, __VA_ARGS__)          \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, double, p, i, __VA_ARGS__)
 
 /** A macro for accessing the inetgral typed contents of a teca_variant_array
  * @param t    container type
@@ -252,17 +268,17 @@ struct object_dispatch :
  *
  * See #NESTED_TEMPLATE_DISPATCH_CASE for details.
  */
-#define NESTED_TEMPLATE_DISPATCH_I(t, p, i, body)                         \
-    NESTED_TEMPLATE_DISPATCH_CASE(t, long long, p, i, body)               \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned long long, p, i, body) \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, long, p, i, body)               \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, int, p, i, body)                \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned int, p, i, body)       \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned long, p, i, body)      \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, short int, p, i, body)          \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, short unsigned int, p, i, body) \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, char, p, i, body)               \
-    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned char, p, i, body)
+#define NESTED_TEMPLATE_DISPATCH_I(t, p, i, ...)                                 \
+    NESTED_TEMPLATE_DISPATCH_CASE(t, long long, p, i, __VA_ARGS__)               \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned long long, p, i, __VA_ARGS__) \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, long, p, i, __VA_ARGS__)               \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, int, p, i, __VA_ARGS__)                \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned int, p, i, __VA_ARGS__)       \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned long, p, i, __VA_ARGS__)      \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, short int, p, i, __VA_ARGS__)          \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, short unsigned int, p, i, __VA_ARGS__) \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, char, p, i, __VA_ARGS__)               \
+    else NESTED_TEMPLATE_DISPATCH_CASE(t, unsigned char, p, i, __VA_ARGS__)
 
 /** \def NESTED_TEMPLATE_DISPATCH(t, p, i, body)
  * A macro for accessing the typed contents of a teca_variant_array
@@ -273,9 +289,9 @@ struct object_dispatch :
  *
  * See #NESTED_TEMPLATE_DISPATCH_CASE for details.
  */
-#define NESTED_TEMPLATE_DISPATCH(t, p, i, body)     \
-    NESTED_TEMPLATE_DISPATCH_FP(t, p, i, body)      \
-    else NESTED_TEMPLATE_DISPATCH_I(t, p, i, body)
+#define NESTED_TEMPLATE_DISPATCH(t, p, i, ...)             \
+    NESTED_TEMPLATE_DISPATCH_FP(t, p, i, __VA_ARGS__)      \
+    else NESTED_TEMPLATE_DISPATCH_I(t, p, i, __VA_ARGS__)
 
 /// @cond
 // tag for contiguous arrays, and objects that have
@@ -315,6 +331,9 @@ template<typename T>
 class TECA_EXPORT teca_variant_array_impl : public teca_variant_array
 {
 public:
+    using element_type = T;
+    using pointer_type = std::shared_ptr<T>;
+
     /** @name Array constructors
      * Constructs a new instance containing the templated type.
      */
@@ -1223,9 +1242,9 @@ void teca_variant_array::get_dispatch(unsigned long i, T &val,
     typename std::enable_if<pod_dispatch<T>::value, T>::type*) const
 {
     // apply on POD types
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         this,
-        TT *ptthis = dynamic_cast<TT*>(this);
+        const TT *ptthis = dynamic_cast<const TT*>(this);
         ptthis->get(i, val);
         return;
         )
@@ -1264,9 +1283,9 @@ void teca_variant_array::get_dispatch(std::vector<T> &vals,
     typename std::enable_if<pod_dispatch<T>::value, T>::type*) const
 {
     // apply on POD types
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         this,
-        TT *ptthis = dynamic_cast<TT*>(this);
+        const TT *ptthis = dynamic_cast<const TT*>(this);
         ptthis->get(vals);
         return;
         )
@@ -1305,9 +1324,9 @@ void teca_variant_array::get_dispatch(size_t src_start, T *dest, size_t dest_sta
     typename std::enable_if<pod_dispatch<T>::value, T>::type*) const
 {
     // apply on POD types
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         this,
-        TT *ptthis = dynamic_cast<TT*>(this);
+        const TT *ptthis = dynamic_cast<const TT*>(this);
         ptthis->get(src_start, dest, dest_start, n_elem);
         return;
         )
@@ -2029,7 +2048,7 @@ void teca_variant_array_impl<T>::set_dispatch(size_t dest_start,
     const const_p_teca_variant_array &src, size_t src_start, size_t n_elem,
     typename std::enable_if<pod_dispatch<U>::value, U>::type*)
 {
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         src.get(),
         const_p_teca_variant_array_impl<NT> tp_src =
             std::static_pointer_cast<const teca_variant_array_impl<NT>>(src);
@@ -2072,9 +2091,9 @@ void teca_variant_array_impl<T>::assign_dispatch(
     const const_p_teca_variant_array &src, size_t src_start, size_t n_elem,
     typename std::enable_if<pod_dispatch<U>::value, U>::type*)
 {
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         src.get(),
-        std::shared_ptr<TT> tp_src = std::static_pointer_cast<TT>(src);
+        std::shared_ptr<const TT> tp_src = std::static_pointer_cast<const TT>(src);
         this->assign_dispatch(tp_src, src_start, n_elem);
         return;
         )
@@ -2113,9 +2132,9 @@ void teca_variant_array_impl<T>::append_dispatch(
     const const_p_teca_variant_array &src, size_t src_start, size_t n_elem,
     typename std::enable_if<pod_dispatch<U>::value, U>::type*)
 {
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         src.get(),
-        std::shared_ptr<TT> tp_src = std::static_pointer_cast<TT>(src);
+        std::shared_ptr<const TT> tp_src = std::static_pointer_cast<const TT>(src);
         this->append_dispatch(tp_src, src_start, n_elem);
         return;
         )

--- a/core/teca_variant_array_impl.h
+++ b/core/teca_variant_array_impl.h
@@ -792,10 +792,10 @@ public:
     T *data() { return m_data.data(); }
 
     /// returns true if the data is accessible from CUDA codes
-    int cuda_accessible() const { return m_data.cuda_accessible(); }
+    int cuda_accessible() const noexcept override { return m_data.cuda_accessible(); }
 
     /// returns true if the data is accessible from codes running on the CPU
-    int cpu_accessible() const { return m_data.cpu_accessible(); }
+    int cpu_accessible() const noexcept override { return m_data.cpu_accessible(); }
 
     /// Get the current size of the data
     unsigned long size() const noexcept override;

--- a/core/teca_variant_array_util.h
+++ b/core/teca_variant_array_util.h
@@ -1,6 +1,8 @@
 #ifndef teca_variant_array_util_h
 #define teca_variant_array_util_h
 
+/// @file
+
 #include <tuple>
 
 /// some functions helping us manipulate teca_variant_array

--- a/core/teca_variant_array_util.h
+++ b/core/teca_variant_array_util.h
@@ -1,0 +1,264 @@
+#ifndef teca_variant_array_util_h
+#define teca_variant_array_util_h
+
+#include <tuple>
+
+/// some functions helping us manipulate teca_variant_array
+namespace teca_variant_array_util
+{
+/** static_cast a number of p_teca_variant_array into their derived type
+ * teca_variant_array_impl<NT>*. Can be used with p_const_teca_variant_array as
+ * well.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a parameter pack
+ * @param args some number of p_teca_variant_array instances.
+ * @returns a std::tuple of teca_variant_array_impl<NT>* one for each of args
+ *          in the same order.
+ */
+template <typename TT, typename... PP>
+auto va_static_cast(PP &&... args)
+{
+    return std::make_tuple(static_cast<TT*>(args.get())...);
+}
+
+/** dynamic_cast a number of p_teca_variant_array into their derived type
+ * teca_variant_array_impl<NT>*. Can be used with p_const_teca_variant_array as
+ * well.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a parameter pack
+ * @param args some number of p_teca_variant_array instances.
+ * @returns a std::tuple of teca_variant_array_impl<NT>* one for each of args
+ *          in the same order.
+ */
+template <typename TT, typename... PP>
+auto va_dynamic_cast(PP &&... args)
+{
+    return std::make_tuple(dynamic_cast<TT*>(args.get())...);
+}
+
+/// terminates recursion
+template <typename TT>
+void assert_type() {}
+
+/** Check that a number of p_teca_variant_array are teca_variant_array_impl<NT>
+ * instances. This will terminate execution if the check fails. Unlike asssert
+ * this check is always applied.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a parameter pack
+ * @param va a p_teca_variant_array instance
+ * @param args some number of p_teca_variant_array instances.
+ */
+template <typename TT, typename... PP>
+void assert_type(const const_p_teca_variant_array &va, PP &&... args)
+{
+    if (!dynamic_cast<const TT*>(va.get()))
+    {
+        TECA_FATAL_ERROR("teca_variant_array instance is not a"
+            " teca_variant_array_impl<" << typeid(typename TT::element_type).name()
+            << sizeof(typename TT::element_type) << ">")
+    }
+
+    (assert_type<TT>(args), ...);
+}
+
+/// terminates recursion
+template <typename TT>
+auto get_cpu_accessible()
+{
+    return std::make_tuple();
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cpu_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... PP>
+auto get_cpu_accessible(const std::shared_ptr<const TT> &va, PP &&... args)
+{
+    auto tva = static_cast<const TT*>(va.get());
+    auto spva = tva->get_cpu_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cpu_accessible<TT>(args...));
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cpu_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a const_p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<const NT> and const NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... V>
+auto get_cpu_accessible(const std::shared_ptr<TT> &va, V &&... args)
+{
+    auto tva = static_cast<TT*>(va.get());
+    auto spva = tva->get_cpu_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cpu_accessible<TT>(args...));
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cpu_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... PP>
+auto get_cpu_accessible(const const_p_teca_variant_array &va, PP &&... args)
+{
+    auto tva = static_cast<const TT*>(va.get());
+    auto spva = tva->get_cpu_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cpu_accessible<TT>(args...));
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cpu_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a const_p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<const NT> and const NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... V>
+auto get_cpu_accessible(const p_teca_variant_array &va, V &&... args)
+{
+    auto tva = static_cast<TT*>(va.get());
+    auto spva = tva->get_cpu_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cpu_accessible<TT>(args...));
+}
+
+/// terminates recursion
+template <typename TT>
+auto get_cuda_accessible()
+{
+    return std::make_tuple();
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cuda_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... PP>
+auto get_cuda_accessible(const const_p_teca_variant_array &va, PP &&... args)
+{
+    auto tva = static_cast<const TT*>(va.get());
+    auto spva = tva->get_cuda_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cuda_accessible<TT>(args...));
+}
+
+/** Calls teca_varaint_array_impl<NT>::get_cuda_accessible on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param va a const_p_teca_variant_array instance
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of std::shared_ptr<const NT> and const NT* one for each
+ *          p_teca_variant_array passed in.
+ */
+template <typename TT, typename... V>
+auto get_cuda_accessible(const p_teca_variant_array &va, V &&... args)
+{
+    auto tva = static_cast<TT*>(va.get());
+    auto spva = tva->get_cuda_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spva, spva.get()), get_cuda_accessible<TT>(args...));
+}
+
+/** Calls teca_varaint_array_impl<NT>::data on a number of
+ * p_teca_variant_array instances. The instances are first static_cast to
+ * teca_variant_array_impl<NT>*. One should only use this method when one is
+ * certain that this static_cast is appropriate. See va_assert_type for one
+ * way to validate that the types are as expected.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @tparam PP a paramater pack
+ * @param args any number of p_teca_variant_array instances
+ * @returns a tuple of NT* one for each p_teca_variant_array passed in.
+ */
+template <typename TT, typename... V>
+auto data(V &&... args)
+{
+    return std::make_tuple(static_cast<TT*>(args.get())->data()...);
+}
+
+/** Allocates a teca_variant_array_impl<NT> instance and returns the newly
+ * allocated array and a pointer to it's memory.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @param n_elem the size of the array
+ * @param alloc the allocator to use
+ * @returns a tuple of p_teca_variant_array_impl<NT> and NT*
+ */
+template <typename TT>
+auto New(size_t n_elem,
+    teca_variant_array::allocator alloc = teca_variant_array::allocator::malloc)
+{
+    auto out = TT::New(n_elem, alloc);
+    return std::make_tuple(out, out->data());
+}
+
+/** Allocates a teca_variant_array_impl<NT> instance and returns the newly
+ * allocated array and a pointer to it's memory.
+ *
+ * @tparam TT teca_variant_array_impl<NT>
+ * @param n_elem the size of the array
+ * @param init_val a value to initialize the contents of the array to
+ * @param alloc the allocator to use
+ * @returns a tuple of p_teca_variant_array_impl<NT> and NT*
+ */
+template <typename TT, typename NT = typename TT::element_type>
+auto New(size_t n_elem, NT init_val,
+    teca_variant_array::allocator alloc = teca_variant_array::allocator::malloc)
+{
+    auto out = TT::New(n_elem, init_val, alloc);
+    return std::make_tuple(out, out->data());
+}
+
+}
+#endif

--- a/data/teca_calendar_util.cxx
+++ b/data/teca_calendar_util.cxx
@@ -181,8 +181,7 @@ int season_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // initialize the time range to iterate over
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        t.get(),
+    VARIANT_ARRAY_DISPATCH(t.get(),
         auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
@@ -422,8 +421,7 @@ int year_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // current time state
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        t.get(),
+    VARIANT_ARRAY_DISPATCH(t.get(),
         auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
@@ -545,8 +543,7 @@ int month_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // time point's to iterate between
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        t.get(),
+    VARIANT_ARRAY_DISPATCH(t.get(),
         auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
@@ -677,8 +674,7 @@ int day_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // current time state
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        t.get(),
+    VARIANT_ARRAY_DISPATCH(t.get(),
         auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);

--- a/data/teca_calendar_util.cxx
+++ b/data/teca_calendar_util.cxx
@@ -3,12 +3,16 @@
 #include "teca_common.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_coordinate_util.h"
 #include "teca_calcalcs.h"
 
 #include <algorithm>
 
 #include <string>
+
+using namespace teca_variant_array_util;
+
 
 // TODO - With 23:59:59, sometimes we select the next day.  What is the right
 // end-of-day time so that all use cases are satisfied without selecting the
@@ -179,12 +183,7 @@ int season_iterator::initialize(const const_p_teca_variant_array &t,
     // initialize the time range to iterate over
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
-
-        // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<const TT>(t);
-        auto pta =ta->get_cpu_accessible();
-        const NT *p_t = pta.get();
-
+        auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
         )
@@ -425,12 +424,7 @@ int year_iterator::initialize(const const_p_teca_variant_array &t,
     // current time state
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
-
-        // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<const TT>(t);
-        auto pta = ta->get_cpu_accessible();
-        const NT *p_t = pta.get();
-
+        auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
         )
@@ -553,12 +547,7 @@ int month_iterator::initialize(const const_p_teca_variant_array &t,
     // time point's to iterate between
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
-
-        // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<const TT>(t);
-        auto pta =ta->get_cpu_accessible();
-        const NT *p_t = pta.get();
-
+        auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
         )
@@ -690,12 +679,7 @@ int day_iterator::initialize(const const_p_teca_variant_array &t,
     // current time state
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
-
-        // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<const TT>(t);
-        auto pta =ta->get_cpu_accessible();
-        const NT *p_t = pta.get();
-
+        auto [sp_t, p_t] = get_cpu_accessible<CTT>(t);
         this->begin = time_point(first_step, p_t[first_step], this->units, this->calendar);
         this->end = time_point(last_step, p_t[last_step], this->units, this->calendar);
         )

--- a/data/teca_calendar_util.cxx
+++ b/data/teca_calendar_util.cxx
@@ -177,11 +177,11 @@ int season_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // initialize the time range to iterate over
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
 
         // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<TT>(t);
+        auto ta = std::static_pointer_cast<const TT>(t);
         auto pta =ta->get_cpu_accessible();
         const NT *p_t = pta.get();
 
@@ -423,11 +423,11 @@ int year_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // current time state
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
 
         // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<TT>(t);
+        auto ta = std::static_pointer_cast<const TT>(t);
         auto pta = ta->get_cpu_accessible();
         const NT *p_t = pta.get();
 
@@ -551,11 +551,11 @@ int month_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // time point's to iterate between
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
 
         // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<TT>(t);
+        auto ta = std::static_pointer_cast<const TT>(t);
         auto pta =ta->get_cpu_accessible();
         const NT *p_t = pta.get();
 
@@ -688,11 +688,11 @@ int day_iterator::initialize(const const_p_teca_variant_array &t,
     }
 
     // current time state
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         t.get(),
 
         // the calendaring code is CPU only
-        auto ta = std::static_pointer_cast<TT>(t);
+        auto ta = std::static_pointer_cast<const TT>(t);
         auto pta =ta->get_cpu_accessible();
         const NT *p_t = pta.get();
 

--- a/data/teca_coordinate_util.cxx
+++ b/data/teca_coordinate_util.cxx
@@ -44,8 +44,7 @@ bool equal(const const_p_teca_variant_array &array1,
     }
 
     // handle POD arrays
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        array1.get(),
+    VARIANT_ARRAY_DISPATCH(array1.get(),
 
         // we know the type of array 1 now, check the type of array 2
         if (!dynamic_cast<CTT*>(array2.get()))
@@ -106,8 +105,7 @@ bool equal(const const_p_teca_variant_array &array1,
         return true;
         )
     // handle arrays of strings
-    TEMPLATE_DISPATCH_CASE(
-        teca_variant_array_impl, std::string,
+    VARIANT_ARRAY_DISPATCH_CASE(std::string,
         array1.get(),
         // we know the type of array 1 now, check the type of array 2
         if (!dynamic_cast<CTT*>(array2.get()))
@@ -194,8 +192,7 @@ int time_step_of(const const_p_teca_variant_array &time,
 
     // locate the nearest time value in the time axis
     unsigned long last = time->size() - 1;
-    TEMPLATE_DISPATCH_FP_SI(teca_variant_array_impl,
-        time.get(),
+    VARIANT_ARRAY_DISPATCH_FP_SI(time.get(),
 
         auto [sp_time, p_time] = get_cpu_accessible<CTT>(time);
 
@@ -319,8 +316,7 @@ int bounds_to_extent(const double *bounds,
     const const_p_teca_variant_array &x, const const_p_teca_variant_array &y,
     const const_p_teca_variant_array &z, unsigned long *extent)
 {
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         assert_type<TT>(y,z);
 
@@ -404,9 +400,7 @@ int bounds_to_extent(const double *bounds,
 int bounds_to_extent(const double *bounds,
     const const_p_teca_variant_array &x, unsigned long *extent)
 {
-    TEMPLATE_DISPATCH_FP(
-        teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
         // in the following, for each side (low, high) of the bounds in
         // each cooridnate direction we are searching for the index that

--- a/data/teca_coordinate_util.cxx
+++ b/data/teca_coordinate_util.cxx
@@ -39,13 +39,13 @@ bool equal(const const_p_teca_variant_array &array1,
     }
 
     // handle POD arrays
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         array1.get(),
 
-        auto a1 = static_cast<TT*>(array1.get());
+        auto a1 = static_cast<const TT*>(array1.get());
 
         // we know the type of array 1 now, check the type of array 2
-        auto a2 = dynamic_cast<TT*>(array2.get());
+        auto a2 = dynamic_cast<const TT*>(array2.get());
         if (!a2)
         {
             oss << "The arrays have different types : "
@@ -108,12 +108,12 @@ bool equal(const const_p_teca_variant_array &array1,
         )
     // handle arrays of strings
     TEMPLATE_DISPATCH_CASE(
-        const teca_variant_array_impl, std::string,
+        teca_variant_array_impl, std::string,
         array1.get(),
         if (dynamic_cast<const TT*>(array2.get()))
         {
-            auto a1 = static_cast<TT*>(array1.get())->get_cpu_accessible();
-            auto a2 = static_cast<TT*>(array2.get())->get_cpu_accessible();
+            auto a1 = static_cast<const TT*>(array1.get())->get_cpu_accessible();
+            auto a2 = static_cast<const TT*>(array2.get())->get_cpu_accessible();
 
             auto pa1 = a1.get();
             auto pa2 = a2.get();
@@ -188,10 +188,10 @@ int time_step_of(const const_p_teca_variant_array &time,
 
     // locate the nearest time value in the time axis
     unsigned long last = time->size() - 1;
-    TEMPLATE_DISPATCH_FP_SI(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP_SI(teca_variant_array_impl,
         time.get(),
 
-        auto ta = std::static_pointer_cast<TT>(time);
+        auto ta = std::static_pointer_cast<const TT>(time);
         auto pta = ta->get_cpu_accessible();
         auto p_time = pta.get();
 
@@ -316,7 +316,7 @@ int bounds_to_extent(const double *bounds,
     const const_p_teca_variant_array &z, unsigned long *extent)
 {
     TEMPLATE_DISPATCH_FP(
-        const teca_variant_array_impl,
+        teca_variant_array_impl,
         x.get(),
 
         // in the following, for each side (low, high) of the bounds in
@@ -336,7 +336,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_i = nx - 1;
         extent[0] = 0;
         extent[1] = high_i;
-        auto xa = std::static_pointer_cast<TT>(x);
+        auto xa = std::static_pointer_cast<const TT>(x);
         auto pxa = xa->get_cpu_accessible();
         const NT *px = pxa.get();
         NT low_x = static_cast<NT>(bounds[0]);
@@ -347,7 +347,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_j = ny - 1;
         extent[2] = 0;
         extent[3] = high_j;
-        auto ya = std::dynamic_pointer_cast<TT>(y);
+        auto ya = std::dynamic_pointer_cast<const TT>(y);
         auto pya = ya->get_cpu_accessible();
         const NT *py = pya.get();
         NT low_y = static_cast<NT>(bounds[2]);
@@ -358,7 +358,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_k = nz - 1;
         extent[4] = 0;
         extent[5] = high_k;
-        auto za = std::dynamic_pointer_cast<TT>(z);
+        auto za = std::dynamic_pointer_cast<const TT>(z);
         auto pza = za->get_cpu_accessible();
         const NT *pz = pza.get();
         NT low_z = static_cast<NT>(bounds[4]);
@@ -406,7 +406,7 @@ int bounds_to_extent(const double *bounds,
     const const_p_teca_variant_array &x, unsigned long *extent)
 {
     TEMPLATE_DISPATCH_FP(
-        const teca_variant_array_impl,
+        teca_variant_array_impl,
         x.get(),
 
         // in the following, for each side (low, high) of the bounds in
@@ -426,7 +426,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_i = nx - 1;
         extent[0] = 0;
         extent[1] = high_i;
-        auto xa = std::static_pointer_cast<TT>(x);
+        auto xa = std::static_pointer_cast<const TT>(x);
         auto pxa = xa->get_cpu_accessible();
         const NT *px = pxa.get();
         NT low_x = static_cast<NT>(bounds[0]);

--- a/data/teca_coordinate_util.cxx
+++ b/data/teca_coordinate_util.cxx
@@ -1,6 +1,8 @@
 #include "teca_coordinate_util.h"
 
 #include "teca_common.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #if defined(TECA_HAS_UDUNITS)
 #include "teca_calcalcs.h"
 #endif
@@ -10,6 +12,9 @@
 #include <ctime>
 #include <sstream>
 #include <iomanip>
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 namespace teca_coordinate_util
 {
@@ -42,11 +47,8 @@ bool equal(const const_p_teca_variant_array &array1,
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         array1.get(),
 
-        auto a1 = static_cast<const TT*>(array1.get());
-
         // we know the type of array 1 now, check the type of array 2
-        auto a2 = dynamic_cast<const TT*>(array2.get());
-        if (!a2)
+        if (!dynamic_cast<CTT*>(array2.get()))
         {
             oss << "The arrays have different types : "
                 << array1->get_class_name() << " and "
@@ -59,11 +61,8 @@ bool equal(const const_p_teca_variant_array &array1,
         }
 
         // compare elements
-        auto a1a = a1->get_cpu_accessible();
-        auto a2a = a2->get_cpu_accessible();
-
-        auto pa1 = a1a.get();
-        auto pa2 = a2a.get();
+        auto [spa1, pa1] = get_cpu_accessible<CTT>(array1);
+        auto [spa2, pa2] = get_cpu_accessible<CTT>(array2);
 
         std::string diagnostic;
         for (size_t i = 0; i < n_elem; ++i)
@@ -110,37 +109,44 @@ bool equal(const const_p_teca_variant_array &array1,
     TEMPLATE_DISPATCH_CASE(
         teca_variant_array_impl, std::string,
         array1.get(),
-        if (dynamic_cast<const TT*>(array2.get()))
+        // we know the type of array 1 now, check the type of array 2
+        if (!dynamic_cast<CTT*>(array2.get()))
         {
-            auto a1 = static_cast<const TT*>(array1.get())->get_cpu_accessible();
-            auto a2 = static_cast<const TT*>(array2.get())->get_cpu_accessible();
+            oss << "The arrays have different types : "
+                << array1->get_class_name() << " and "
+                << array2->get_class_name();
 
-            auto pa1 = a1.get();
-            auto pa2 = a2.get();
+            errorStr = oss.str();
+            errorNo = equal_error::type_missmatch;
 
-            for (size_t i = 0; i < n_elem; ++i)
-            {
-                // compare elements
-                const std::string &v1 = pa1[i];
-                const std::string &v2 = pa2[i];
-                if (v1 != v2)
-                {
-                    oss << "string element " << i << " not equal. ref value \""
-                        << v1 << "\" is not equal to test value \"" << v2 << "\"";
-
-                    errorStr = oss.str();
-                    errorNo = equal_error::value_missmatch;
-
-                    return false;
-                }
-            }
-
-            // we are here, arrays are the same
-            errorStr = "The arrays are equal";
-            errorNo = equal_error::no_error;
-
-            return true;
+            return false;
         }
+
+        auto [spa1, pa1] = get_cpu_accessible<CTT>(array1);
+        auto [spa2, pa2] = get_cpu_accessible<CTT>(array2);
+
+        for (size_t i = 0; i < n_elem; ++i)
+        {
+            // compare elements
+            const std::string &v1 = pa1[i];
+            const std::string &v2 = pa2[i];
+            if (v1 != v2)
+            {
+                oss << "string element " << i << " not equal. ref value \""
+                    << v1 << "\" is not equal to test value \"" << v2 << "\"";
+
+                errorStr = oss.str();
+                errorNo = equal_error::value_missmatch;
+
+                return false;
+            }
+        }
+
+        // we are here, arrays are the same
+        errorStr = "The arrays are equal";
+        errorNo = equal_error::no_error;
+
+        return true;
         )
 
     // we are here, array type is not handled
@@ -191,9 +197,7 @@ int time_step_of(const const_p_teca_variant_array &time,
     TEMPLATE_DISPATCH_FP_SI(teca_variant_array_impl,
         time.get(),
 
-        auto ta = std::static_pointer_cast<const TT>(time);
-        auto pta = ta->get_cpu_accessible();
-        auto p_time = pta.get();
+        auto [sp_time, p_time] = get_cpu_accessible<CTT>(time);
 
         if (clamp && (t <= p_time[0]))
         {
@@ -315,9 +319,10 @@ int bounds_to_extent(const double *bounds,
     const const_p_teca_variant_array &x, const const_p_teca_variant_array &y,
     const const_p_teca_variant_array &z, unsigned long *extent)
 {
-    TEMPLATE_DISPATCH_FP(
-        teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         x.get(),
+
+        assert_type<TT>(y,z);
 
         // in the following, for each side (low, high) of the bounds in
         // each cooridnate direction we are searching for the index that
@@ -336,9 +341,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_i = nx - 1;
         extent[0] = 0;
         extent[1] = high_i;
-        auto xa = std::static_pointer_cast<const TT>(x);
-        auto pxa = xa->get_cpu_accessible();
-        const NT *px = pxa.get();
+        auto [spx, px] = get_cpu_accessible<CTT>(x);
         NT low_x = static_cast<NT>(bounds[0]);
         NT high_x = static_cast<NT>(bounds[1]);
         bool slice_x = equal(low_x, high_x, eps8);
@@ -347,9 +350,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_j = ny - 1;
         extent[2] = 0;
         extent[3] = high_j;
-        auto ya = std::dynamic_pointer_cast<const TT>(y);
-        auto pya = ya->get_cpu_accessible();
-        const NT *py = pya.get();
+        auto [spy, py] = get_cpu_accessible<CTT>(y);
         NT low_y = static_cast<NT>(bounds[2]);
         NT high_y = static_cast<NT>(bounds[3]);
         bool slice_y = equal(low_y, high_y, eps8);
@@ -358,9 +359,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_k = nz - 1;
         extent[4] = 0;
         extent[5] = high_k;
-        auto za = std::dynamic_pointer_cast<const TT>(z);
-        auto pza = za->get_cpu_accessible();
-        const NT *pz = pza.get();
+        auto [spz, pz] = get_cpu_accessible<CTT>(z);
         NT low_z = static_cast<NT>(bounds[4]);
         NT high_z = static_cast<NT>(bounds[5]);
         bool slice_z = equal(low_z, high_z, eps8);
@@ -426,9 +425,7 @@ int bounds_to_extent(const double *bounds,
         unsigned long high_i = nx - 1;
         extent[0] = 0;
         extent[1] = high_i;
-        auto xa = std::static_pointer_cast<const TT>(x);
-        auto pxa = xa->get_cpu_accessible();
-        const NT *px = pxa.get();
+        auto [spx, px] = get_cpu_accessible<CTT>(x);
         NT low_x = static_cast<NT>(bounds[0]);
         NT high_x = static_cast<NT>(bounds[1]);
         bool slice_x = equal(low_x, high_x, eps8);

--- a/data/teca_coordinate_util.h
+++ b/data/teca_coordinate_util.h
@@ -418,12 +418,12 @@ int index_of(const const_p_teca_cartesian_mesh &mesh, T x, T y, T z,
     const_p_teca_variant_array zc = mesh->get_z_coordinates();
 
     TEMPLATE_DISPATCH_FP(
-        const teca_variant_array_impl,
+        teca_variant_array_impl,
         xc.get(),
 
-        auto p_xc = std::dynamic_pointer_cast<TT>(xc)->get_cpu_accessible();
-        auto p_yc = std::dynamic_pointer_cast<TT>(yc)->get_cpu_accessible();
-        auto p_zc = std::dynamic_pointer_cast<TT>(zc)->get_cpu_accessible();
+        auto p_xc = std::dynamic_pointer_cast<const TT>(xc)->get_cpu_accessible();
+        auto p_yc = std::dynamic_pointer_cast<const TT>(yc)->get_cpu_accessible();
+        auto p_zc = std::dynamic_pointer_cast<const TT>(zc)->get_cpu_accessible();
 
         unsigned long nx = xc->size();
         unsigned long ny = yc->size();

--- a/data/teca_coordinate_util.h
+++ b/data/teca_coordinate_util.h
@@ -7,6 +7,7 @@
 #include "teca_cartesian_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 
@@ -17,6 +18,9 @@
 #include <iomanip>
 #include <deque>
 #include <vector>
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 #if defined(TECA_HAS_CUDA)
 #define TECA_TARGET __host__ __device__
@@ -417,21 +421,22 @@ int index_of(const const_p_teca_cartesian_mesh &mesh, T x, T y, T z,
     const_p_teca_variant_array yc = mesh->get_y_coordinates();
     const_p_teca_variant_array zc = mesh->get_z_coordinates();
 
-    TEMPLATE_DISPATCH_FP(
-        teca_variant_array_impl,
+    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
         xc.get(),
 
-        auto p_xc = std::dynamic_pointer_cast<const TT>(xc)->get_cpu_accessible();
-        auto p_yc = std::dynamic_pointer_cast<const TT>(yc)->get_cpu_accessible();
-        auto p_zc = std::dynamic_pointer_cast<const TT>(zc)->get_cpu_accessible();
+        assert_type<TT>(yc, zc);
+
+        auto [sp_xc, p_xc,
+              sp_yc, p_yc,
+              sp_zc, p_zc] = get_cpu_accessible<CTT>(xc, yc, zc);
 
         unsigned long nx = xc->size();
         unsigned long ny = yc->size();
         unsigned long nz = zc->size();
 
-        if (teca_coordinate_util::index_of(p_xc.get(), 0, nx-1, x, true, i)
-            || teca_coordinate_util::index_of(p_yc.get(), 0, ny-1, y, true, j)
-            || teca_coordinate_util::index_of(p_zc.get(), 0, nz-1, z, true, k))
+        if (teca_coordinate_util::index_of(p_xc, 0, nx-1, x, true, i)
+            || teca_coordinate_util::index_of(p_yc, 0, ny-1, y, true, j)
+            || teca_coordinate_util::index_of(p_zc, 0, nz-1, z, true, k))
         {
             // out of bounds
             return -1;

--- a/data/teca_coordinate_util.h
+++ b/data/teca_coordinate_util.h
@@ -421,8 +421,7 @@ int index_of(const const_p_teca_cartesian_mesh &mesh, T x, T y, T z,
     const_p_teca_variant_array yc = mesh->get_y_coordinates();
     const_p_teca_variant_array zc = mesh->get_z_coordinates();
 
-    TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-        xc.get(),
+    VARIANT_ARRAY_DISPATCH_FP(xc.get(),
 
         assert_type<TT>(yc, zc);
 

--- a/data/teca_table.cxx
+++ b/data/teca_table.cxx
@@ -180,14 +180,14 @@ int teca_table::to_stream(std::ostream &s) const
     {
         if (n_cols)
         {
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
+            VARIANT_ARRAY_DISPATCH(
                 m_impl->columns->get(0).get(),
                 TT *a = dynamic_cast<TT*>(m_impl->columns->get(0).get());
                 NT v = NT();
                 a->get(j, v);
                 s << v;
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+            else VARIANT_ARRAY_DISPATCH_CASE(
                 std::string,
                 m_impl->columns->get(0).get(),
                 TT *a = dynamic_cast<TT*>(m_impl->columns->get(0).get());
@@ -197,14 +197,14 @@ int teca_table::to_stream(std::ostream &s) const
                 )
             for (unsigned int i = 1; i < n_cols; ++i)
             {
-                TEMPLATE_DISPATCH(teca_variant_array_impl,
+                VARIANT_ARRAY_DISPATCH(
                     m_impl->columns->get(i).get(),
                     TT *a = dynamic_cast<TT*>(m_impl->columns->get(i).get());
                     NT v = NT();
                     a->get(j, v);
                     s << ", " << v;
                     )
-                else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+                else VARIANT_ARRAY_DISPATCH_CASE(
                     std::string,
                     m_impl->columns->get(i).get(),
                     TT *a = dynamic_cast<TT*>(m_impl->columns->get(i).get());
@@ -357,7 +357,7 @@ int teca_table::from_stream(std::istream &s)
     {
         // deserialize the column
         p_teca_variant_array col = cols[j];
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
+        VARIANT_ARRAY_DISPATCH(
             col.get(),
             auto [p_col] = teca_variant_array_util::data<TT>(col);
             const char *fmt = teca_string_util::scanf_tt<NT>::format();
@@ -375,7 +375,7 @@ int teca_table::from_stream(std::istream &s)
 
             }
             )
-        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+        else VARIANT_ARRAY_DISPATCH_CASE(
             std::string, col.get(),
             auto [p_col] = teca_variant_array_util::data<TT>(col);
             for (size_t i = 0; i < n_rows; ++i)

--- a/data/teca_table.cxx
+++ b/data/teca_table.cxx
@@ -1,10 +1,14 @@
 #include "teca_table.h"
 
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_binary_stream.h"
 #include "teca_dataset_util.h"
 #include "teca_string_util.h"
 #include "teca_bad_cast.h"
+
+using namespace teca_variant_array_util;
+
 
 teca_table::impl_t::impl_t() :
     columns(teca_array_collection::New()), active_column(0)
@@ -355,9 +359,7 @@ int teca_table::from_stream(std::istream &s)
         p_teca_variant_array col = cols[j];
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             col.get(),
-            auto ca = std::static_pointer_cast<TT>(col);
-            auto pca = ca->get_cpu_accessible();
-            NT *p_col = pca.get();
+            auto [p_col] = teca_variant_array_util::data<TT>(col);
             const char *fmt = teca_string_util::scanf_tt<NT>::format();
             for (size_t i = 0; i < n_rows; ++i)
             {
@@ -375,9 +377,7 @@ int teca_table::from_stream(std::istream &s)
             )
         else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
             std::string, col.get(),
-            auto ca = std::static_pointer_cast<TT>(col);
-            auto pca = ca->get_cpu_accessible();
-            NT *p_col = pca.get();
+            auto [p_col] = teca_variant_array_util::data<TT>(col);
             for (size_t i = 0; i < n_rows; ++i)
             {
                 const char *cell = data[i*n_cols + j];

--- a/doc/rtd/Doxyfile
+++ b/doc/rtd/Doxyfile
@@ -897,8 +897,10 @@ RECURSIVE              = YES
 #
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
+# varaitn_array_operator crashes Doxygen versions older than 1.9.1
 
 EXCLUDE                = ../../alg/teca_deeplab_ar_detect_internals.py \
+                         ../../alg/teca_variant_array_operator.h \
                          parse_xml.py
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or

--- a/io/teca_array_collection_reader.cxx
+++ b/io/teca_array_collection_reader.cxx
@@ -454,8 +454,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                 if (!this->t_units.empty() || (units_i == base_units))
                 {
                     // the files are in the same units copy the data
-                    TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        t_axis.get(),
+                    VARIANT_ARRAY_DISPATCH(t_axis.get(),
 
                         auto [p_t] = data<TT>(t_axis);
                         auto [p_ti] = data<CTT>(t_i);
@@ -480,8 +479,7 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                         << units_i << "\" differs from base units \"" << base_units
                         << "\" a conversion will be made.")
 
-                    TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        t_axis.get(),
+                    VARIANT_ARRAY_DISPATCH(t_axis.get(),
 
                         auto [p_t] = data<TT>(t_axis);
                         auto [p_ti] = data<CTT>(t_i);
@@ -825,8 +823,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
     if (!request.get("time", t))
     {
         // translate time to a time step
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            in_t.get(),
+        VARIANT_ARRAY_DISPATCH_FP(in_t.get(),
             auto [pin_t] = data<CTT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))

--- a/io/teca_array_collection_reader.cxx
+++ b/io/teca_array_collection_reader.cxx
@@ -16,6 +16,7 @@
 #include "teca_calcalcs.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <netcdf.h>
 #include <iostream>
@@ -42,6 +43,8 @@
 #if defined(TECA_HAS_MPI)
 #include <mpi.h>
 #endif
+
+using namespace teca_variant_array_util;
 
 // PIMPL idiom
 struct teca_array_collection_reader::teca_array_collection_reader_internals
@@ -454,11 +457,9 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                     TEMPLATE_DISPATCH(teca_variant_array_impl,
                         t_axis.get(),
 
-                        auto sp_ti = static_cast<const TT*>(t_i.get())->get_cpu_accessible();
-                        const NT *p_ti = sp_ti.get();
+                        auto [p_t] = data<TT>(t_axis);
+                        auto [p_ti] = data<CTT>(t_i);
 
-                        auto sp_t = static_cast<TT*>(t_axis.get())->get_cpu_accessible();
-                        NT *p_t = sp_t.get();
                         p_t += n_t;
 
                         memcpy(p_t, p_ti, sizeof(NT)*n_ti);
@@ -482,11 +483,9 @@ teca_metadata teca_array_collection_reader::get_output_metadata(unsigned int por
                     TEMPLATE_DISPATCH(teca_variant_array_impl,
                         t_axis.get(),
 
-                        auto sp_ti = static_cast<TT*>(elem_i.first.get())->get_cpu_accessible();
-                        NT *p_ti = sp_ti.get();
+                        auto [p_t] = data<TT>(t_axis);
+                        auto [p_ti] = data<CTT>(t_i);
 
-                        auto sp_t = static_cast<TT*>(t_axis.get())->get_cpu_accessible();
-                        NT *p_t = sp_t.get();
                         p_t += n_t;
 
                         for (size_t j = 0; j < n_ti; ++j)
@@ -811,6 +810,9 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
         return nullptr;
     }
 
+    // assume the data is on the CPU
+    assert(in_t->cpu_accessible());
+
     // get names, need to be careful since some of these depend
     // on run time information. eg: user can specify a time axis
     // via algorithm properties
@@ -825,10 +827,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
         // translate time to a time step
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             in_t.get(),
-
-            auto spin_t = dynamic_cast<TT*>(in_t.get())->get_cpu_accessible();
-            NT *pin_t = spin_t.get();
-
+            auto [pin_t] = data<CTT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))
             {
@@ -999,9 +998,7 @@ const_p_teca_dataset teca_array_collection_reader::execute(unsigned int port,
         // read the array
         p_teca_variant_array array;
         NC_DISPATCH(type,
-            p_teca_variant_array_impl<NC_T> a = teca_variant_array_impl<NC_T>::New(n_vals);
-            auto spa = a->get_cpu_accessible();
-            NC_T *pa = spa.get();
+            auto [a, pa] = ::New<NC_TT>(n_vals);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());

--- a/io/teca_cartesian_mesh_writer.cxx
+++ b/io/teca_cartesian_mesh_writer.cxx
@@ -87,10 +87,10 @@ void write_vtk_array_data(FILE *ofile,
     if (a)
     {
         size_t na = a->size();
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             a.get(),
 
-            auto spa = static_cast<TT*>(a.get())->get_cpu_accessible();
+            auto spa = static_cast<const TT*>(a.get())->get_cpu_accessible();
             const NT *pa = spa.get();
 
             if (binary)
@@ -157,7 +157,7 @@ int write_vtk_legacy_rectilinear_header(FILE *ofile,
     size_t nz = (z ? z->size() : 1);
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -223,7 +223,7 @@ int write_vtk_legacy_arakawa_c_grid_header(FILE *ofile,
     }
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -315,7 +315,7 @@ int write_vtk_legacy_curvilinear_header(FILE *ofile,
     }
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -401,7 +401,7 @@ int write_vtk_legacy_attribute(FILE *ofile, unsigned long n_vals,
         else
             fprintf(ofile, "%s 1 %zu ", array_name.c_str(), n_elem);
 
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             array.get(), fprintf(ofile, "%s\n",
             teca_vtk_util::vtk_tt<NT>::str());
             )

--- a/io/teca_cartesian_mesh_writer.cxx
+++ b/io/teca_cartesian_mesh_writer.cxx
@@ -89,8 +89,7 @@ void write_vtk_array_data(FILE *ofile,
     if (a)
     {
         size_t na = a->size();
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            a.get(),
+        VARIANT_ARRAY_DISPATCH(a.get(),
             auto [spa, pa] = get_cpu_accessible<CTT>(a);
             if (binary)
             {
@@ -156,7 +155,7 @@ int write_vtk_legacy_rectilinear_header(FILE *ofile,
     size_t nz = (z ? z->size() : 1);
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
+    VARIANT_ARRAY_DISPATCH(
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -222,7 +221,7 @@ int write_vtk_legacy_arakawa_c_grid_header(FILE *ofile,
     }
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
+    VARIANT_ARRAY_DISPATCH(
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -236,8 +235,7 @@ int write_vtk_legacy_arakawa_c_grid_header(FILE *ofile,
 
     // convert the WRF coordinate arrays into VTK layout
     p_teca_variant_array xyz = x->new_instance(3*nxyz);
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH(x.get(),
 
         assert_type<CTT>(y, z);
         auto [pxyz] = data<TT>(xyz);
@@ -306,7 +304,7 @@ int write_vtk_legacy_curvilinear_header(FILE *ofile,
     }
 
     const char *coord_type_str = nullptr;
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
+    VARIANT_ARRAY_DISPATCH(
         (x ? x.get() : (y ? y.get() : (z ? z.get() : nullptr))),
         coord_type_str = teca_vtk_util::vtk_tt<NT>::str();
         )
@@ -321,8 +319,7 @@ int write_vtk_legacy_curvilinear_header(FILE *ofile,
     // convert the WRF arrays into VTK layout
     p_teca_variant_array xyz = x->new_instance(3*nxyz);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x.get(),
+    VARIANT_ARRAY_DISPATCH(x.get(),
 
         assert_type<CTT>(y, z);
 
@@ -386,9 +383,8 @@ int write_vtk_legacy_attribute(FILE *ofile, unsigned long n_vals,
         else
             fprintf(ofile, "%s 1 %zu ", array_name.c_str(), n_elem);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            array.get(), fprintf(ofile, "%s\n",
-            teca_vtk_util::vtk_tt<NT>::str());
+        VARIANT_ARRAY_DISPATCH(array.get(),
+            fprintf(ofile, "%s\n", teca_vtk_util::vtk_tt<NT>::str());
             )
         else
         {

--- a/io/teca_cartesian_mesh_writer.cxx
+++ b/io/teca_cartesian_mesh_writer.cxx
@@ -7,10 +7,10 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_file_util.h"
 #include "teca_vtk_util.h"
 #include "teca_metadata_util.h"
-
 
 #if defined(TECA_HAS_VTK) || defined(TECA_HAS_PARAVIEW)
 #include "vtkRectilinearGrid.h"
@@ -29,6 +29,8 @@
 #if defined(TECA_HAS_MPI)
 #include <mpi.h>
 #endif
+
+using namespace teca_variant_array_util;
 
 namespace internals {
 
@@ -89,10 +91,7 @@ void write_vtk_array_data(FILE *ofile,
         size_t na = a->size();
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             a.get(),
-
-            auto spa = static_cast<const TT*>(a.get())->get_cpu_accessible();
-            const NT *pa = spa.get();
-
+            auto [spa, pa] = get_cpu_accessible<CTT>(a);
             if (binary)
             {
                 // because VTK's legacy file fomrat  requires big endian storage
@@ -238,19 +237,11 @@ int write_vtk_legacy_arakawa_c_grid_header(FILE *ofile,
     // convert the WRF coordinate arrays into VTK layout
     p_teca_variant_array xyz = x->new_instance(3*nxyz);
     TEMPLATE_DISPATCH(teca_variant_array_impl,
-        xyz.get(),
+        x.get(),
 
-        auto spx = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-        const NT *px = spx.get();
-
-        auto spy = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-        const NT *py = spy.get();
-
-        auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-        const NT *pz = spz.get();
-
-        auto spxyz = dynamic_cast<TT*>(xyz.get())->get_cpu_accessible();
-        NT *pxyz = spxyz.get();
+        assert_type<CTT>(y, z);
+        auto [pxyz] = data<TT>(xyz);
+        auto [spx, px, spy, py, spz, pz] = get_cpu_accessible<CTT>(x, y, z);
 
         for (size_t k = 0; k < nz; ++k)
         {
@@ -331,23 +322,17 @@ int write_vtk_legacy_curvilinear_header(FILE *ofile,
     p_teca_variant_array xyz = x->new_instance(3*nxyz);
 
     TEMPLATE_DISPATCH(teca_variant_array_impl,
-        xyz.get(),
+        x.get(),
 
-        auto spx = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-        const NT *px = spx.get();
+        assert_type<CTT>(y, z);
 
-        auto spy = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-        const NT *py = spy.get();
+        auto [pxyz] = data<TT>(xyz);
+        auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
 
+        CSP spz;
         const NT *pz = nullptr;
         if (z)
-        {
-            auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            pz = spz.get();
-        }
-
-        auto spxyz = dynamic_cast<TT*>(xyz.get())->get_cpu_accessible();
-        NT *pxyz = spxyz.get();
+            std::tie(spz, pz) = get_cpu_accessible<CTT>(z);
 
         for (size_t i = 0; i < nxyz; ++i)
             pxyz[3*i] = px[i];

--- a/io/teca_cf_layout_manager.cxx
+++ b/io/teca_cf_layout_manager.cxx
@@ -320,8 +320,7 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         // define variable for the axis
         int var_id = -1;
         unsigned int var_type_code = 0;
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            coord_arrays[i].get(),
+        VARIANT_ARRAY_DISPATCH(coord_arrays[i].get(),
             var_type_code = teca_variant_array_code<NT>::get();
             int var_nc_type = teca_netcdf_util::netcdf_tt<NT>::type_code;
 #if !defined(HDF5_THREAD_SAFE)
@@ -603,8 +602,7 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         size_t count = rank == 0 ? (this->dims[i] == NC_UNLIMITED ?
             unlimited_dim_actual_size : this->dims[i]) : 0;
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            coord_arrays[i].get(),
+        VARIANT_ARRAY_DISPATCH(coord_arrays[i].get(),
 
             auto [spa, pa] = get_cpu_accessible<CTT>(coord_arrays[i]);
 
@@ -689,8 +687,7 @@ int teca_cf_layout_manager::write(long index,
                 }
             }
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                array.get(),
+            VARIANT_ARRAY_DISPATCH(array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
                 if (actual_type_code != declared_type_code)
@@ -750,8 +747,7 @@ int teca_cf_layout_manager::write(long index,
 
             size_t counts[2] = {1, array->size()};
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                array.get(),
+            VARIANT_ARRAY_DISPATCH(array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
                 if (actual_type_code != declared_type_code)
@@ -863,8 +859,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                 }
             }
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                array.get(),
+            VARIANT_ARRAY_DISPATCH(array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
                 if (actual_type_code != declared_type_code)
@@ -928,8 +923,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
             int var_id = it->second.var_id;
             unsigned int declared_type_code = it->second.type_code;
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                array.get(),
+            VARIANT_ARRAY_DISPATCH(array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
                 if (actual_type_code != declared_type_code)

--- a/io/teca_cf_layout_manager.cxx
+++ b/io/teca_cf_layout_manager.cxx
@@ -7,6 +7,7 @@
 #include "teca_array_attributes.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <iostream>
 #include <sstream>
@@ -14,7 +15,9 @@
 #include <cerrno>
 #include <string>
 
-// --------------------------------------------------------------------------
+using namespace teca_variant_array_util;
+
+// -------------------------------------/-------------------------------------
 int teca_cf_layout_manager::create(const std::string &file_name,
     const std::string &date_format, const teca_metadata &md_in,
     int mode_flags, int use_unlimited_dim)
@@ -603,8 +606,8 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             coord_arrays[i].get(),
 
-            auto spa = static_cast<const TT*>(coord_arrays[i].get())->get_cpu_accessible();
-            const NT *pa = spa.get();
+            auto [spa, pa] = get_cpu_accessible<CTT>(coord_arrays[i]);
+
             pa += starts[i];
 
 #if !defined(HDF5_THREAD_SAFE)
@@ -699,8 +702,7 @@ int teca_cf_layout_manager::write(long index,
                     return -1;
                 }
 
-                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
-                const NT *pa = spa.get();
+                auto [spa, pa] = get_cpu_accessible<CTT>(array);
 
 #if !defined(HDF5_THREAD_SAFE)
                 {
@@ -761,8 +763,7 @@ int teca_cf_layout_manager::write(long index,
                     return -1;
                 }
 
-                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
-                const NT *pa = spa.get();
+                auto [spa, pa] = get_cpu_accessible<CTT>(array);
 
 #if !defined(HDF5_THREAD_SAFE)
                 {
@@ -875,8 +876,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                     return -1;
                 }
 
-                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
-                const NT *pa = spa.get();
+                auto [spa, pa] = get_cpu_accessible<CTT>(array);
 
                 // advance the pointer to the first time step that will be
                 // written by this manager
@@ -941,8 +941,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                     return -1;
                 }
 
-                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
-                const NT *pa = spa.get();
+                auto [spa, pa] = get_cpu_accessible<CTT>(array);
 
                 // advance the pointer to the first time step that will be
                 // written by this manager

--- a/io/teca_cf_layout_manager.cxx
+++ b/io/teca_cf_layout_manager.cxx
@@ -317,7 +317,7 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         // define variable for the axis
         int var_id = -1;
         unsigned int var_type_code = 0;
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             coord_arrays[i].get(),
             var_type_code = teca_variant_array_code<NT>::get();
             int var_nc_type = teca_netcdf_util::netcdf_tt<NT>::type_code;
@@ -600,10 +600,10 @@ int teca_cf_layout_manager::define(const teca_metadata &md_in,
         size_t count = rank == 0 ? (this->dims[i] == NC_UNLIMITED ?
             unlimited_dim_actual_size : this->dims[i]) : 0;
 
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             coord_arrays[i].get(),
 
-            auto spa = static_cast<TT*>(coord_arrays[i].get())->get_cpu_accessible();
+            auto spa = static_cast<const TT*>(coord_arrays[i].get())->get_cpu_accessible();
             const NT *pa = spa.get();
             pa += starts[i];
 
@@ -686,7 +686,7 @@ int teca_cf_layout_manager::write(long index,
                 }
             }
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
@@ -699,7 +699,7 @@ int teca_cf_layout_manager::write(long index,
                     return -1;
                 }
 
-                auto spa = static_cast<TT*>(array.get())->get_cpu_accessible();
+                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
                 const NT *pa = spa.get();
 
 #if !defined(HDF5_THREAD_SAFE)
@@ -748,7 +748,7 @@ int teca_cf_layout_manager::write(long index,
 
             size_t counts[2] = {1, array->size()};
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
@@ -761,7 +761,7 @@ int teca_cf_layout_manager::write(long index,
                     return -1;
                 }
 
-                auto spa = static_cast<TT*>(array.get())->get_cpu_accessible();
+                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
                 const NT *pa = spa.get();
 
 #if !defined(HDF5_THREAD_SAFE)
@@ -862,7 +862,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                 }
             }
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
@@ -875,7 +875,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                     return -1;
                 }
 
-                auto spa = static_cast<TT*>(array.get())->get_cpu_accessible();
+                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
                 const NT *pa = spa.get();
 
                 // advance the pointer to the first time step that will be
@@ -928,7 +928,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
             int var_id = it->second.var_id;
             unsigned int declared_type_code = it->second.type_code;
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 array.get(),
 
                 unsigned int actual_type_code = teca_variant_array_code<NT>::get();
@@ -941,7 +941,7 @@ int teca_cf_layout_manager::write(const unsigned long extent[6],
                     return -1;
                 }
 
-                auto spa = static_cast<TT*>(array.get())->get_cpu_accessible();
+                auto spa = static_cast<const TT*>(array.get())->get_cpu_accessible();
                 const NT *pa = spa.get();
 
                 // advance the pointer to the first time step that will be

--- a/io/teca_cf_reader.cxx
+++ b/io/teca_cf_reader.cxx
@@ -692,8 +692,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                 if (!this->t_units.empty() || (units_i == base_units))
                 {
                     // the files are in the same units copy the data
-                    TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        t_axis.get(),
+                    VARIANT_ARRAY_DISPATCH(t_axis.get(),
 
                         auto [p_ti] = data<CTT>(t_i);
                         auto [p_t] = data<TT>(t_axis);
@@ -718,8 +717,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
                         << units_i << "\" differs from base units \"" << base_units
                         << "\" a conversion will be made.")
 
-                    TEMPLATE_DISPATCH(teca_variant_array_impl,
-                        t_axis.get(),
+                    VARIANT_ARRAY_DISPATCH(t_axis.get(),
 
                         auto [p_ti] = data<CTT>(t_i);
                         auto [p_t] = data<TT>(t_axis);
@@ -1080,8 +1078,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     if (!request.get("time", temporal_bounds[0]))
     {
         // translate time to a time step
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            in_t.get(),
+        VARIANT_ARRAY_DISPATCH_FP(in_t.get(),
             auto [pin_t] = data<TT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(temporal_bounds[0]), temporal_extent[0]))

--- a/io/teca_cf_reader.cxx
+++ b/io/teca_cf_reader.cxx
@@ -13,6 +13,7 @@
 #include "teca_calcalcs.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata_util.h"
 
 #include <netcdf.h>
@@ -27,9 +28,6 @@
 #include <utility>
 #include <memory>
 #include <iomanip>
-
-using std::endl;
-using std::cerr;
 
 #if defined(TECA_HAS_MPI)
 #include <mpi.h>
@@ -46,6 +44,12 @@ using std::cerr;
 #if defined(TECA_HAS_CUDA)
 #include "teca_cuda_util.h"
 #endif
+
+using std::endl;
+using std::cerr;
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 // internals for the cf reader
 class teca_cf_reader_internals
@@ -384,9 +388,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
         NC_DISPATCH(x_t,
             size_t x_0 = 0;
-            p_teca_variant_array_impl<NC_T> x = teca_variant_array_impl<NC_T>::New(n_x);
-            auto spx = x->get_cpu_accessible();
-            NC_T *px = spx.get();
+            auto [x, px] = ::New<NC_TT>(n_x);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -445,9 +447,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
             NC_DISPATCH(y_t,
                 size_t y_0 = 0;
-                p_teca_variant_array_impl<NC_T> y = teca_variant_array_impl<NC_T>::New(n_y);
-                auto spy = y->get_cpu_accessible();
-                NC_T *py = spy.get();
+                auto [y, py] = ::New<NC_TT>(n_y);
 #if !defined(HDF5_THREAD_SAFE)
                 {
                 std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -488,8 +488,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
         else
         {
             NC_DISPATCH_FP(x_t,
-                p_teca_variant_array_impl<NC_T> y = teca_variant_array_impl<NC_T>::New(1);
-                y->set(0, NC_T());
+                NC_PT y = NC_TT::New(1, NC_NT());
                 y_axis = y;
                 )
         }
@@ -515,9 +514,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
 
             NC_DISPATCH(z_t,
                 size_t z_0 = 0;
-                p_teca_variant_array_impl<NC_T> z = teca_variant_array_impl<NC_T>::New(n_z);
-                auto spz = z->get_cpu_accessible();
-                NC_T *pz = spz.get();
+                auto [z, pz] = ::New<NC_TT>(n_z);
 #if !defined(HDF5_THREAD_SAFE)
                 {
                 std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -558,8 +555,7 @@ teca_metadata teca_cf_reader::get_output_metadata(
         else
         {
             NC_DISPATCH(x_t,
-                p_teca_variant_array_impl<NC_T> z = teca_variant_array_impl<NC_T>::New(1);
-                z->set(0, NC_T());
+                NC_PT z = NC_TT::New(1, NC_NT());
                 z_axis = z;
                 )
         }
@@ -680,6 +676,9 @@ teca_metadata teca_cf_reader::get_output_metadata(
                     return teca_metadata();
                 }
 
+                // we assume data is on the CPU
+                assert(t_i->cpu_accessible());
+
                 // update the step map
                 size_t n_ti = t_i->size();
                 step_count.push_back(n_ti);
@@ -696,11 +695,9 @@ teca_metadata teca_cf_reader::get_output_metadata(
                     TEMPLATE_DISPATCH(teca_variant_array_impl,
                         t_axis.get(),
 
-                        auto sp_ti = static_cast<const TT*>(t_i.get())->get_cpu_accessible();
-                        const NT *p_ti = sp_ti.get();
+                        auto [p_ti] = data<CTT>(t_i);
+                        auto [p_t] = data<TT>(t_axis);
 
-                        auto sp_t = static_cast<TT*>(t_axis.get())->get_cpu_accessible();
-                        NT *p_t = sp_t.get();
                         p_t += n_t;
 
                         memcpy(p_t, p_ti, sizeof(NT)*n_ti);
@@ -724,11 +721,9 @@ teca_metadata teca_cf_reader::get_output_metadata(
                     TEMPLATE_DISPATCH(teca_variant_array_impl,
                         t_axis.get(),
 
-                        auto sp_ti = static_cast<TT*>(elem_i.first.get())->get_cpu_accessible();
-                        NT *p_ti = sp_ti.get();
+                        auto [p_ti] = data<CTT>(t_i);
+                        auto [p_t] = data<TT>(t_axis);
 
-                        auto sp_t = static_cast<TT*>(t_axis.get())->get_cpu_accessible();
-                        NT *p_t = sp_t.get();
                         p_t += n_t;
 
                         for (size_t j = 0; j < n_ti; ++j)
@@ -949,11 +944,10 @@ teca_metadata teca_cf_reader::get_output_metadata(
             // work.
             size_t n_files = files.size();
             NC_DISPATCH(x_t,
-                p_teca_variant_array_impl<NC_T> t =
-                    teca_variant_array_impl<NC_T>::New(n_files);
+                auto [t, pt] = ::New<NC_TT>(n_files);
                 for (size_t i = 0; i < n_files; ++i)
                 {
-                    t->set(i, NC_T(i));
+                    pt[i] = NC_NT(i);
                     step_count.push_back(1);
                 }
                 t_axis = t;
@@ -1058,6 +1052,11 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         return nullptr;
     }
 
+    // assume coordinate data is on the CPU
+    assert(in_x->cpu_accessible());
+    assert(in_y->cpu_accessible());
+    assert(in_z->cpu_accessible());
+
     // the requested extents must not exceed these limits
     unsigned long nx_max = in_x->size();
     unsigned long ny_max = in_y->size();
@@ -1083,10 +1082,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         // translate time to a time step
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             in_t.get(),
-
-            auto spin_t = dynamic_cast<TT*>(in_t.get())->get_cpu_accessible();
-            NT *pin_t = spin_t.get();
-
+            auto [pin_t] = data<TT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(temporal_bounds[0]), temporal_extent[0]))
             {
@@ -1336,7 +1332,8 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     mesh->set_attributes(out_atrs);
 
     // get the requested target device
-    teca_variant_array::allocator alloc = teca_variant_array::allocator::malloc;
+    allocator alloc = allocator::malloc;
+    allocator tmp_alloc = allocator::malloc;
 #if defined(TECA_HAS_CUDA)
     int device_id = -1;
     request.get("device_id", device_id);
@@ -1344,7 +1341,8 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
     {
         // place all data read on the assigned device
         teca_cuda_util::set_device(device_id);
-        alloc = teca_variant_array::allocator::cuda;
+        alloc = allocator::cuda_async;
+        tmp_alloc = allocator::cuda_host;
     }
 #endif
 
@@ -1444,7 +1442,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         // allocate the array and reserve space, later we append data from each
         // file. save the array in the output mesh.
         NC_DISPATCH(type,
-            p_teca_variant_array_impl<NC_T> a = teca_variant_array_impl<NC_T>::New(alloc);
+            NC_PT a = NC_TT::New(alloc);
             a->reserve(n_vals);
             mesh->get_arrays(centering)->append(arrays[i], a);
             )
@@ -1622,9 +1620,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
 
             NC_DISPATCH(type,
                 // read the data into a temprary array
-                p_teca_variant_array_impl<NC_T> a = teca_variant_array_impl<NC_T>::New(n_vals);
-                auto spa = a->get_cpu_accessible();
-                NC_T *pa = spa.get();
+                auto [a, pa] = ::New<NC_TT>(n_vals, tmp_alloc);
 #if !defined(HDF5_THREAD_SAFE)
                 {
                 std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1643,7 +1639,7 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
                 p_teca_variant_array array = mesh->get_arrays(centering)->get(arrays[i]);
 
                 // append the temporary to the output
-                std::static_pointer_cast<teca_variant_array_impl<NC_T>>(array)->append(a);
+                static_cast<NC_TT*>(array.get())->append(a);
                 )
         }
     }

--- a/io/teca_netcdf_util.cxx
+++ b/io/teca_netcdf_util.cxx
@@ -4,10 +4,13 @@
 #include "teca_file_util.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_array_attributes.h"
 
 #include <cstring>
 #include <vector>
+
+using namespace teca_variant_array_util;
 
 static std::mutex g_netcdf_mutex;
 
@@ -353,7 +356,7 @@ int read_attribute(netcdf_handle &fh, int var_id, int att_id, teca_metadata &att
     else
     {
         NC_DISPATCH(att_type,
-            NC_T *tmp = static_cast<NC_T*>(malloc(sizeof(NC_T)*att_len));
+            NC_NT *tmp = static_cast<NC_NT*>(malloc(sizeof(NC_NT)*att_len));
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -424,7 +427,7 @@ int read_variable_attributes(netcdf_handle &fh, const std::string &var_name,
 
     // convert from the netcdf type code
     NC_DISPATCH(var_nc_type,
-       var_type = teca_variant_array_code<NC_T>::get();
+       var_type = teca_variant_array_code<NC_NT>::get();
        )
 
     // read attributes
@@ -573,7 +576,7 @@ int read_variable_attributes(netcdf_handle &fh, int var_id,
 
     // convert from the netcdf type code
     NC_DISPATCH(var_nc_type,
-       var_type = teca_variant_array_code<NC_T>::get();
+       var_type = teca_variant_array_code<NC_NT>::get();
        )
 
     // read attributes
@@ -719,13 +722,15 @@ read_variable_and_attributes::operator()(int device_id)
         return this->package(m_id);
     }
 
+    // assume data is on the CPU
+    assert(dims->cpu_accessible());
+
     // get the size
     size_t var_size = 1;
     size_t start[NC_MAX_DIMS] = {0};
     size_t count[NC_MAX_DIMS] = {0};
     int n_dims = dims->size();
-    auto spdims = dims->get_cpu_accessible();
-    size_t *p_dims = spdims.get();
+    size_t *p_dims = dims->data();
     for (int i = 0; i < n_dims; ++i)
     {
         var_size *= p_dims[i];
@@ -735,9 +740,7 @@ read_variable_and_attributes::operator()(int device_id)
     // allocate a buffer and read the variable.
     NC_DISPATCH(var_type,
 
-        p_teca_variant_array_impl<NC_T> var = teca_variant_array_impl<NC_T>::New(var_size);
-        auto spvar = var->get_cpu_accessible();
-        NC_T *pvar = spvar.get();
+        auto [var, pvar] = ::New<NC_TT>(var_size);
 
 #if !defined(HDF5_THREAD_SAFE)
         {
@@ -815,9 +818,7 @@ read_variable::data_t read_variable::operator()(int device_id)
     // allocate a buffer and read the variable.
     NC_DISPATCH(var_type,
         size_t start = 0;
-        p_teca_variant_array_impl<NC_T> var = teca_variant_array_impl<NC_T>::New(var_size);
-        auto spvar = var->get_cpu_accessible();
-        NC_T *pvar = spvar.get();
+        auto [var, pvar] = ::New<NC_TT>(var_size);
 #if !defined(HDF5_THREAD_SAFE)
         {
         std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -870,14 +871,17 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
         // get the attribute value
         const_p_teca_variant_array att_values = array_atts.get(att_name);
 
+        // assume the data is on the CPU
+        assert(att_values->cpu_accessible());
+
         // handle string type
         TEMPLATE_DISPATCH_CASE(
             teca_variant_array_impl, std::string,
             att_values.get(),
             if (att_values->size() > 1)
                 continue;
-            std::string att_val;
-            static_cast<const TT*>(att_values.get())->get(0, att_val);
+            auto [patt] = data<CTT>(att_values);
+            std::string att_val(patt[0]);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -896,10 +900,9 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
         else TEMPLATE_DISPATCH(teca_variant_array_impl,
             att_values.get(),
 
+            size_t n_vals = att_values->size();
             int type = teca_netcdf_util::netcdf_tt<NT>::type_code;
-            auto spvals = static_cast<const TT*>(att_values.get())->get_cpu_accessible();
-            const NT *pvals = spvals.get();
-            unsigned long n_vals = att_values->size();
+            auto [pvals] = data<CTT>(att_values);
 
 #if !defined(HDF5_THREAD_SAFE)
             {

--- a/io/teca_netcdf_util.cxx
+++ b/io/teca_netcdf_util.cxx
@@ -875,9 +875,7 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
         assert(att_values->cpu_accessible());
 
         // handle string type
-        TEMPLATE_DISPATCH_CASE(
-            teca_variant_array_impl, std::string,
-            att_values.get(),
+        VARIANT_ARRAY_DISPATCH_CASE(std::string, att_values.get(),
             if (att_values->size() > 1)
                 continue;
             auto [patt] = data<CTT>(att_values);
@@ -897,8 +895,7 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
 #endif
             )
         // handle POD types
-        else TEMPLATE_DISPATCH(teca_variant_array_impl,
-            att_values.get(),
+        else VARIANT_ARRAY_DISPATCH(att_values.get(),
 
             size_t n_vals = att_values->size();
             int type = teca_netcdf_util::netcdf_tt<NT>::type_code;

--- a/io/teca_netcdf_util.cxx
+++ b/io/teca_netcdf_util.cxx
@@ -872,7 +872,7 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
 
         // handle string type
         TEMPLATE_DISPATCH_CASE(
-            const teca_variant_array_impl, std::string,
+            teca_variant_array_impl, std::string,
             att_values.get(),
             if (att_values->size() > 1)
                 continue;
@@ -893,11 +893,11 @@ int write_variable_attributes(netcdf_handle &fh, int var_id,
 #endif
             )
         // handle POD types
-        else TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        else TEMPLATE_DISPATCH(teca_variant_array_impl,
             att_values.get(),
 
             int type = teca_netcdf_util::netcdf_tt<NT>::type_code;
-            auto spvals = static_cast<TT*>(att_values.get())->get_cpu_accessible();
+            auto spvals = static_cast<const TT*>(att_values.get())->get_cpu_accessible();
             const NT *pvals = spvals.get();
             unsigned long n_vals = att_values->size();
 

--- a/io/teca_netcdf_util.h
+++ b/io/teca_netcdf_util.h
@@ -17,43 +17,49 @@
 #endif
 
 /// macro to help with netcdf floating point data types
-#define NC_DISPATCH_FP(tc_, code_)                          \
-    switch (tc_)                                            \
-    {                                                       \
-    NC_DISPATCH_CASE(NC_FLOAT, float, code_)                \
-    NC_DISPATCH_CASE(NC_DOUBLE, double, code_)              \
-    default:                                                \
-        TECA_ERROR("netcdf type code_ " << tc_              \
-            << " is not a floating point type")             \
+#define NC_DISPATCH_FP(tc_, ...)                                \
+    switch (tc_)                                                \
+    {                                                           \
+    NC_DISPATCH_CASE(NC_FLOAT, float, __VA_ARGS__)              \
+    NC_DISPATCH_CASE(NC_DOUBLE, double, __VA_ARGS__)            \
+    default:                                                    \
+        TECA_ERROR("netcdf type __VA_ARGS__ " << tc_            \
+            << " is not a floating point type")                 \
     }
 
 /// macro to help with netcdf data types
-#define NC_DISPATCH(tc_, code_)                             \
-    switch (tc_)                                            \
-    {                                                       \
-    NC_DISPATCH_CASE(NC_BYTE, char, code_)                  \
-    NC_DISPATCH_CASE(NC_UBYTE, unsigned char, code_)        \
-    NC_DISPATCH_CASE(NC_CHAR, char, code_)                  \
-    NC_DISPATCH_CASE(NC_SHORT, short int, code_)            \
-    NC_DISPATCH_CASE(NC_USHORT, unsigned short int, code_)  \
-    NC_DISPATCH_CASE(NC_INT, int, code_)                    \
-    NC_DISPATCH_CASE(NC_UINT, unsigned int, code_)          \
-    NC_DISPATCH_CASE(NC_INT64, long long, code_)            \
-    NC_DISPATCH_CASE(NC_UINT64, unsigned long long, code_)  \
-    NC_DISPATCH_CASE(NC_FLOAT, float, code_)                \
-    NC_DISPATCH_CASE(NC_DOUBLE, double, code_)              \
-    default:                                                \
-        TECA_ERROR("netcdf type code " << tc_               \
-            << " is not supported")                         \
+#define NC_DISPATCH(tc_, ...)                                     \
+    switch (tc_)                                                  \
+    {                                                             \
+    NC_DISPATCH_CASE(NC_BYTE, char, __VA_ARGS__)                  \
+    NC_DISPATCH_CASE(NC_UBYTE, unsigned char, __VA_ARGS__)        \
+    NC_DISPATCH_CASE(NC_CHAR, char, __VA_ARGS__)                  \
+    NC_DISPATCH_CASE(NC_SHORT, short int, __VA_ARGS__)            \
+    NC_DISPATCH_CASE(NC_USHORT, unsigned short int, __VA_ARGS__)  \
+    NC_DISPATCH_CASE(NC_INT, int, __VA_ARGS__)                    \
+    NC_DISPATCH_CASE(NC_UINT, unsigned int, __VA_ARGS__)          \
+    NC_DISPATCH_CASE(NC_INT64, long long, __VA_ARGS__)            \
+    NC_DISPATCH_CASE(NC_UINT64, unsigned long long, __VA_ARGS__)  \
+    NC_DISPATCH_CASE(NC_FLOAT, float, __VA_ARGS__)                \
+    NC_DISPATCH_CASE(NC_DOUBLE, double, __VA_ARGS__)              \
+    default:                                                      \
+        TECA_ERROR("netcdf type code " << tc_                     \
+            << " is not supported")                               \
     }
 
 /// macro that executes code when the type code is matched.
-#define NC_DISPATCH_CASE(cc_, tt_, code_)   \
-    case cc_:                               \
-    {                                       \
-        using NC_T = tt_;                   \
-        code_                               \
-        break;                              \
+#define NC_DISPATCH_CASE(cc_, tt_, ...)                                     \
+    case cc_:                                                               \
+    {                                                                       \
+        using NC_NT = tt_;                                                  \
+        using NC_TT = teca_variant_array_impl<tt_>;                         \
+        using NC_CTT = const teca_variant_array_impl<tt_>;                  \
+        using NC_PT = std::shared_ptr<teca_variant_array_impl<tt_>>;        \
+        using NC_CPT = std::shared_ptr<const teca_variant_array_impl<tt_>>; \
+        using NC_SP = std::shared_ptr<tt_>;                                 \
+        using NC_CSP = std::shared_ptr<const tt_>;                          \
+        __VA_ARGS__                                                         \
+        break;                                                              \
     }
 
 /// Codes dealing with NetCDF I/O calls

--- a/io/teca_shape_file_mask.cxx
+++ b/io/teca_shape_file_mask.cxx
@@ -4,6 +4,7 @@
 #include "teca_array_collection.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_metadata.h"
 #include "teca_array_attributes.h"
 #include "teca_geometry.h"
@@ -25,11 +26,9 @@
 #include <boost/program_options.hpp>
 #endif
 
-//#define TECA_DEBUG
+using namespace teca_variant_array_util;
 
-namespace internal
-{
-}
+//#define TECA_DEBUG
 
 using poly_coord_t = double;
 
@@ -244,9 +243,7 @@ const_p_teca_dataset teca_shape_file_mask::execute(
     unsigned long ny = y->size();
     unsigned long nxy = nx*ny;
 
-    p_teca_char_array mask = teca_char_array::New(nxy, 0);
-    auto sp_mask = mask->get_cpu_accessible();
-    char *p_mask = sp_mask.get();
+    auto [mask, p_mask] = ::New<teca_char_array>(nxy, char(0));
 
     // visit each polygon
     unsigned long np = this->internals->polys.size();
@@ -270,11 +267,9 @@ const_p_teca_dataset teca_shape_file_mask::execute(
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             x.get(),
 
-            auto sp_x = static_cast<const TT*>(x.get())->get_cpu_accessible();
-            const NT *p_x = sp_x.get();
+            assert_type<CTT>(y);
 
-            auto sp_y = static_cast<const TT*>(y.get())->get_cpu_accessible();
-            const NT *p_y = sp_y.get();
+            auto [sp_x, p_x, sp_y, p_y] = get_cpu_accessible<CTT>(x, y);
 
             for (unsigned long j = extent[2]; j <= extent[3]; ++j)
             {

--- a/io/teca_shape_file_mask.cxx
+++ b/io/teca_shape_file_mask.cxx
@@ -267,13 +267,13 @@ const_p_teca_dataset teca_shape_file_mask::execute(
         }
 
         // test each point in the extent for intersection with the polygon
-        TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             x.get(),
 
-            auto sp_x = static_cast<TT*>(x.get())->get_cpu_accessible();
+            auto sp_x = static_cast<const TT*>(x.get())->get_cpu_accessible();
             const NT *p_x = sp_x.get();
 
-            auto sp_y = static_cast<TT*>(y.get())->get_cpu_accessible();
+            auto sp_y = static_cast<const TT*>(y.get())->get_cpu_accessible();
             const NT *p_y = sp_y.get();
 
             for (unsigned long j = extent[2]; j <= extent[3]; ++j)

--- a/io/teca_shape_file_mask.cxx
+++ b/io/teca_shape_file_mask.cxx
@@ -264,8 +264,7 @@ const_p_teca_dataset teca_shape_file_mask::execute(
         }
 
         // test each point in the extent for intersection with the polygon
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            x.get(),
+        VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
             assert_type<CTT>(y);
 

--- a/io/teca_table_reader.cxx
+++ b/io/teca_table_reader.cxx
@@ -6,15 +6,12 @@
 #include "teca_common.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <algorithm>
 #include <cstring>
 #include <cstdio>
 #include <errno.h>
-
-using std::string;
-using std::endl;
-using std::cerr;
 
 #if defined(TECA_HAS_BOOST)
 #include <boost/program_options.hpp>
@@ -23,6 +20,12 @@ using std::cerr;
 #if defined(TECA_HAS_MPI)
 #include <mpi.h>
 #endif
+
+using std::string;
+using std::endl;
+using std::cerr;
+
+using namespace teca_variant_array_util;
 
 // PIMPL idiom
 struct teca_table_reader::teca_table_reader_internals
@@ -290,8 +293,7 @@ teca_metadata teca_table_reader::get_output_metadata(unsigned int port,
     TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         index.get(),
 
-        auto spindex = dynamic_cast<TT*>(index.get())->get_cpu_accessible();
-        NT *pindex = spindex.get();
+        auto [pindex] = data<CTT>(index);
 
         teca_coordinate_util::get_table_offsets(pindex,
             this->internals->table->get_number_of_rows(),
@@ -404,11 +406,7 @@ const_p_teca_dataset teca_table_reader::execute(unsigned int port,
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             out_col.get(),
 
-            auto spin_col = static_cast<TT*>(in_col.get())->get_cpu_accessible();
-            NT *pin_col = spin_col.get();
-
-            auto spout_col = static_cast<TT*>(out_col.get())->get_cpu_accessible();
-            NT *pout_col = spout_col.get();
+            auto [pin_col, pout_col] = data<TT>(in_col, out_col);
 
             memcpy(pout_col, pin_col+first_row, nrows*sizeof(NT));
             )
@@ -416,9 +414,7 @@ const_p_teca_dataset teca_table_reader::execute(unsigned int port,
 
     if (this->generate_original_ids)
     {
-        p_teca_unsigned_long_array ids = teca_unsigned_long_array::New(nrows);
-        auto spids = ids->get_cpu_accessible();
-        unsigned long *pids = spids.get();
+        auto [ids, pids] = ::New<teca_unsigned_long_array>(nrows);
 
         for (unsigned long i = 0, q = first_row; i < nrows; ++i, ++q)
             pids[i] = q;

--- a/io/teca_table_reader.cxx
+++ b/io/teca_table_reader.cxx
@@ -290,8 +290,7 @@ teca_metadata teca_table_reader::get_output_metadata(unsigned int port,
         return teca_metadata();
     }
 
-    TEMPLATE_DISPATCH_I(teca_variant_array_impl,
-        index.get(),
+    VARIANT_ARRAY_DISPATCH_I(index.get(),
 
         auto [pindex] = data<CTT>(index);
 
@@ -403,8 +402,7 @@ const_p_teca_dataset teca_table_reader::execute(unsigned int port,
 
         out_col->resize(nrows);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            out_col.get(),
+        VARIANT_ARRAY_DISPATCH(out_col.get(),
 
             auto [pin_col, pout_col] = data<TT>(in_col, out_col);
 

--- a/io/teca_table_writer.cxx
+++ b/io/teca_table_writer.cxx
@@ -117,7 +117,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
         {
         std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
 #endif
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             col.get(),
             if ((ierr = nc_def_var(fh.get(), col_name.c_str(),
                 teca_netcdf_util::netcdf_tt<NT>::type_code, 1,
@@ -128,7 +128,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
                 return -1;
             }
             )
-        else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
             std::string, col.get(),
             if ((ierr = nc_def_var(fh.get(), col_name.c_str(),
                 NC_STRING, 1, &row_dim_id, &var_id)) != NC_NOERR)
@@ -185,9 +185,9 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
         size_t starts = 0;
         size_t counts = n_rows;
 
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             col.get(),
-            auto sp_col = static_cast<TT*>(col.get())->get_cpu_accessible();
+            auto sp_col = static_cast<const TT*>(col.get())->get_cpu_accessible();
             const NT *p_col = sp_col.get();
 #if !defined(HDF5_THREAD_SAFE)
             {
@@ -203,9 +203,9 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
             }
 #endif
             )
-        else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
             std::string, col.get(),
-            auto sp_col = static_cast<TT*>(col.get())->get_cpu_accessible();
+            auto sp_col = static_cast<const TT*>(col.get())->get_cpu_accessible();
             const NT *p_col = sp_col.get();
             // put the strings into a buffer for netcdf
             const char **string_data = (const char **)malloc(n_rows*sizeof(char*));
@@ -258,14 +258,14 @@ int write_xlsx(const_p_teca_table table, lxw_worksheet *worksheet)
     {
         for (unsigned int i = 0; i < n_cols; ++i)
         {
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 table->get_column(i).get(),
                 const TT *a = dynamic_cast<const TT*>(table->get_column(i).get());
                 NT v = NT();
                 a->get(j, v);
                 worksheet_write_number(worksheet, j+1, i, static_cast<double>(v), NULL);
                 )
-            else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
                 std::string,
                 table->get_column(i).get(),
                 const TT *a = dynamic_cast<const TT*>(table->get_column(i).get());

--- a/io/teca_table_writer.cxx
+++ b/io/teca_table_writer.cxx
@@ -8,6 +8,7 @@
 #include "teca_mpi.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <iostream>
 #include <sstream>
@@ -33,6 +34,8 @@
 #include <netcdf.h>
 #include "teca_netcdf_util.h"
 #endif
+
+using namespace teca_variant_array_util;
 
 namespace internal
 {
@@ -187,8 +190,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             col.get(),
-            auto sp_col = static_cast<const TT*>(col.get())->get_cpu_accessible();
-            const NT *p_col = sp_col.get();
+            auto [sp_col, p_col] = get_cpu_accessible<CTT>(col);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -205,8 +207,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
             )
         else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
             std::string, col.get(),
-            auto sp_col = static_cast<const TT*>(col.get())->get_cpu_accessible();
-            const NT *p_col = sp_col.get();
+            auto [sp_col, p_col] = get_cpu_accessible<CTT>(col);
             // put the strings into a buffer for netcdf
             const char **string_data = (const char **)malloc(n_rows*sizeof(char*));
             for (size_t j = 0; j < n_rows; ++j)

--- a/io/teca_table_writer.cxx
+++ b/io/teca_table_writer.cxx
@@ -120,7 +120,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
         {
         std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
 #endif
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
+        VARIANT_ARRAY_DISPATCH(
             col.get(),
             if ((ierr = nc_def_var(fh.get(), col_name.c_str(),
                 teca_netcdf_util::netcdf_tt<NT>::type_code, 1,
@@ -131,7 +131,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
                 return -1;
             }
             )
-        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+        else VARIANT_ARRAY_DISPATCH_CASE(
             std::string, col.get(),
             if ((ierr = nc_def_var(fh.get(), col_name.c_str(),
                 NC_STRING, 1, &row_dim_id, &var_id)) != NC_NOERR)
@@ -188,7 +188,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
         size_t starts = 0;
         size_t counts = n_rows;
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
+        VARIANT_ARRAY_DISPATCH(
             col.get(),
             auto [sp_col, p_col] = get_cpu_accessible<CTT>(col);
 #if !defined(HDF5_THREAD_SAFE)
@@ -205,7 +205,7 @@ int write_netcdf(const_p_teca_table table, const std::string &file_name,
             }
 #endif
             )
-        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+        else VARIANT_ARRAY_DISPATCH_CASE(
             std::string, col.get(),
             auto [sp_col, p_col] = get_cpu_accessible<CTT>(col);
             // put the strings into a buffer for netcdf
@@ -259,14 +259,14 @@ int write_xlsx(const_p_teca_table table, lxw_worksheet *worksheet)
     {
         for (unsigned int i = 0; i < n_cols; ++i)
         {
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
+            VARIANT_ARRAY_DISPATCH(
                 table->get_column(i).get(),
                 const TT *a = dynamic_cast<const TT*>(table->get_column(i).get());
                 NT v = NT();
                 a->get(j, v);
                 worksheet_write_number(worksheet, j+1, i, static_cast<double>(v), NULL);
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+            else VARIANT_ARRAY_DISPATCH_CASE(
                 std::string,
                 table->get_column(i).get(),
                 const TT *a = dynamic_cast<const TT*>(table->get_column(i).get());

--- a/io/teca_vtk_util.cxx
+++ b/io/teca_vtk_util.cxx
@@ -3,6 +3,7 @@
 #include "teca_common.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <vector>
 #include <string>
@@ -14,6 +15,8 @@
 #include "vtkInformation.h"
 #include "vtkStreamingDemandDrivenPipeline.h"
 #endif
+
+using namespace teca_variant_array_util;
 
 namespace teca_vtk_util
 {
@@ -46,39 +49,33 @@ int deep_copy(vtkRectilinearGrid *output,
     // transfer coordinates
     const_p_teca_variant_array x = input->get_x_coordinates();
     TEMPLATE_DISPATCH(teca_variant_array_impl, x.get(),
-        const TT *xx = static_cast<const TT*>(x.get());
-        auto spxx = xx->get_cpu_accessible();
-        const NT *pxx = spxx.get();
+        auto [spx, px] = get_cpu_accessible<CTT>(x);
         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
-        a->SetNumberOfTuples(xx->size());
+        a->SetNumberOfTuples(x->size());
         NT *p_a = a->GetPointer(0);
-        memcpy(p_a, pxx, sizeof(NT)*xx->size());
+        memcpy(p_a, px, sizeof(NT)*x->size());
         output->SetXCoordinates(a);
         a->Delete();
         );
 
     const_p_teca_variant_array y = input->get_y_coordinates();
     TEMPLATE_DISPATCH(teca_variant_array_impl, y.get(),
-        const TT *yy = static_cast<const TT*>(y.get());
-        auto spyy = yy->get_cpu_accessible();
-        const NT *pyy = spyy.get();
-         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
-        a->SetNumberOfTuples(yy->size());
+        auto [spy, py] = get_cpu_accessible<CTT>(y);
+        vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
+        a->SetNumberOfTuples(y->size());
         NT *p_a = a->GetPointer(0);
-        memcpy(p_a, pyy, sizeof(NT)*yy->size());
+        memcpy(p_a, py, sizeof(NT)*y->size());
         output->SetYCoordinates(a);
         a->Delete();
         )
 
     const_p_teca_variant_array z = input->get_z_coordinates();
     TEMPLATE_DISPATCH(teca_variant_array_impl, z.get(),
-        const TT *zz = static_cast<const TT*>(z.get());
-        auto spzz = zz->get_cpu_accessible();
-        const NT *pzz = spzz.get();
+        auto [spz, pz] = get_cpu_accessible<CTT>(z);
         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
-        a->SetNumberOfTuples(zz->size());
+        a->SetNumberOfTuples(z->size());
         NT *p_a = a->GetPointer(0);
-        memcpy(p_a, pzz, sizeof(NT)*zz->size());
+        memcpy(p_a, pzz, sizeof(NT)*z->size());
         output->SetZCoordinates(a);
         a->Delete();
         )
@@ -92,14 +89,12 @@ int deep_copy(vtkRectilinearGrid *output,
         std::string name = pd->get_name(i);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl, a.get(),
-            const TT *aa = static_cast<const TT*>(a.get());
-            auto spaa = aa->get_cpu_accessible();
-            const NT *paa = spaa.get();
+            auto [spa, pa] = get_cpu_accessible<CTT>(a);
             vtk_tt<NT>::type *b = vtk_tt<NT>::type::New();
-            b->SetNumberOfTuples(aa->size());
+            b->SetNumberOfTuples(a->size());
             b->SetName(name.c_str());
             NT *p_b = b->GetPointer(0);
-            memcpy(p_b, paa, sizeof(NT)*aa->size());
+            memcpy(p_b, pa, sizeof(NT)*a->size());
             output->GetPointData()->AddArray(b);
             b->Delete();
             )

--- a/io/teca_vtk_util.cxx
+++ b/io/teca_vtk_util.cxx
@@ -48,7 +48,7 @@ int deep_copy(vtkRectilinearGrid *output,
 
     // transfer coordinates
     const_p_teca_variant_array x = input->get_x_coordinates();
-    TEMPLATE_DISPATCH(teca_variant_array_impl, x.get(),
+    VARIANT_ARRAY_DISPATCH(x.get(),
         auto [spx, px] = get_cpu_accessible<CTT>(x);
         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
         a->SetNumberOfTuples(x->size());
@@ -59,7 +59,7 @@ int deep_copy(vtkRectilinearGrid *output,
         );
 
     const_p_teca_variant_array y = input->get_y_coordinates();
-    TEMPLATE_DISPATCH(teca_variant_array_impl, y.get(),
+    VARIANT_ARRAY_DISPATCH(y.get(),
         auto [spy, py] = get_cpu_accessible<CTT>(y);
         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
         a->SetNumberOfTuples(y->size());
@@ -70,7 +70,7 @@ int deep_copy(vtkRectilinearGrid *output,
         )
 
     const_p_teca_variant_array z = input->get_z_coordinates();
-    TEMPLATE_DISPATCH(teca_variant_array_impl, z.get(),
+    VARIANT_ARRAY_DISPATCH(z.get(),
         auto [spz, pz] = get_cpu_accessible<CTT>(z);
         vtk_tt<NT>::type *a = vtk_tt<NT>::type::New();
         a->SetNumberOfTuples(z->size());
@@ -88,7 +88,7 @@ int deep_copy(vtkRectilinearGrid *output,
         const_p_teca_variant_array a = pd->get(i);
         std::string name = pd->get_name(i);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl, a.get(),
+        VARIANT_ARRAY_DISPATCH(a.get(),
             auto [spa, pa] = get_cpu_accessible<CTT>(a);
             vtk_tt<NT>::type *b = vtk_tt<NT>::type::New();
             b->SetNumberOfTuples(a->size());

--- a/io/teca_vtk_util.cxx
+++ b/io/teca_vtk_util.cxx
@@ -45,7 +45,7 @@ int deep_copy(vtkRectilinearGrid *output,
 
     // transfer coordinates
     const_p_teca_variant_array x = input->get_x_coordinates();
-    TEMPLATE_DISPATCH(const teca_variant_array_impl, x.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl, x.get(),
         const TT *xx = static_cast<const TT*>(x.get());
         auto spxx = xx->get_cpu_accessible();
         const NT *pxx = spxx.get();
@@ -58,7 +58,7 @@ int deep_copy(vtkRectilinearGrid *output,
         );
 
     const_p_teca_variant_array y = input->get_y_coordinates();
-    TEMPLATE_DISPATCH(const teca_variant_array_impl, y.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl, y.get(),
         const TT *yy = static_cast<const TT*>(y.get());
         auto spyy = yy->get_cpu_accessible();
         const NT *pyy = spyy.get();
@@ -71,7 +71,7 @@ int deep_copy(vtkRectilinearGrid *output,
         )
 
     const_p_teca_variant_array z = input->get_z_coordinates();
-    TEMPLATE_DISPATCH( const teca_variant_array_impl, z.get(),
+    TEMPLATE_DISPATCH(teca_variant_array_impl, z.get(),
         const TT *zz = static_cast<const TT*>(z.get());
         auto spzz = zz->get_cpu_accessible();
         const NT *pzz = spzz.get();
@@ -91,7 +91,7 @@ int deep_copy(vtkRectilinearGrid *output,
         const_p_teca_variant_array a = pd->get(i);
         std::string name = pd->get_name(i);
 
-        TEMPLATE_DISPATCH(const teca_variant_array_impl, a.get(),
+        TEMPLATE_DISPATCH(teca_variant_array_impl, a.get(),
             const TT *aa = static_cast<const TT*>(a.get());
             auto spaa = aa->get_cpu_accessible();
             const NT *paa = spaa.get();

--- a/io/teca_wrf_reader.cxx
+++ b/io/teca_wrf_reader.cxx
@@ -2,6 +2,7 @@
 #include "teca_array_attributes.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_file_util.h"
 #include "teca_arakawa_c_grid.h"
 #include "teca_coordinate_util.h"
@@ -23,6 +24,7 @@
 
 using std::endl;
 using std::cerr;
+using namespace teca_variant_array_util;
 
 #if defined(TECA_HAS_MPI)
 #include <mpi.h>
@@ -431,7 +433,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
 #endif
                 // convert from the netcdf type code
                 NC_DISPATCH(var_nc_type,
-                   var_type = teca_variant_array_code<NC_T>::get();
+                   var_type = teca_variant_array_code<NC_NT>::get();
                    )
 
                 // skip scalars
@@ -534,7 +536,7 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                     else
                     {
                         NC_DISPATCH(att_type,
-                            NC_T *tmp = static_cast<NC_T*>(realloc(att_buffer, sizeof(NC_T)*att_len));
+                            NC_NT *tmp = static_cast<NC_NT*>(realloc(att_buffer, sizeof(NC_NT)*att_len));
 #if !defined(HDF5_THREAD_SAFE)
                             {
                             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -828,11 +830,10 @@ teca_metadata teca_wrf_reader::get_output_metadata(
 
                 size_t n_files = files.size();
                 NC_DISPATCH_FP(x_t,
-                    p_teca_variant_array_impl<NC_T> t =
-                        teca_variant_array_impl<NC_T>::New(n_files);
+                    auto [t, pt] = ::New<NC_TT>(n_files);
                     for (size_t i = 0; i < n_files; ++i)
                     {
-                        t->set(i, NC_T(i));
+                        pt[i] = NC_NT(i);
                         step_count.push_back(1);
                     }
                     t_axis = t;
@@ -962,10 +963,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
         // translate time to a time step
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             in_t.get(),
-
-            auto spin_t = dynamic_cast<TT*>(in_t.get())->get_cpu_accessible();
-            NT *pin_t = spin_t.get();
-
+            auto [pin_t] = data<TT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))
             {
@@ -1180,14 +1178,8 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
         NC_DISPATCH_FP(m_x_type,
             // allocate temporary storage
-            p_teca_variant_array_impl<NC_T> m_x = teca_variant_array_impl<NC_T>::New(n_m_xy);
-            auto spm_x = m_x->get_cpu_accessible();
-            NC_T *pm_x = spm_x.get();
-
-            p_teca_variant_array_impl<NC_T> m_y = teca_variant_array_impl<NC_T>::New(n_m_xy);
-            auto spm_y = m_y->get_cpu_accessible();
-            NC_T *pm_y = spm_y.get();
-
+            auto [m_x, pm_x] = ::New<NC_TT>(n_m_xy);
+            auto [m_y, pm_y] = ::New<NC_TT>(n_m_xy);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1258,13 +1250,8 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
         NC_DISPATCH_FP(u_x_type,
             // allocate temporary storage
-            p_teca_variant_array_impl<NC_T> u_x = teca_variant_array_impl<NC_T>::New(n_u_xy);
-            auto spu_x = u_x->get_cpu_accessible();
-            NC_T *pu_x = spu_x.get();
-
-            p_teca_variant_array_impl<NC_T> u_y = teca_variant_array_impl<NC_T>::New(n_u_xy);
-            auto spu_y = u_y->get_cpu_accessible();
-            NC_T *pu_y = spu_y.get();
+            auto [u_x, pu_x] = ::New<NC_TT>(n_u_xy);
+            auto [u_y, pu_y] = ::New<NC_TT>(n_u_xy);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1335,13 +1322,8 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
         NC_DISPATCH_FP(v_x_type,
             // allocate temporary storage
-            p_teca_variant_array_impl<NC_T> v_x = teca_variant_array_impl<NC_T>::New(n_v_xy);
-            auto spv_x = v_x->get_cpu_accessible();
-            NC_T *pv_x = spv_x.get();
-
-            p_teca_variant_array_impl<NC_T> v_y = teca_variant_array_impl<NC_T>::New(n_v_xy);
-            auto spv_y = v_y->get_cpu_accessible();
-            NC_T *pv_y = spv_y.get();
+            auto [v_x, pv_x] = ::New<NC_TT>(n_v_xy);
+            auto [v_y, pv_y] = ::New<NC_TT>(n_v_xy);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1396,9 +1378,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
         NC_DISPATCH_FP(m_z_type,
             // allocate temporary storage
-            p_teca_variant_array_impl<NC_T> m_z = teca_variant_array_impl<NC_T>::New(n_m_z);
-            auto spm_z = m_z->get_cpu_accessible();
-            NC_T *pm_z = spm_z.get();
+            auto [m_z, pm_z] = ::New<NC_TT>(n_m_z);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1446,9 +1426,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
 
         NC_DISPATCH_FP(w_z_type,
             // allocate temporary storage
-            p_teca_variant_array_impl<NC_T> w_z = teca_variant_array_impl<NC_T>::New(n_w_z);
-            auto spw_z = w_z->get_cpu_accessible();
-            NC_T *pw_z = spw_z.get();
+            auto [w_z, pw_z] = ::New<NC_TT>(n_w_z);
 #if !defined(HDF5_THREAD_SAFE)
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1584,9 +1562,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             // read mesh based data
             p_teca_variant_array array;
             NC_DISPATCH(type,
-                p_teca_variant_array_impl<NC_T> a = teca_variant_array_impl<NC_T>::New(mesh_size);
-                auto spa = a->get_cpu_accessible();
-                NC_T *pa = spa.get();
+                auto [a, pa] = ::New<NC_TT>(mesh_size);
 #if !defined(HDF5_THREAD_SAFE)
                 {
                 std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
@@ -1644,9 +1620,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
             p_teca_variant_array array;
 
             NC_DISPATCH(type,
-                p_teca_variant_array_impl<NC_T> a = teca_variant_array_impl<NC_T>::New(n_vals);
-                auto spa = a->get_cpu_accessible();
-                NC_T *pa = spa.get();
+                auto [a, pa] = ::New<NC_TT>(n_vals);
 #if !defined(HDF5_THREAD_SAFE)
                 {
                 std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());

--- a/io/teca_wrf_reader.cxx
+++ b/io/teca_wrf_reader.cxx
@@ -961,8 +961,7 @@ const_p_teca_dataset teca_wrf_reader::execute(unsigned int port,
     if (!request.get("time", t))
     {
         // translate time to a time step
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            in_t.get(),
+        VARIANT_ARRAY_DISPATCH_FP(in_t.get(),
             auto [pin_t] = data<TT>(in_t);
             if (teca_coordinate_util::index_of(pin_t, 0,
                 in_t->size()-1, static_cast<NT>(t), time_step))

--- a/paraview/vtkTECATCCandidateTableReader.cxx
+++ b/paraview/vtkTECATCCandidateTableReader.cxx
@@ -375,8 +375,7 @@ int vtkTECATCCandidateTableReader::RequestData(
     {
     const_p_teca_variant_array ar = this->Table->get_column(i);
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
-      ar.get(),
+    VARIANT_ARRAY_DISPATCH(ar.get(),
 
       vtk_tt<NT>::VTK_TT *da = vtk_tt<NT>::VTK_TT::New();
       da->SetName(this->Table->get_column_name(i).c_str());

--- a/paraview/vtkTECATCTrackTableReader.cxx
+++ b/paraview/vtkTECATCTrackTableReader.cxx
@@ -371,8 +371,7 @@ int vtkTECATCTrackTableReader::RequestData(
     {
     p_teca_variant_array ar = this->Table->get_column(i);
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-      ar.get(),
+    VARIANT_ARRAY_DISPATCH(ar.get(),
 
       vtk_tt<NT>::VTK_TT *da = vtk_tt<NT>::VTK_TT::New();
       da->SetName(this->Table->get_column_name(i).c_str());

--- a/python/teca_py_array.h
+++ b/python/teca_py_array.h
@@ -230,7 +230,7 @@ bool append(teca_variant_array *varr, PyObject *obj)
             return true;
 
         // append
-        TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+        VARIANT_ARRAY_DISPATCH( varr,
             TT *varrt = static_cast<TT*>(varr);
             varrt->reserve(n_elem);
             TECA_PY_ARRAY_DISPATCH(arr,
@@ -267,7 +267,7 @@ bool append(teca_variant_array *varr, PyObject *obj)
     // numpy scalar
     if (PyArray_CheckScalar(obj))
     {
-        TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+        VARIANT_ARRAY_DISPATCH( varr,
             TT *varrt = static_cast<TT*>(varr);
             varrt->reserve(1);
 
@@ -307,7 +307,7 @@ bool set(teca_variant_array *varr, unsigned long i, PyObject *obj)
     // numpy scalar
     if (PyArray_CheckScalar(obj))
     {
-        TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+        VARIANT_ARRAY_DISPATCH( varr,
             TT *varrt = static_cast<TT*>(varr);
             TECA_PY_ARRAY_SCALAR_DISPATCH(obj,
                 varrt->set(i, teca_py_array::numpy_scalar_tt<ST>::value(obj));
@@ -476,7 +476,7 @@ PyArrayObject *new_object(teca_variant_array_impl<NT> *varrt, bool deep_copy = f
 TECA_EXPORT
 PyArrayObject *new_object(teca_variant_array *varr, bool deep_copy = false)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+    VARIANT_ARRAY_DISPATCH(varr,
         TT *varrt = static_cast<TT*>(varr);
         return new_object(varrt);
         )

--- a/python/teca_py_core.i
+++ b/python/teca_py_core.i
@@ -319,9 +319,12 @@ if get_teca_has_cupy():
 
             TT *tself = static_cast<TT*>(self);
 
+            hamr::stream stream;
+
             hamr::buffer_handle<NT> *ph = new hamr::buffer_handle<NT>(
                 tself->get_cpu_accessible(), tself->size(), 0, 1,
-                tself->cpu_accessible() && tself->cuda_accessible());
+                tself->cpu_accessible() && tself->cuda_accessible(),
+                stream);
 
             return SWIG_NewPointerObj(SWIG_as_voidptr(ph),
                 hamr::buffer_handle_tt<NT>::swig_type(), SWIG_POINTER_OWN);
@@ -358,9 +361,12 @@ if get_teca_has_cupy():
 
             TT *tself = static_cast<TT*>(self);
 
+            hamr::stream stream;
+
             hamr::buffer_handle<NT> *ph = new hamr::buffer_handle<NT>(
                 tself->get_cuda_accessible(), tself->size(), 0,
-                tself->cpu_accessible() && tself->cuda_accessible(), 1);
+                tself->cpu_accessible() && tself->cuda_accessible(), 1,
+                stream);
 
             return SWIG_NewPointerObj(SWIG_as_voidptr(ph),
                 hamr::buffer_handle_tt<NT>::swig_type(), SWIG_POINTER_OWN);

--- a/python/teca_py_core.i
+++ b/python/teca_py_core.i
@@ -285,12 +285,11 @@ if get_teca_has_cupy():
             return nullptr;
         }
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl, self,
+        VARIANT_ARRAY_DISPATCH(self,
             TT *varrt = static_cast<TT*>(self);
             return teca_py_object::py_tt<NT>::new_object(varrt->get(i));
             )
-        else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-            std::string, self,
+        else VARIANT_ARRAY_DISPATCH_CASE(std::string, self,
             TT *varrt = static_cast<TT*>(self);
             return teca_py_object::py_tt<NT>::new_object(varrt->get(i));
             )
@@ -314,8 +313,7 @@ if get_teca_has_cupy():
     PyObject *get_cpu_accessible_impl()
     {
         teca_py_gil_state gil;
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            self,
+        VARIANT_ARRAY_DISPATCH(self,
 
             TT *tself = static_cast<TT*>(self);
 
@@ -356,8 +354,7 @@ if get_teca_has_cupy():
     PyObject *get_cuda_accessible_impl()
     {
         teca_py_gil_state gil;
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            self,
+        VARIANT_ARRAY_DISPATCH(self,
 
             TT *tself = static_cast<TT*>(self);
 
@@ -514,32 +511,27 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
         }
         else if (n_elem == 1)
         {
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                varr.get(),
+            VARIANT_ARRAY_DISPATCH(varr.get(),
                 TT *varrt = static_cast<TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-                std::string, varr.get(),
+            else VARIANT_ARRAY_DISPATCH_CASE(std::string, varr.get(),
                 const TT *varrt = static_cast<const TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-                teca_metadata, varr.get(),
+            else VARIANT_ARRAY_DISPATCH_CASE(teca_metadata, varr.get(),
                 const TT *varrt = static_cast<const TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
         }
         else if (n_elem > 1)
         {
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                varr.get(),
+            VARIANT_ARRAY_DISPATCH(varr.get(),
                 TT *varrt = static_cast<TT*>(varr.get());
                 return reinterpret_cast<PyObject*>(
                     teca_py_array::new_object(varrt));
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-                std::string, varr.get(),
+            else VARIANT_ARRAY_DISPATCH_CASE(std::string, varr.get(),
                 const TT *varrt = static_cast<const TT*>(varr.get());
                 PyObject *list = PyList_New(n_elem);
                 for (size_t i = 0; i < n_elem; ++i)
@@ -549,8 +541,7 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
                 }
                 return list;
                 )
-            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-                teca_metadata, varr.get(),
+            else VARIANT_ARRAY_DISPATCH_CASE(teca_metadata, varr.get(),
                 const TT *varrt = static_cast<const TT*>(varr.get());
                 PyObject *list = PyList_New(n_elem);
                 for (size_t i = 0; i < n_elem; ++i)

--- a/python/teca_py_core.i
+++ b/python/teca_py_core.i
@@ -513,14 +513,14 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
                 TT *varrt = static_cast<TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
-            else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
                 std::string, varr.get(),
-                TT *varrt = static_cast<TT*>(varr.get());
+                const TT *varrt = static_cast<const TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
-            else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
                 teca_metadata, varr.get(),
-                TT *varrt = static_cast<TT*>(varr.get());
+                const TT *varrt = static_cast<const TT*>(varr.get());
                 return teca_py_object::py_tt<NT>::new_object(varrt->get(0));
                 )
         }
@@ -532,9 +532,9 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
                 return reinterpret_cast<PyObject*>(
                     teca_py_array::new_object(varrt));
                 )
-            else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
                 std::string, varr.get(),
-                TT *varrt = static_cast<TT*>(varr.get());
+                const TT *varrt = static_cast<const TT*>(varr.get());
                 PyObject *list = PyList_New(n_elem);
                 for (size_t i = 0; i < n_elem; ++i)
                 {
@@ -543,9 +543,9 @@ TECA_PY_DYNAMIC_VARIANT_ARRAY_CAST(unsigned long long, unsigned_long_long)
                 }
                 return list;
                 )
-            else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+            else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
                 teca_metadata, varr.get(),
-                TT *varrt = static_cast<TT*>(varr.get());
+                const TT *varrt = static_cast<const TT*>(varr.get());
                 PyObject *list = PyList_New(n_elem);
                 for (size_t i = 0; i < n_elem; ++i)
                 {

--- a/python/teca_py_data.i
+++ b/python/teca_py_data.i
@@ -433,8 +433,7 @@ TECA_PY_CONST_CAST(teca_table)
         // numpy scalars
         TECA_PY_ARRAY_SCALAR_DISPATCH(obj,
             ST val = teca_py_array::numpy_scalar_tt<ST>::value(obj);
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                col.get(),
+            VARIANT_ARRAY_DISPATCH(col.get(),
                 TT *arr = static_cast<TT*>(col.get());
                 arr->set(r, val);
                 return Py_None;
@@ -444,9 +443,7 @@ TECA_PY_CONST_CAST(teca_table)
         TECA_PY_OBJECT_DISPATCH_NUM(obj,
             teca_py_object::cpp_tt<OT>::type val
                 = teca_py_object::cpp_tt<OT>::value(obj);
-            TEMPLATE_DISPATCH(
-                teca_variant_array_impl,
-                col.get(),
+            VARIANT_ARRAY_DISPATCH(col.get(),
                 TT *arr = static_cast<TT*>(col.get());
                 arr->set(r, val);
                 return Py_None;
@@ -455,10 +452,7 @@ TECA_PY_CONST_CAST(teca_table)
         TECA_PY_OBJECT_DISPATCH_STR(obj,
             teca_py_object::cpp_tt<OT>::type val
                 = teca_py_object::cpp_tt<OT>::value(obj);
-            TEMPLATE_DISPATCH_CASE(
-                teca_variant_array_impl,
-                std::string,
-                col.get(),
+            VARIANT_ARRAY_DISPATCH_CASE(std::string, col.get(),
                 TT *arr = static_cast<TT*>(col.get());
                 arr->set(r, val);
                 return Py_None;
@@ -506,15 +500,12 @@ TECA_PY_CONST_CAST(teca_table)
         }
 
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            col.get(),
+        VARIANT_ARRAY_DISPATCH(col.get(),
             TT *arr = static_cast<TT*>(col.get());
             return reinterpret_cast<PyObject*>(
                 teca_py_object::py_tt<NT>::new_object(arr->get(r)));
             )
-        TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-            std::string,
-            col.get(),
+        VARIANT_ARRAY_DISPATCH_CASE(std::string, col.get(),
             TT *arr = static_cast<TT*>(col.get());
             return reinterpret_cast<PyObject*>(
                 teca_py_object::py_tt<NT>::new_object(arr->get(r)));
@@ -729,8 +720,7 @@ TECA_PY_CONST_CAST(teca_table)
             p_teca_variant_array tmp =
                 teca_py_array_interface::new_variant_array(obj);
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                tmp.get(),
+            VARIANT_ARRAY_DISPATCH(tmp.get(),
 
                 TT *ttmp = static_cast<TT*>(tmp.get());
 

--- a/python/teca_py_iterator.h
+++ b/python/teca_py_iterator.h
@@ -99,7 +99,7 @@ bool append(teca_variant_array *va, PyObject *obj)
         return false;
 
     // append numeric types
-    TEMPLATE_DISPATCH(teca_variant_array_impl, va,
+    VARIANT_ARRAY_DISPATCH(va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_ITERATOR_DISPATCH_NUM(obj,
             PyObject *iter = PyObject_GetIter(obj);
@@ -115,7 +115,7 @@ bool append(teca_variant_array *va, PyObject *obj)
         )
 
     // append strings
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         std::string, va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_ITERATOR_DISPATCH_STR(obj,
@@ -144,7 +144,7 @@ bool copy(teca_variant_array *va, PyObject *obj)
         return false;
 
     // copy numeric types
-    TEMPLATE_DISPATCH(teca_variant_array_impl, va,
+    VARIANT_ARRAY_DISPATCH(va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_ITERATOR_DISPATCH_NUM(obj,
             vat->clear();
@@ -161,7 +161,7 @@ bool copy(teca_variant_array *va, PyObject *obj)
         )
 
     // copy strings
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         std::string, va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_ITERATOR_DISPATCH_STR(obj,

--- a/python/teca_py_object.h
+++ b/python/teca_py_object.h
@@ -195,7 +195,7 @@ p_teca_variant_array new_variant_array(PyObject *obj)
 /// Copies values from the object into the variant array.
 bool copy(teca_variant_array *varr, PyObject *obj)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+    VARIANT_ARRAY_DISPATCH(varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_NUM(obj,
             varrt->resize(1);
@@ -203,7 +203,7 @@ bool copy(teca_variant_array *varr, PyObject *obj)
             return true;
             )
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         std::string, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_STR(obj,
@@ -212,7 +212,7 @@ bool copy(teca_variant_array *varr, PyObject *obj)
             return true;
             )
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         teca_metadata, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_MD(obj,
@@ -228,14 +228,14 @@ bool copy(teca_variant_array *varr, PyObject *obj)
 /// Sets the i'th element of the variant array to the value of the object.
 bool set(teca_variant_array *varr, unsigned long i, PyObject *obj)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+    VARIANT_ARRAY_DISPATCH(varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_NUM(obj,
             varrt->set(i, cpp_tt<OT>::value(obj));
             return true;
             )
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         std::string, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_STR(obj,
@@ -243,7 +243,7 @@ bool set(teca_variant_array *varr, unsigned long i, PyObject *obj)
             return true;
             )
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         teca_metadata, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_MD(obj,
@@ -258,14 +258,14 @@ bool set(teca_variant_array *varr, unsigned long i, PyObject *obj)
 /// Appends values from the object at the end of the variant array.
 bool append(teca_variant_array *varr, PyObject *obj)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl, varr,
+    VARIANT_ARRAY_DISPATCH(varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_NUM(obj,
             varrt->append(static_cast<NT>(cpp_tt<OT>::value(obj)));
             return true;
             )
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         std::string, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_STR(obj,
@@ -273,7 +273,7 @@ bool append(teca_variant_array *varr, PyObject *obj)
             return true;
             )
          )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
+    else VARIANT_ARRAY_DISPATCH_CASE(
         teca_metadata, varr,
         TT *varrt = static_cast<TT*>(varr);
         TECA_PY_OBJECT_DISPATCH_MD(obj,

--- a/python/teca_py_sequence.h
+++ b/python/teca_py_sequence.h
@@ -94,7 +94,7 @@ bool append(teca_variant_array *va, PyObject *seq)
         return true;
 
     // append number objects
-    TEMPLATE_DISPATCH(teca_variant_array_impl, va,
+    VARIANT_ARRAY_DISPATCH(va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_SEQUENCE_DISPATCH_NUM(seq,
             for (long i = 0; i < n_items; ++i)
@@ -106,8 +106,7 @@ bool append(teca_variant_array *va, PyObject *seq)
             )
         )
     // append strings
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-        std::string, va,
+    else VARIANT_ARRAY_DISPATCH_CASE(std::string, va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_SEQUENCE_DISPATCH_STR(seq,
             for (long i = 0; i < n_items; ++i)
@@ -137,7 +136,7 @@ bool copy(teca_variant_array *va, PyObject *seq)
         return true;
 
     // copy numeric types
-    TEMPLATE_DISPATCH(teca_variant_array_impl, va,
+    VARIANT_ARRAY_DISPATCH(va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_SEQUENCE_DISPATCH_NUM(seq,
             vat->resize(n_items);
@@ -151,8 +150,7 @@ bool copy(teca_variant_array *va, PyObject *seq)
         )
 
     // copy strings
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-        std::string, va,
+    else VARIANT_ARRAY_DISPATCH_CASE(std::string, va,
         TT *vat = static_cast<TT*>(va);
         TECA_PY_SEQUENCE_DISPATCH_STR(seq,
             vat->resize(n_items);
@@ -220,12 +218,10 @@ PyObject *new_object(const teca_variant_array_impl<NT> *va)
 TECA_EXPORT
 PyObject *new_object(const_p_teca_variant_array va)
 {
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        va.get(),
+    VARIANT_ARRAY_DISPATCH(va.get(),
         return teca_py_sequence::new_object(static_cast<const TT*>(va.get()));
         )
-    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
-        std::string, va.get(),
+    else VARIANT_ARRAY_DISPATCH_CASE(std::string, va.get(),
         return teca_py_sequence::new_object(static_cast<const TT*>(va.get()));
         )
 

--- a/python/teca_py_sequence.h
+++ b/python/teca_py_sequence.h
@@ -220,11 +220,11 @@ PyObject *new_object(const teca_variant_array_impl<NT> *va)
 TECA_EXPORT
 PyObject *new_object(const_p_teca_variant_array va)
 {
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         va.get(),
         return teca_py_sequence::new_object(static_cast<const TT*>(va.get()));
         )
-    else TEMPLATE_DISPATCH_CASE(const teca_variant_array_impl,
+    else TEMPLATE_DISPATCH_CASE(teca_variant_array_impl,
         std::string, va.get(),
         return teca_py_sequence::new_object(static_cast<const TT*>(va.get()));
         )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -349,7 +349,7 @@ teca_add_test(test_streaming_reduce_threads
 teca_add_test(test_streaming_reduce_mpi_threads
     LIBS teca_core teca_data teca_io teca_alg ${teca_test_link}
     COMMAND ${MPIEXEC} -n ${HALF_TEST_CORES} test_descriptive_statistics 0
-    "${TECA_DATA_ROOT}/prw_hus_day_MRI-CGCM3.*\\.nc"
+    "${TECA_DATA_ROOT}/prw_hus_day_MRI-CGCM3.historical_r1i1p1_19500101-19501231\\.nc"
     "${TECA_DATA_ROOT}/test_streaming_reduce.bin" 0 -1 4 prw
     FEATURES ${TECA_HAS_UDUNITS} ${TECA_HAS_NETCDF} ${TEST_MPI_THREADS}
     REQ_TECA_DATA)
@@ -542,7 +542,8 @@ teca_add_test(test_event_filter
 teca_add_test(test_binary_segmentation
     SOURCES test_binary_segmentation.cpp
     LIBS teca_core teca_data teca_io teca_alg ${teca_test_link}
-    COMMAND test_binary_segmentation "${TECA_DATA_ROOT}/prw_hus_day_MRI.*\\.nc$"
+    COMMAND test_binary_segmentation
+    "${TECA_DATA_ROOT}/prw_hus_day_MRI-CGCM3.historical_r1i1p1_19500101-19501231\\.nc"
     prw 50 75 "prw_segmentation_50-75_%t%.%e%"
     FEATURES ${TECA_HAS_NETCDF}
     REQ_TECA_DATA)

--- a/test/test_2d_component_area.cpp
+++ b/test/test_2d_component_area.cpp
@@ -51,13 +51,13 @@ struct tile_labeler
 
         memset(pcc,0, nxy*sizeof(int));
 
-         TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
              x.get(),
 
-             auto spx = std::static_pointer_cast<TT>(x)->get_cpu_accessible();
+             auto spx = std::static_pointer_cast<const TT>(x)->get_cpu_accessible();
              const NT *px = spx.get();
 
-             auto spy = std::static_pointer_cast<TT>(y)->get_cpu_accessible();
+             auto spy = std::static_pointer_cast<const TT>(y)->get_cpu_accessible();
              const NT *py = spy.get();
 
              for (unsigned long j = 0; j < ny; ++j)

--- a/test/test_2d_component_area.cpp
+++ b/test/test_2d_component_area.cpp
@@ -12,6 +12,7 @@
 #include "teca_cartesian_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_array_attributes.h"
 
 #define _USE_MATH_DEFINES
@@ -21,6 +22,7 @@
 #include <string>
 
 using namespace std;
+using namespace teca_variant_array_util;
 
 // genrates a field with nxl by nyl tiles, each having a unique integer id
 struct tile_labeler
@@ -45,20 +47,13 @@ struct tile_labeler
         unsigned long ny = y->size();
         unsigned long nxy = nx*ny;
 
-        p_teca_int_array cc = teca_int_array::New(nxy);
-        auto spcc = cc->get_cpu_accessible();
-        int *pcc = spcc.get();
-
-        memset(pcc,0, nxy*sizeof(int));
+        auto [cc, pcc] = ::New<teca_int_array>(nxy, int(0));
 
          TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
              x.get(),
 
-             auto spx = std::static_pointer_cast<const TT>(x)->get_cpu_accessible();
-             const NT *px = spx.get();
-
-             auto spy = std::static_pointer_cast<const TT>(y)->get_cpu_accessible();
-             const NT *py = spy.get();
+             assert_type<TT>(y);
+             auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
 
              for (unsigned long j = 0; j < ny; ++j)
              {

--- a/test/test_2d_component_area.cpp
+++ b/test/test_2d_component_area.cpp
@@ -49,8 +49,7 @@ struct tile_labeler
 
         auto [cc, pcc] = ::New<teca_int_array>(nxy, int(0));
 
-         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-             x.get(),
+         VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
              assert_type<TT>(y);
              auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);

--- a/test/test_array/array.cxx
+++ b/test/test_array/array.cxx
@@ -57,7 +57,7 @@ p_array array::new_cpu_accessible()
 // --------------------------------------------------------------------------
 p_array array::new_cuda_accessible()
 {
-    return array::New(allocator::cuda);
+    return array::New(allocator::cuda_async);
 }
 
 // --------------------------------------------------------------------------

--- a/test/test_array_collection_cuda_access.cpp
+++ b/test/test_array_collection_cuda_access.cpp
@@ -414,15 +414,15 @@ int main(int, char **)
             p_teca_variant_array cuda_out;
             p_teca_variant_array cpu_out;
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 cuda_in.get(),
 
                 // mult data already acccessible in CUDA
-                auto pcuda_in = std::dynamic_pointer_cast<TT>(cuda_in);
+                auto pcuda_in = std::dynamic_pointer_cast<const TT>(cuda_in);
                 cuda_out = multiply_scalar_cuda(pcuda_in, mult_value);
 
                 // mult data accessible in the CPU
-                auto pcpu_in = std::dynamic_pointer_cast<TT>(cpu_in);
+                auto pcpu_in = std::dynamic_pointer_cast<const TT>(cpu_in);
                 auto tmp = multiply_scalar_cuda(pcpu_in, mult_value);
 
                 // move back to the CPU
@@ -465,11 +465,11 @@ int main(int, char **)
             const_p_teca_variant_array cpu_in = col_in->get("cpu_array");
 
 
-            TEMPLATE_DISPATCH(const teca_variant_array_impl,
+            TEMPLATE_DISPATCH(teca_variant_array_impl,
                 cuda_in.get(),
 
                 // compare data already acccessible in CUDA
-                auto pcuda_in = std::dynamic_pointer_cast<TT>(cuda_in);
+                auto pcuda_in = std::dynamic_pointer_cast<const TT>(cuda_in);
                 if (compare_int(pcuda_in, comp_value))
                 {
                     TECA_ERROR("The CUDA array was not equal to the expected"
@@ -480,7 +480,7 @@ int main(int, char **)
                 }
 
                 // compare data already acccessible in CPU
-                auto pcpu_in = std::dynamic_pointer_cast<TT>(cpu_in);
+                auto pcpu_in = std::dynamic_pointer_cast<const TT>(cpu_in);
                 if (compare_int(pcpu_in, comp_value))
                 {
                     TECA_ERROR("The CPU array was not equal to the expected"

--- a/test/test_array_collection_cuda_access.cpp
+++ b/test/test_array_collection_cuda_access.cpp
@@ -333,8 +333,7 @@ int main(int, char **)
             p_teca_variant_array cuda_out;
             p_teca_variant_array cpu_out;
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                add_val.get(),
+            VARIANT_ARRAY_DISPATCH(add_val.get(),
 
                 // add data already acccessible in CUDA
                 auto pcuda_in = std::dynamic_pointer_cast<const TT>(cuda_in);
@@ -391,8 +390,7 @@ int main(int, char **)
             p_teca_variant_array cuda_out;
             p_teca_variant_array cpu_out;
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                cuda_in.get(),
+            VARIANT_ARRAY_DISPATCH(cuda_in.get(),
 
                 // mult data already acccessible in CUDA
                 auto pcuda_in = std::dynamic_pointer_cast<const TT>(cuda_in);
@@ -442,8 +440,7 @@ int main(int, char **)
             const_p_teca_variant_array cpu_in = col_in->get("cpu_array");
 
 
-            TEMPLATE_DISPATCH(teca_variant_array_impl,
-                cuda_in.get(),
+            VARIANT_ARRAY_DISPATCH(cuda_in.get(),
 
                 // compare data already acccessible in CUDA
                 auto pcuda_in = std::dynamic_pointer_cast<const TT>(cuda_in);

--- a/test/test_cartesian_mesh_coordinate_transform.cpp
+++ b/test/test_cartesian_mesh_coordinate_transform.cpp
@@ -11,9 +11,12 @@
 #include "teca_metadata.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <cmath>
 #include <functional>
+
+using namespace teca_variant_array_util;
 
 
 // generates f = k*nxy + j*nx + i
@@ -34,10 +37,7 @@ struct index_function
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             f.get(),
-
-            auto spf = dynamic_cast<TT*>(f.get())->get_cpu_accessible();
-            NT *pf = spf.get();
-
+            auto [pf] = data<TT>(f);
             for (size_t i = 0; i < nxyz; ++i)
             {
                 pf[i] = i;

--- a/test/test_cartesian_mesh_coordinate_transform.cpp
+++ b/test/test_cartesian_mesh_coordinate_transform.cpp
@@ -35,8 +35,7 @@ struct index_function
 
         p_teca_variant_array f = x->new_instance(nxyz);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            f.get(),
+        VARIANT_ARRAY_DISPATCH(f.get(),
             auto [pf] = data<TT>(f);
             for (size_t i = 0; i < nxyz; ++i)
             {

--- a/test/test_cf_writer_bad_type.cpp
+++ b/test/test_cf_writer_bad_type.cpp
@@ -1,12 +1,15 @@
 #include "teca_cartesian_mesh_source.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_cartesian_mesh.h"
 #include "teca_array_collection.h"
 #include "teca_programmable_algorithm.h"
 #include "teca_cf_writer.h"
 #include "teca_array_attributes.h"
 #include "teca_index_executive.h"
+
+using namespace teca_variant_array_util;
 
 // this function returns a double array initialized with time
 // values.
@@ -20,10 +23,7 @@ p_teca_variant_array generate_mesh_time(const const_p_teca_variant_array &x,
 
     size_t nxyz = nx*ny*nz;
 
-    p_teca_double_array da = teca_double_array::New(nxyz);
-
-    auto spda = da->get_cpu_accessible();
-    double *pda = spda.get();
+    auto [da, pda] = ::New<teca_double_array>(nxyz);
 
     for (size_t i = 0; i < nxyz; ++i)
         pda[i] = t;

--- a/test/test_cf_writer_collective.cpp
+++ b/test/test_cf_writer_collective.cpp
@@ -2,6 +2,7 @@
 #include "teca_metadata.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_array_attributes.h"
 #include "teca_algorithm.h"
 #include "teca_cartesian_mesh_source.h"
@@ -27,6 +28,8 @@
 
 class generate_test_data;
 using p_generate_test_data = std::shared_ptr<generate_test_data>;
+
+using namespace teca_variant_array_util;
 
 // This class generates point centered data according to the function:
 //
@@ -187,9 +190,9 @@ const_p_teca_dataset generate_test_data::execute(unsigned int port,
     const_p_teca_variant_array x_in = mesh_in->get_x_coordinates();
     const_p_teca_variant_array y_in = mesh_in->get_y_coordinates();
 
-    p_teca_double_array x = teca_double_array::New(nx);
-    p_teca_double_array y = teca_double_array::New(ny);
-    p_teca_double_array z = teca_double_array::New(nxy);
+    auto [x, px] = ::New<teca_double_array>(nx);
+    auto [y, py] = ::New<teca_double_array>(ny);
+    auto [z, pz] = ::New<teca_double_array>(nxy);
 
     double rad_per_deg = M_PI/180.0;
 
@@ -198,20 +201,10 @@ const_p_teca_dataset generate_test_data::execute(unsigned int port,
     TEMPLATE_DISPATCH(teca_variant_array_impl,
         x_in.get(),
 
-        auto spx_in = std::static_pointer_cast<const TT>(x_in)->get_cpu_accessible();
-        const NT *px_in = spx_in.get();
+        assert_type<CTT>(y_in);
 
-        auto spy_in = std::static_pointer_cast<const TT>(y_in)->get_cpu_accessible();
-        const NT *py_in = spy_in.get();
-
-        auto spx = x->get_cpu_accessible();
-        double *px = spx.get();
-
-        auto spy = y->get_cpu_accessible();
-        double *py = spy.get();
-
-        auto spz = z->get_cpu_accessible();
-        double *pz = spz.get();
+        auto [spx_in, px_in,
+              spy_in, py_in] = get_cpu_accessible<CTT>(x_in, y_in);
 
         // deg to rad
         for (unsigned long i = 0; i < nx; ++i)
@@ -237,15 +230,11 @@ const_p_teca_dataset generate_test_data::execute(unsigned int port,
         )
 
     // package up counts and thredshold
-    p_teca_int_array counts = teca_int_array::New(2);
-    auto sp_counts = counts->get_cpu_accessible();
-    int *p_counts = sp_counts.get();
+    auto [counts, p_counts] = ::New<teca_int_array>(2);
     p_counts[0] = n_above;
     p_counts[1] = nxy - n_above;
 
-    p_teca_double_array z_threshold = teca_double_array::New(1);
-    auto sp_zt = z_threshold->get_cpu_accessible();
-    double *p_zt = sp_zt.get();
+    auto [z_threshold, p_zt] = ::New<teca_double_array>(1);
     p_zt[0] = this->threshold;
 
     // create the output and add in the arrays

--- a/test/test_cf_writer_collective.cpp
+++ b/test/test_cf_writer_collective.cpp
@@ -198,8 +198,7 @@ const_p_teca_dataset generate_test_data::execute(unsigned int port,
 
     unsigned long n_above = 0;
 
-    TEMPLATE_DISPATCH(teca_variant_array_impl,
-        x_in.get(),
+    VARIANT_ARRAY_DISPATCH(x_in.get(),
 
         assert_type<CTT>(y_in);
 

--- a/test/test_cf_writer_collective.cpp
+++ b/test/test_cf_writer_collective.cpp
@@ -195,7 +195,7 @@ const_p_teca_dataset generate_test_data::execute(unsigned int port,
 
     unsigned long n_above = 0;
 
-    TEMPLATE_DISPATCH(const teca_variant_array_impl,
+    TEMPLATE_DISPATCH(teca_variant_array_impl,
         x_in.get(),
 
         auto spx_in = std::static_pointer_cast<const TT>(x_in)->get_cpu_accessible();

--- a/test/test_cf_writer_partitions.cpp
+++ b/test/test_cf_writer_partitions.cpp
@@ -43,8 +43,7 @@ struct fxyz
 
         p_teca_variant_array f = x->new_instance(nxyz);
 
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            x.get(),
+        VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
             assert_type<CTT>(y, z);
 

--- a/test/test_cf_writer_partitions.cpp
+++ b/test/test_cf_writer_partitions.cpp
@@ -10,10 +10,14 @@
 #include "teca_index_executive.h"
 #include "teca_array_attributes.h"
 #include "teca_mpi_manager.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <vector>
 #include <string>
 #include <iostream>
+
+using namespace teca_variant_array_util;
 
 // generates : f(x,y,z) = x - t; or f(x,y,z) = y; or f(x,y,z) = z depending on
 // the value of m_dir. this is used to generate a vector field whose magnitude
@@ -40,19 +44,12 @@ struct fxyz
         p_teca_variant_array f = x->new_instance(nxyz);
 
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            f.get(),
+            x.get(),
 
-            auto spf = dynamic_cast<TT*>(f.get())->get_cpu_accessible();
-            NT *pf = spf.get();
+            assert_type<CTT>(y, z);
 
-            auto spx = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-            const NT *px = spx.get();
-
-            auto spy = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-            const NT *py = spy.get();
-
-            auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            const NT *pz = spz.get();
+            auto [pf] = data<TT>(f);
+            auto [spx, px, spy, py, spz, pz] = get_cpu_accessible<CTT>(x, y, z);
 
             for (size_t k = 0; k < nz; ++k)
             {

--- a/test/test_component_area_filter.cpp
+++ b/test/test_component_area_filter.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
     size_t n_filtered = filtered_label_id.size();
     size_t n_labels_total = va->size();
 
-    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
+    NESTED_VARIANT_ARRAY_DISPATCH_I(
         va.get(), _LABEL,
         auto [splf, p_labels_filtered] = get_cpu_accessible<CTT_LABEL>(va);
         for (size_t i = 0; i < n_filtered; ++i)

--- a/test/test_component_area_filter.cpp
+++ b/test/test_component_area_filter.cpp
@@ -187,11 +187,11 @@ int main(int argc, char **argv)
     size_t n_filtered = filtered_label_id.size();
     size_t n_labels_total = va->size();
 
-    NESTED_TEMPLATE_DISPATCH_I(const teca_variant_array_impl,
+    NESTED_TEMPLATE_DISPATCH_I(teca_variant_array_impl,
         va.get(),
         _LABEL,
 
-        auto sp_labels_filtered = static_cast<TT_LABEL*>(va.get())->get_cpu_accessible();
+        auto sp_labels_filtered = static_cast<const TT_LABEL*>(va.get())->get_cpu_accessible();
         const NT_LABEL *p_labels_filtered = sp_labels_filtered.get();
 
         for (size_t i = 0; i < n_filtered; ++i)

--- a/test/test_integrated_vapor_transport.cpp
+++ b/test/test_integrated_vapor_transport.cpp
@@ -10,10 +10,13 @@
 #include "teca_system_interface.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 
 #include <cmath>
 #include <functional>
+
+using namespace teca_variant_array_util;
 
 
 // ivt = - \frac{1}{g} \int_{p_{sfc}}^{p_{top}} q \vec{v} dp
@@ -52,14 +55,12 @@ struct function_of_z
         size_t nz = z->size();
         size_t nxy = nx*ny;
 
-        p_teca_variant_array_impl<num_t> fz = teca_variant_array_impl<num_t>::New(nx*ny*nz);
-        auto spfz = fz->get_cpu_accessible();
-        num_t *pfz = spfz.get();
+        auto [fz, pfz] = New<teca_variant_array_impl<num_t>>(nx*ny*nz);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             fz.get(),
-            auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            const NT *pz = spz.get();
+            assert_type<CTT>(z);
+            auto [spz, pz] = get_cpu_accessible<CTT>(z);
             for (size_t k = 0; k < nz; ++k)
             {
                 for (size_t j = 0; j < ny; ++j)

--- a/test/test_integrated_vapor_transport.cpp
+++ b/test/test_integrated_vapor_transport.cpp
@@ -57,8 +57,7 @@ struct function_of_z
 
         auto [fz, pfz] = New<teca_variant_array_impl<num_t>>(nx*ny*nz);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            fz.get(),
+        VARIANT_ARRAY_DISPATCH(fz.get(),
             assert_type<CTT>(z);
             auto [spz, pz] = get_cpu_accessible<CTT>(z);
             for (size_t k = 0; k < nz; ++k)

--- a/test/test_integrated_water_vapor.cpp
+++ b/test/test_integrated_water_vapor.cpp
@@ -10,11 +10,12 @@
 #include "teca_system_interface.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
-
+#include "teca_variant_array_util.h"
 
 #include <cmath>
 #include <functional>
 
+using namespace teca_variant_array_util;
 
 // iwv = - \frac{1}{g} \int_{p_{sfc}}^{p_{top}} q dp
 //
@@ -28,7 +29,7 @@
 // iwv = exp(p) |_{p_{sfc}}^{p_{top}}
 //
 
-template <typename num_t>
+template <typename num_t, typename array_t = teca_variant_array_impl<num_t>>
 struct function_of_z
 {
     using f_type = std::function<num_t(num_t)>;
@@ -47,16 +48,11 @@ struct function_of_z
         size_t nz = z->size();
         size_t nxy = nx*ny;
 
-        p_teca_variant_array_impl<num_t> fz = teca_variant_array_impl<num_t>::New(nx*ny*nz);
-        auto spfz = fz->get_cpu_accessible();
-        num_t *pfz = spfz.get();
+        auto [fz, pfz] = ::New<array_t>(nx*ny*nz);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
-            fz.get(),
-
-            auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            const NT *pz = spz.get();
-
+            z.get(),
+            auto [spz, pz] = get_cpu_accessible<CTT>(z);
             for (size_t k = 0; k < nz; ++k)
             {
                 for (size_t j = 0; j < ny; ++j)

--- a/test/test_integrated_water_vapor.cpp
+++ b/test/test_integrated_water_vapor.cpp
@@ -50,8 +50,7 @@ struct function_of_z
 
         auto [fz, pfz] = ::New<array_t>(nx*ny*nz);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            z.get(),
+        VARIANT_ARRAY_DISPATCH(z.get(),
             auto [spz, pz] = get_cpu_accessible<CTT>(z);
             for (size_t k = 0; k < nz; ++k)
             {

--- a/test/test_l2_norm.cpp
+++ b/test/test_l2_norm.cpp
@@ -39,8 +39,7 @@ struct fxyz
 
         p_teca_variant_array f = x->new_instance(nxyz);
 
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            f.get(),
+        VARIANT_ARRAY_DISPATCH_FP(f.get(),
 
             assert_type<CTT>(y, z);
 

--- a/test/test_l2_norm.cpp
+++ b/test/test_l2_norm.cpp
@@ -9,10 +9,14 @@
 #include "teca_system_interface.h"
 #include "teca_index_executive.h"
 #include "teca_array_attributes.h"
+#include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <vector>
 #include <string>
 #include <iostream>
+
+using namespace teca_variant_array_util;
 
 // generates : f(x,y,z) = x - t; or f(x,y,z) = y; or f(x,y,z) = z depending on
 // the value of m_dir. this is used to generate a vector field whose magnitude
@@ -38,17 +42,10 @@ struct fxyz
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             f.get(),
 
-            auto spf = dynamic_cast<TT*>(f.get())->get_cpu_accessible();
-            NT *pf = spf.get();
+            assert_type<CTT>(y, z);
 
-            auto spx = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-            const NT *px = spx.get();
-
-            auto spy = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-            const NT *py = spy.get();
-
-            auto spz = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            const NT *pz = spz.get();
+            auto [pf] = data<TT>(f);
+            auto [spx, px, spy, py, spz, pz] = get_cpu_accessible<CTT>(x, y, z);
 
             for (size_t k = 0; k < nz; ++k)
             {

--- a/test/test_latitude_damper.cpp
+++ b/test/test_latitude_damper.cpp
@@ -8,6 +8,7 @@
 #include "teca_cartesian_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_dataset_source.h"
 
 #define _USE_MATH_DEFINES
@@ -16,6 +17,7 @@
 #include <string>
 
 using namespace std;
+using namespace teca_variant_array_util;
 
 
 bool isequal(double a, double b, double epsilon)
@@ -41,35 +43,23 @@ int main(int argc, char **argv)
     // allocate a mesh
     // coordinate axes
     using coord_t = double;
+    using array_t = teca_variant_array_impl<double>;
+
     coord_t dx = coord_t(360.)/coord_t(nx - 1);
-    p_teca_variant_array_impl<coord_t> x = teca_variant_array_impl<coord_t>::New(nx);
-    auto spx = x->get_cpu_accessible();
-    coord_t *px = spx.get();
+    auto [x, px] = ::New<array_t>(nx);
     for (unsigned long i = 0; i < nx; ++i)
         px[i] = i*dx;
 
     coord_t dy = coord_t(180.)/coord_t(ny - 1);
-    p_teca_variant_array_impl<coord_t> y = teca_variant_array_impl<coord_t>::New(ny);
-    auto spy = y->get_cpu_accessible();
-    coord_t *py = spy.get();
+    auto [y, py] = ::New<array_t>(ny);
     for (unsigned long i = 0; i < ny; ++i)
         py[i] = coord_t(-90.) + i*dy;
 
-    p_teca_variant_array_impl<coord_t> z = teca_variant_array_impl<coord_t>::New(1);
-    z->set(0, 0.f);
-
-    p_teca_variant_array_impl<coord_t> t = teca_variant_array_impl<coord_t>::New(1);
-    t->set(0, 1.f);
+    auto z = array_t::New(1, coord_t(0));
+    auto t = array_t::New(1, coord_t(1));
 
     unsigned long nxy = nx * ny;
-    p_teca_double_array ones_grid = teca_double_array::New(nxy);
-    auto sp_ones_grid = ones_grid->get_cpu_accessible();
-    double *p_ones_grid = sp_ones_grid.get();
-
-    for (unsigned int i = 0; i < nxy; ++i)
-    {
-        p_ones_grid[i] = 1;
-    }
+    p_teca_double_array ones_grid = teca_double_array::New(nxy, double(1));
 
     unsigned long wext[] = {0, nx - 1, 0, ny - 1, 0, 0};
 
@@ -121,11 +111,7 @@ int main(int argc, char **argv)
     const_p_teca_cartesian_mesh cds = std::dynamic_pointer_cast<const teca_cartesian_mesh>(ds);
     const_p_teca_variant_array va = cds->get_point_arrays()->get("ones_grid_damped");
 
-    using TT = teca_variant_array_impl<double>;
-    using NT = double;
-
-    auto sp_damped_array = dynamic_cast<const TT*>(va.get())->get_cpu_accessible();
-    const NT *p_damped_array = sp_damped_array.get();
+    auto [spda, p_damped_array] = get_cpu_accessible<const array_t>(va);
 
     // find lat index where scalar should be half
     long hwhm_index = -1;
@@ -146,7 +132,7 @@ int main(int argc, char **argv)
     }
 
     // check that it is half there
-    NT test_val = p_damped_array[hwhm_index*nx];
+    coord_t test_val = p_damped_array[hwhm_index*nx];
     if (!isequal(test_val, 0.5, 1e-7))
     {
         TECA_ERROR("Value " << test_val << " at index " << hwhm_index << " is not 0.5")

--- a/test/test_normalize_coordinates.cpp
+++ b/test/test_normalize_coordinates.cpp
@@ -52,16 +52,16 @@ struct distance_field
         auto spd = d->get_cpu_accessible();
         double *pd = spd.get();
 
-        TEMPLATE_DISPATCH_FP(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             x.get(),
 
-            auto spx = std::static_pointer_cast<TT>(x)->get_cpu_accessible();
+            auto spx = std::static_pointer_cast<const TT>(x)->get_cpu_accessible();
             const NT *px = spx.get();
 
-            auto spy = std::static_pointer_cast<TT>(y)->get_cpu_accessible();
+            auto spy = std::static_pointer_cast<const TT>(y)->get_cpu_accessible();
             const NT *py = spy.get();
 
-            auto spz = std::static_pointer_cast<TT>(z)->get_cpu_accessible();
+            auto spz = std::static_pointer_cast<const TT>(z)->get_cpu_accessible();
             const NT *pz = spz.get();
 
             for (unsigned long k = 0; k < nz; ++k)

--- a/test/test_normalize_coordinates.cpp
+++ b/test/test_normalize_coordinates.cpp
@@ -11,6 +11,7 @@
 #include "teca_cartesian_mesh.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_file_util.h"
 #include "teca_system_util.h"
 
@@ -21,6 +22,7 @@
 #include <string>
 
 using namespace std;
+using namespace teca_variant_array_util;
 
 // genrates a distance field centered on x0,y0,z0
 struct distance_field
@@ -48,21 +50,13 @@ struct distance_field
         unsigned long nz = z->size();
         unsigned long nxy = nx*ny;
 
-        p_teca_double_array d = teca_double_array::New(nxy*nz);
-        auto spd = d->get_cpu_accessible();
-        double *pd = spd.get();
+        auto [d, pd] = ::New<teca_double_array>(nxy*nz);
 
         TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
             x.get(),
 
-            auto spx = std::static_pointer_cast<const TT>(x)->get_cpu_accessible();
-            const NT *px = spx.get();
-
-            auto spy = std::static_pointer_cast<const TT>(y)->get_cpu_accessible();
-            const NT *py = spy.get();
-
-            auto spz = std::static_pointer_cast<const TT>(z)->get_cpu_accessible();
-            const NT *pz = spz.get();
+            assert_type<TT>(y,z);
+            auto [spx, px, spy, py, spz, pz] = get_cpu_accessible<CTT>(x, y, z);
 
             for (unsigned long k = 0; k < nz; ++k)
             {

--- a/test/test_normalize_coordinates.cpp
+++ b/test/test_normalize_coordinates.cpp
@@ -52,8 +52,7 @@ struct distance_field
 
         auto [d, pd] = ::New<teca_double_array>(nxy*nz);
 
-        TEMPLATE_DISPATCH_FP(teca_variant_array_impl,
-            x.get(),
+        VARIANT_ARRAY_DISPATCH_FP(x.get(),
 
             assert_type<TT>(y,z);
             auto [spx, px, spy, py, spz, pz] = get_cpu_accessible<CTT>(x, y, z);

--- a/test/test_rename_variables.cpp
+++ b/test/test_rename_variables.cpp
@@ -11,9 +11,12 @@
 #include "teca_metadata.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <cmath>
 #include <functional>
+
+using namespace teca_variant_array_util;
 
 
 // generates f = k*nxy + j*nx + i
@@ -34,8 +37,7 @@ struct index_function
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             f.get(),
-            auto spf = dynamic_cast<TT*>(f.get())->get_cpu_accessible();
-            NT *pf = spf.get();
+            auto [pf] = data<TT>(f);
             for (size_t i = 0; i < nxyz; ++i)
             {
                 pf[i] = i;

--- a/test/test_rename_variables.cpp
+++ b/test/test_rename_variables.cpp
@@ -35,8 +35,7 @@ struct index_function
 
         p_teca_variant_array f = x->new_instance(nxyz);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            f.get(),
+        VARIANT_ARRAY_DISPATCH(f.get(),
             auto [pf] = data<TT>(f);
             for (size_t i = 0; i < nxyz; ++i)
             {

--- a/test/test_unpack_data.cpp
+++ b/test/test_unpack_data.cpp
@@ -69,7 +69,7 @@ struct packed_data
 
         // compute
         // f = cos(z)*sin(x+t)*sin(y+t)
-        TEMPLATE_DISPATCH(const teca_variant_array_impl,
+        TEMPLATE_DISPATCH(teca_variant_array_impl,
             x.get(),
 
             auto sp_x = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();

--- a/test/test_unpack_data.cpp
+++ b/test/test_unpack_data.cpp
@@ -70,8 +70,7 @@ struct packed_data
 
         // compute
         // f = cos(z)*sin(x+t)*sin(y+t)
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            x.get(),
+        VARIANT_ARRAY_DISPATCH(x.get(),
 
             assert_type<CTT>(y, z);
 

--- a/test/test_unpack_data.cpp
+++ b/test/test_unpack_data.cpp
@@ -1,5 +1,6 @@
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_cartesian_mesh_source.h"
 #include "teca_valid_value_mask.h"
 #include "teca_unpack_data.h"
@@ -12,6 +13,8 @@
 #include "teca_file_util.h"
 
 #include "math.h"
+
+using namespace teca_variant_array_util;
 
 
 // compute data to pack
@@ -63,23 +66,18 @@ struct packed_data
         size_t nxyz = nxy*nz;
 
         // allocate f
-        p_teca_float_array f = teca_float_array::New(nxyz);
-        auto sp_f = f->get_cpu_accessible();
-        float *p_f = sp_f.get();
+        auto [f, p_f] = ::New<teca_float_array>(nxyz);
 
         // compute
         // f = cos(z)*sin(x+t)*sin(y+t)
         TEMPLATE_DISPATCH(teca_variant_array_impl,
             x.get(),
 
-            auto sp_x = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-            const NT *p_x = sp_x.get();
+            assert_type<CTT>(y, z);
 
-            auto sp_y = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-            const NT *p_y = sp_y.get();
-
-            auto sp_z = dynamic_cast<const TT*>(z.get())->get_cpu_accessible();
-            const NT *p_z = sp_z.get();
+            auto [sp_x, p_x,
+                  sp_y, p_y,
+                  sp_z, p_z] = get_cpu_accessible<CTT>(x, y, z);
 
             for (size_t k = 0; k < nz; ++k)
             {
@@ -93,11 +91,8 @@ struct packed_data
             }
             )
 
-
         // allcate q
-        p_teca_unsigned_char_array q = teca_unsigned_char_array::New(nxyz);
-        auto sp_q = q->get_cpu_accessible();
-        unsigned char *p_q = sp_q.get();
+        auto [q, p_q] = ::New<teca_unsigned_char_array>(nxyz);
 
         // pack
         for (size_t i = 0; i < nxyz; ++i)

--- a/test/test_valid_value_mask.cpp
+++ b/test/test_valid_value_mask.cpp
@@ -38,8 +38,7 @@ struct cosx_cosy
 
         p_teca_variant_array f = x->new_instance(nxy);
 
-        TEMPLATE_DISPATCH(teca_variant_array_impl,
-            x.get(),
+        VARIANT_ARRAY_DISPATCH(x.get(),
             assert_type<CTT>(y);
             auto [pf] = data<TT>(f);
             auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);

--- a/test/test_valid_value_mask.cpp
+++ b/test/test_valid_value_mask.cpp
@@ -10,9 +10,12 @@
 #include "teca_system_interface.h"
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <cmath>
 #include <functional>
+
+using namespace teca_variant_array_util;
 
 // generates f = cos(x)*cos(y) where f >= m_threshold and m_fill otherwise
 struct cosx_cosy
@@ -36,17 +39,10 @@ struct cosx_cosy
         p_teca_variant_array f = x->new_instance(nxy);
 
         TEMPLATE_DISPATCH(teca_variant_array_impl,
-            f.get(),
-
-            auto spf = dynamic_cast<TT*>(f.get())->get_cpu_accessible();
-            NT *pf = spf.get();
-
-            auto spx = dynamic_cast<const TT*>(x.get())->get_cpu_accessible();
-            const NT *px = spx.get();
-
-            auto spy = dynamic_cast<const TT*>(y.get())->get_cpu_accessible();
-            const NT *py = spy.get();
-
+            x.get(),
+            assert_type<CTT>(y);
+            auto [pf] = data<TT>(f);
+            auto [spx, px, spy, py] = get_cpu_accessible<CTT>(x, y);
             for (size_t j = 0; j < ny; ++j)
             {
                 for (size_t i = 0; i < nx; ++i)

--- a/test/test_variant_array_cpu_access.cpp
+++ b/test/test_variant_array_cpu_access.cpp
@@ -1,7 +1,14 @@
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 
 #include <iostream>
+#include <tuple>
+#include <memory>
+
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
+
 
 // **************************************************************************
 template<typename NT>
@@ -17,15 +24,10 @@ void initialize_cpu(NT *data, double val, size_t n_vals)
 template <typename NT>
 p_teca_variant_array_impl<NT> initialize_cpu(size_t n_vals, const NT &val)
 {
-    // allocate the memory
     using TT = teca_variant_array_impl<NT>;
-    using PTT = std::shared_ptr<TT>;
 
-    PTT ao  = TT::New(teca_variant_array::allocator::malloc);
-    ao->resize(n_vals);
-
-    auto spao = ao->get_cpu_accessible();
-    NT *pao = spao.get();
+    // allocate the memory
+    auto [ao, pao] = ::New<TT>(n_vals, allocator::malloc);
 
     // initialize the data
     initialize_cpu(pao, val, n_vals);
@@ -62,25 +64,15 @@ p_teca_variant_array_impl<NT1> add_cpu(
     const const_p_teca_variant_array_impl<NT2> &a2)
 {
     using TT1 = teca_variant_array_impl<NT1>;
-    using PTT1 = std::shared_ptr<TT1>;
-
     using TT2 = teca_variant_array_impl<NT2>;
-    using PTT2 = std::shared_ptr<TT2>;
 
     // get the inputs
-    auto spa1 = a1->get_cpu_accessible();
-    const NT1 *pa1 = spa1.get();
-
-    auto spa2 = a2->get_cpu_accessible();
-    const NT2 *pa2 = spa2.get();
+    auto [spa1, pa1] = get_cpu_accessible<const TT1>(a1);
+    auto [spa2, pa2] = get_cpu_accessible<const TT2>(a2);
 
     // allocate the memory
     size_t n_vals = a1->size();
-    auto ao = TT1::New(teca_variant_array::allocator::malloc);
-    ao->resize(n_vals, NT1(0));
-
-    auto spao = ao->get_cpu_accessible();
-    NT1 *pao = spao.get();
+    auto [ao, pao] = ::New<TT1>(n_vals, NT1(0), allocator::malloc);
 
     // initialize the data
     add_cpu(pao, pa1, pa2, n_vals);
@@ -118,22 +110,13 @@ p_teca_variant_array_impl<NT1> multiply_scalar_cpu(
     const const_p_teca_variant_array_impl<NT1> &ain, const NT2 &val)
 {
     using TT1 = teca_variant_array_impl<NT1>;
-    using PTT1 = std::shared_ptr<TT1>;
-
-    using TT2 = teca_variant_array_impl<NT2>;
-    using PTT2 = std::shared_ptr<TT2>;
 
     // get the inputs
-    auto spain = ain->get_cpu_accessible();
-    const NT1 *pain = spain.get();
+    auto [spain, pain] = get_cpu_accessible<TT1>(ain);
 
     // allocate the memory
     size_t n_vals = ain->size();
-    PTT1 ao = TT1::New(teca_variant_array::allocator::malloc);
-    ao->resize(n_vals, NT1(0));
-
-    auto spao = ao->get_cpu_accessible();
-    NT1 *pao = spao.get();
+    auto [ao, pao] = ::New<TT1>(n_vals, NT1(0), allocator::malloc);
 
     // initialize the data
     multiply_scalar_cpu(pao, pain, val, n_vals);
@@ -157,13 +140,14 @@ p_teca_variant_array_impl<NT1> multiply_scalar_cpu(
 template <typename T>
 int compare_int(const const_p_teca_variant_array_impl<T> &ain, int val)
 {
+    using TT = teca_variant_array_impl<T>;
+
     size_t n_vals = ain->size();
 
     std::cerr << "comparing array with " << n_vals
          << " elements to " << val << std::endl;
 
-    p_teca_int_array ai = teca_int_array::New(ain->get_allocator());
-    ai->resize(n_vals);
+    p_teca_int_array ai = teca_int_array::New(n_vals, ain->get_allocator());
     ain->get(ai);
 
     if (n_vals < 33)
@@ -171,8 +155,7 @@ int compare_int(const const_p_teca_variant_array_impl<T> &ain, int val)
         ai->debug_print();
     }
 
-    auto spai = ai->get_cpu_accessible();
-    int *pai = spai.get();
+    auto [spai, pai] = get_cpu_accessible<teca_int_array>(ai);
 
     for (size_t i = 0; i < n_vals; ++i)
     {

--- a/test/test_variant_array_cuda_access.cpp
+++ b/test/test_variant_array_cuda_access.cpp
@@ -1,5 +1,6 @@
 #include "teca_variant_array.h"
 #include "teca_variant_array_impl.h"
+#include "teca_variant_array_util.h"
 #include "teca_cuda_util.h"
 
 #include <cuda.h>
@@ -7,6 +8,8 @@
 
 #include <iostream>
 
+using namespace teca_variant_array_util;
+using allocator = teca_variant_array::allocator;
 
 // **************************************************************************
 template<typename NT>
@@ -22,17 +25,11 @@ void initialize_cuda(NT *data, double val, size_t n_vals)
 }
 
 // **************************************************************************
-template <typename NT>
-p_teca_variant_array_impl<NT> initialize_cuda(size_t n_vals, const NT &val)
+template <typename NT, typename TT = teca_variant_array_impl<NT>>
+std::shared_ptr<TT> initialize_cuda(size_t n_vals, const NT &val)
 {
     // allocate the memory
-    p_teca_variant_array_impl<NT> ao =
-        teca_variant_array_impl<NT>::New(teca_variant_array::allocator::cuda);
-
-    ao->resize(n_vals);
-
-    auto spao = ao->get_cuda_accessible();
-    NT *pao = spao.get();
+    auto [ao, pao] = ::New<TT>(n_vals, allocator::cuda_async);
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -94,25 +91,15 @@ p_teca_variant_array_impl<NT1> add_cuda(const const_p_teca_variant_array_impl<NT
     const const_p_teca_variant_array_impl<NT2> &a2)
 {
     using TT1 = teca_variant_array_impl<NT1>;
-    using PTT1 = std::shared_ptr<TT1>;
-
     using TT2 = teca_variant_array_impl<NT2>;
-    using PTT2 = std::shared_ptr<TT2>;
 
     // get the inputs
-    auto spa1 = a1->get_cuda_accessible();
-    const NT1 *pa1 = spa1.get();
-
-    auto spa2 = a2->get_cuda_accessible();
-    const NT2 *pa2 = spa2.get();
+    auto [spa1, pa1] = get_cuda_accessible<TT1>(a1);
+    auto [spa2, pa2] = get_cuda_accessible<TT2>(a2);
 
     // allocate the memory
     size_t n_vals = a1->size();
-    PTT1 ao = TT1::New(teca_variant_array::allocator::cuda);
-    ao->resize(n_vals, NT1(0));
-
-    auto spao = ao->get_cuda_accessible();
-    NT1 *pao = spao.get();
+    auto [ao, pao] = ::New<TT1>(n_vals, NT1(0), allocator::cuda_async);
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -174,22 +161,13 @@ p_teca_variant_array_impl<NT1> multiply_scalar_cuda(
     const const_p_teca_variant_array_impl<NT1> &ain, const NT2 &val)
 {
     using TT1 = teca_variant_array_impl<NT1>;
-    using PTT1 = std::shared_ptr<TT1>;
-
-    using TT2 = teca_variant_array_impl<NT2>;
-    using PTT2 = std::shared_ptr<TT2>;
 
     // get the inputs
-    auto spain = ain->get_cuda_accessible();
-    const NT1 *pain = spain.get();
+    auto [spain, pain] = get_cuda_accessible<TT1>(ain);
 
     // allocate the memory
     size_t n_vals = ain->size();
-    PTT1 ao = TT1::New(teca_variant_array::allocator::cuda);
-    ao->resize(n_vals, NT1(0));
-
-    auto spao = ao->get_cuda_accessible();
-    NT1 *pao = spao.get();
+    auto [ao, pao] = ::New<TT1>(n_vals, NT1(0), allocator::cuda_async);
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -239,8 +217,7 @@ int compare_int(const const_p_teca_variant_array_impl<NT> &ain, int val)
     std::cerr << "comparing array with " << n_vals
         << " elements to " << val << std::endl;
 
-    p_teca_int_array ai = teca_int_array::New(ain->get_allocator());
-    ai->resize(n_vals);
+    p_teca_int_array ai = teca_int_array::New(n_vals, ain->get_allocator());
     ain->get(ai);
 
     if (n_vals < 33)
@@ -248,8 +225,7 @@ int compare_int(const const_p_teca_variant_array_impl<NT> &ain, int val)
         ai->debug_print();
     }
 
-    auto spai = ai->get_cpu_accessible();
-    int *pai = spai.get();
+    auto [spai, pai] = get_cpu_accessible<teca_int_array>(ai);
 
     for (size_t i = 0; i < n_vals; ++i)
     {
@@ -273,8 +249,8 @@ int main(int, char **)
 {
     size_t n_vals = 100000;
 
-    teca_variant_array::allocator cuda_alloc = teca_variant_array::allocator::cuda;
-    teca_variant_array::allocator cpu_alloc = teca_variant_array::allocator::malloc;
+    allocator cuda_alloc = allocator::cuda_async;
+    allocator cpu_alloc = allocator::malloc;
 
     p_teca_float_array  ao0 = teca_float_array::New(n_vals, 1.0f, cuda_alloc);  // = 1 (CUDA)
     p_teca_float_array  ao1 = multiply_scalar_cuda(const_ptr(ao0), 2.0f);       // = 2 (CUDA)


### PR DESCRIPTION
- use variadic arguments in the dispatch macros so that we can have commas outside of function calls.
- adds utility functions to simplify read only data access. these cast, call get_X_accessible, and dereference the smart pointer in one line.
- adds utilty function to simplify allocations. these allocate and access the raw pointer in one line
- adds utitly functions to simplify write data access. These cast and access the raw pointer in one line
- updates HAMR to get asynchronous CUDA allocators
- replaces use of get_X_accessible for write data access, use raw pointer instead to save consrtuctor of std::shared_ptr.
- removes dependence on const-ness from dispatch macros.
- adds a simpler versions of dispatch macros
- documents data access in a new developer oriented tutorial in the user guide


Some exciting changes that simplify data access. this example from the `teca_laplacian` algorithm illustrates

Old code
```C++
    // allocate the output array
    p_teca_variant_array lapl = comp_0->new_instance();
    lapl->resize(comp_0->size());

    // compute laplacian
    NESTED_TEMPLATE_DISPATCH_FP(
        const teca_variant_array_impl,
        lon.get(), 1,

        auto sp_lon = dynamic_cast<TT1*>
            (lon.get())->get_cpu_accessible();

        const NT1 *p_lon = sp_lon.get();

        auto sp_lat = dynamic_cast<TT1*>
            (lat.get())->get_cpu_accessible();

        const NT1 *p_lat = sp_lat.get();

        NESTED_TEMPLATE_DISPATCH_FP(
            teca_variant_array_impl,
            lapl.get(), 2,

            auto sp_comp_0 = dynamic_cast<const TT2*>
                (comp_0.get())->get_cpu_accessible();

            const NT2 *p_comp_0 = sp_comp_0.get();

            auto sp_lapl = dynamic_cast<TT2*>
                (lapl.get())->get_cpu_accessible();

            NT2 *p_lapl = sp_lapl.get();

            ::laplacian(p_lapl, p_lon, p_lat,
                p_comp_0, lon->size(), lat->size());
            )   
        ) 
```

New code
```C++
    // allocate the output array
    p_teca_variant_array lapl = comp_0->new_instance(comp_0->size());

    // compute laplacian
    NESTED_VARIANT_ARRAY_DISPATCH_FP(                                                                                                                         
        lon.get(), 1,

        assert_type<CTT1>(lat);
        auto [splo, p_lon, spla, p_lat] = get_cpu_accessible<CTT1>(lon, lat);

        NESTED_VARIANT_ARRAY_DISPATCH_FP(
            lapl.get(), 2,

            auto [sp_comp_0, p_comp_0] = get_cpu_accessible<CTT2>(comp_0);
            auto [p_lapl] = data<TT2>(lapl);

            ::laplacian(p_lapl, p_lon, p_lat,
                p_comp_0, lon->size(), lat->size());
            )
        )
```
The new code is quite a bit shorter and easier to read. It also eliminates unnecessary use of std::shared_ptr instance when accessing the output data.