### PR TITLE
Draft: Add support for reading variables in groups.

### DIFF
--- a/io/teca_cf_reader.h
+++ b/io/teca_cf_reader.h
@@ -5,6 +5,7 @@
 #include "teca_algorithm.h"
 #include "teca_metadata.h"
 #include "teca_shared_object.h"
+#include "teca_netcdf_util.h"
 
 #include <vector>
 #include <string>
@@ -241,6 +242,13 @@ protected:
 
 private:
     using teca_algorithm::get_output_metadata;
+
+    void get_variables_in_group(
+        teca_netcdf_util::netcdf_handle &fh,
+        int parent_id,
+        std::string group_name,
+        teca_metadata &atrs,
+        std::vector<std::string> &vars);
 
     teca_metadata get_output_metadata(
         unsigned int port,

--- a/io/teca_netcdf_util.h
+++ b/io/teca_netcdf_util.h
@@ -211,6 +211,7 @@ public:
 
 private:
     int m_handle;
+    //int m_grp_handle;
 };
 
 /**
@@ -219,7 +220,7 @@ private:
  * return is non-zero if an error occurred.
  */
 TECA_EXPORT
-int read_attribute(netcdf_handle &fh, int var_id,
+int read_attribute(int parent_id, int var_id,
     const std::string &att_name, teca_metadata &atts);
 
 /**
@@ -228,7 +229,7 @@ int read_attribute(netcdf_handle &fh, int var_id,
  * return is non-zero if an error occurred.
  */
 TECA_EXPORT
-int read_attribute(netcdf_handle &fh, int var_id,
+int read_attribute(int parent_id, int var_id,
     int att_id, teca_metadata &atts);
 
 /**
@@ -262,7 +263,7 @@ int read_attribute(netcdf_handle &fh, int var_id,
  * returns non-zero if an error occurred.
  */
 TECA_EXPORT
-int read_variable_attributes(netcdf_handle &fh, int var_id,
+int read_variable_attributes(netcdf_handle &fh, int parent_id, int var_id,
     const std::string &x_variable, const std::string &y_variable,
     const std::string &z_variable, const std::string &t_variable,
     int clamp_dimensions_of_one, std::string &name, teca_metadata &atts);
@@ -273,8 +274,16 @@ int read_variable_attributes(netcdf_handle &fh, int var_id,
  * for details of attributes returned. returns non-zero if an error occurred.
  */
 TECA_EXPORT
-int read_variable_attributes(netcdf_handle &fh, int var_id,
+int read_variable_attributes(netcdf_handle &fh, int parent_id, int var_id,
     std::string &name, teca_metadata &atts);
+
+/**
+ * Get the variable ID in a NetCDF file where var_name can be a fully qualified 
+ * path including group names, such as "global/lat"
+ */
+TECA_EXPORT
+int get_varid(netcdf_handle &fh, const std::string &var_name,
+    int *parent_id, int *var_id);
 
 /**
  * Read the specified variable's dimensions, and it's associated

--- a/io/teca_wrf_reader.cxx
+++ b/io/teca_wrf_reader.cxx
@@ -312,7 +312,9 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             std::string file = path + PATH_SEP + files[0];
 
             // get mesh coordinates and dimensions
+            int x_parent_id = 0;
             int x_id = 0;
+            int z_parent_id = 0;
             int z_id = 0;
             int x_ndims = 0;
             int z_ndims = 0;
@@ -343,12 +345,12 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
 #endif
-            if (((ierr = nc_inq_varid(fh.get(), m_x_axis_variable.c_str(), &x_id)) != NC_NOERR)
-                || ((ierr = nc_inq_varndims(fh.get(), x_id, &x_ndims)) != NC_NOERR)
-                || ((ierr = nc_inq_vardimid(fh.get(), x_id, x_dims)) != NC_NOERR)
-                || ((ierr = nc_inq_vartype(fh.get(), x_id, &x_t)) != NC_NOERR)
-                || ((ierr = nc_inq_dimlen(fh.get(), x_dims[2], &n_x)) != NC_NOERR)
-                || ((ierr = nc_inq_dimlen(fh.get(), x_dims[1], &n_y)) != NC_NOERR))
+            if (((ierr = get_varid(fh, m_x_axis_variable.c_str(), &x_parent_id, &x_id)) != NC_NOERR)
+                || ((ierr = nc_inq_varndims(x_parent_id, x_id, &x_ndims)) != NC_NOERR)
+                || ((ierr = nc_inq_vardimid(x_parent_id, x_id, x_dims)) != NC_NOERR)
+                || ((ierr = nc_inq_vartype(x_parent_id, x_id, &x_t)) != NC_NOERR)
+                || ((ierr = nc_inq_dimlen(x_parent_id, x_dims[2], &n_x)) != NC_NOERR)
+                || ((ierr = nc_inq_dimlen(x_parent_id, x_dims[1], &n_y)) != NC_NOERR))
             {
                 this->clear_cached_metadata();
                 TECA_FATAL_ERROR(
@@ -363,11 +365,11 @@ teca_metadata teca_wrf_reader::get_output_metadata(
             {
             std::lock_guard<std::mutex> lock(teca_netcdf_util::get_netcdf_mutex());
 #endif
-            if (((ierr = nc_inq_varid(fh.get(), m_z_axis_variable.c_str(), &z_id)) != NC_NOERR)
-                || ((ierr = nc_inq_varndims(fh.get(), z_id, &z_ndims)) != NC_NOERR)
-                || ((ierr = nc_inq_vardimid(fh.get(), z_id, z_dims)) != NC_NOERR)
-                || ((ierr = nc_inq_vartype(fh.get(), z_id, &z_t)) != NC_NOERR)
-                || ((ierr = nc_inq_dimlen(fh.get(), z_dims[1], &n_z)) != NC_NOERR))
+            if (((ierr = get_varid(fh, m_z_axis_variable.c_str(), &z_parent_id, &z_id)) != NC_NOERR)
+                || ((ierr = nc_inq_varndims(z_parent_id, z_id, &z_ndims)) != NC_NOERR)
+                || ((ierr = nc_inq_vardimid(z_parent_id, z_id, z_dims)) != NC_NOERR)
+                || ((ierr = nc_inq_vartype(z_parent_id, z_id, &z_t)) != NC_NOERR)
+                || ((ierr = nc_inq_dimlen(z_parent_id, z_dims[1], &n_z)) != NC_NOERR))
             {
                 this->clear_cached_metadata();
                 TECA_FATAL_ERROR(
@@ -818,10 +820,11 @@ teca_metadata teca_wrf_reader::get_output_metadata(
                 // ordering of the files and there will be no calendaring
                 // information. As a result many time aware algorithms will not
                 // work.
+                int x_parent_id = 0;
                 int x_id = 0;
                 nc_type x_t = 0;
-                if (((ierr = nc_inq_varid(fh.get(), m_x_axis_variable.c_str(), &x_id)) != NC_NOERR)
-                    || ((ierr = nc_inq_vartype(fh.get(), x_id, &x_t)) != NC_NOERR))
+                if (((ierr = get_varid(fh, m_x_axis_variable.c_str(), &x_parent_id, &x_id)) != NC_NOERR)
+                    || ((ierr = nc_inq_vartype(x_parent_id, x_id, &x_t)) != NC_NOERR))
                 {
                     TECA_FATAL_ERROR("Failed to deduce the time axis type from "
                         << m_x_axis_variable << endl << nc_strerror(ierr))


### PR DESCRIPTION
Add support to read variables that are not in the `root` group but instead a group.

Refer to variables by `<groupname>/<varname>' in `.mfc` file.

Limitations:
* Not sure if it is ok to cache `cf_parent_id` or if a group `ncid` can change when a file is closed and re-opened.
* Currently only supports variables in top-level groups. Need to add recursion to support groups at arbitrary depth in hierarchy. 
*  No support for groups in `teca_wrf_reader`, yet.