### PR TITLE
Add missing dependency to teca_add_app_test for teca_integrated_water…

### DIFF
--- a/test/apps/CMakeLists.txt
+++ b/test/apps/CMakeLists.txt
@@ -60,6 +60,7 @@ teca_add_app_test(test_bayesian_ar_detect_app_packed_data_mpi
     REQ_TECA_DATA)
 
 teca_add_app_test(test_integrated_water_vapor_app_threads
+    teca_integrated_water_vapor
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_integrated_water_vapor_app.sh
     ${CMAKE_BINARY_DIR}/${BIN_PREFIX} ${TECA_DATA_ROOT} -1 2
     FEATURES ${TECA_HAS_NETCDF}
@@ -82,6 +83,7 @@ teca_add_app_test(test_integrated_water_vapor_app_mpi_threads
     REQ_TECA_DATA)
 
 teca_add_app_test(test_integrated_vapor_transport_app_threads
+    teca_integrated_water_vapor
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_integrated_vapor_transport_app.sh
     ${CMAKE_BINARY_DIR}/${BIN_PREFIX} ${TECA_DATA_ROOT} -1
     FEATURES ${TECA_HAS_NETCDF}


### PR DESCRIPTION
Noticed that these tests weren't executed as the app target they depend on was missing when working on another branch. Adding them in a separate pull request.