### PR TITLE
Cfr page locked memory

### DIFF
--- a/io/teca_cf_reader.cxx
+++ b/io/teca_cf_reader.cxx
@@ -1357,7 +1357,8 @@ const_p_teca_dataset teca_cf_reader::execute(unsigned int port,
         // place all data read on the assigned device
         teca_cuda_util::set_device(device_id);
         alloc = allocator::cuda_async;
-        tmp_alloc = allocator::cuda_host;
+        // using the cuda host allocator slowed things down on Perlmutter
+        //tmp_alloc = allocator::cuda_host;
     }
 #endif
 


### PR DESCRIPTION
improves overall performance of the temporal reduction application by replacing cudaMallocHost w/ malloc allocators in the cf_reader (I made the change in hamr as well for device to host transfers)